### PR TITLE
fix(install-remote): survive ETXTBSY by writing to temp file then mv

### DIFF
--- a/scripts/install-remote.sh
+++ b/scripts/install-remote.sh
@@ -36,8 +36,16 @@ DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${TAG}/${BINARY_NAME}
 echo "Installing ${BINARY_NAME} ${TAG} for ${PLATFORM}..."
 
 mkdir -p "${INSTALL_DIR}"
-curl -fsSL --progress-bar "${DOWNLOAD_URL}" -o "${INSTALL_DIR}/${BINARY_NAME}"
-chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+# Download to a temp file and rename into place.
+# Direct -o on the final path would fail with ETXTBSY if the binary is
+# currently running (e.g. Claude Code has it open as an MCP subprocess).
+# rename(2) unlinks the old inode but keeps it alive for running processes.
+TMP="${INSTALL_DIR}/${BINARY_NAME}.tmp.$$"
+trap 'rm -f "${TMP}"' EXIT
+curl -fsSL --progress-bar "${DOWNLOAD_URL}" -o "${TMP}"
+chmod +x "${TMP}"
+mv -f "${TMP}" "${INSTALL_DIR}/${BINARY_NAME}"
+trap - EXIT
 
 echo "Installed to ${INSTALL_DIR}/${BINARY_NAME}"
 


### PR DESCRIPTION
## Summary

Fixes the ETXTBSY bug inherited from mcp-server-discord's scaffold. Parity fix with [mcp-server-discord#33](https://github.com/Wave-Engineering/mcp-server-discord/pull/33).

## Fix

Download to \`$FINAL.tmp.$$\`, \`chmod +x\`, \`mv -f\` into place. rename(2) unlinks the old inode while keeping it alive for running processes.

## Test Results

\`./scripts/ci/validate.sh\` — 31 pass, 0 fail; shellcheck clean.

Closes #3

Generated with [Claude Code](https://claude.com/claude-code)