### PR TITLE
feat(wave-mcp): implement wave_init handler

### DIFF
--- a/handlers/wave_init.ts
+++ b/handlers/wave_init.ts
@@ -1,0 +1,60 @@
+import { execSync } from 'child_process';
+import { writeFileSync } from 'fs';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  plan_json: z.string().min(1, 'plan_json must be a non-empty JSON string'),
+  extend: z.boolean().optional().default(false),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function writePlanFile(planJson: string): string {
+  const path = `/tmp/wave-init-plan-${Date.now()}-${Math.floor(Math.random() * 1e6)}.json`;
+  writeFileSync(path, planJson);
+  return path;
+}
+
+const waveInitHandler: HandlerDef = {
+  name: 'wave_init',
+  description: 'Initialize a wave plan from structured JSON; supports --extend mode',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: Input;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const planFile = writePlanFile(args.plan_json);
+      const extendFlag = args.extend ? ' --extend' : '';
+      const cmd = `wave-status init${extendFlag} ${planFile}`;
+      const output = execSync(cmd, {
+        cwd: projectDir(),
+        encoding: 'utf8',
+      });
+      return {
+        content: [
+          { type: 'text' as const, text: JSON.stringify({ ok: true, data: output.trim() }) },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default waveInitHandler;

--- a/tests/wave_init.test.ts
+++ b/tests/wave_init.test.ts
@@ -1,0 +1,103 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+// ---- Mocks ----------------------------------------------------------------
+let lastExecCall = '';
+let execMockFn: (cmd: string) => string = () => 'wave plan initialized\n';
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  lastExecCall = cmd;
+  return execMockFn(cmd);
+});
+
+const mockWriteFileSync = mock((_path: unknown, _data: unknown) => undefined);
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+mock.module('fs', () => ({ writeFileSync: mockWriteFileSync }));
+
+const { default: handler } = await import('../handlers/wave_init.ts');
+
+function resetMocks() {
+  lastExecCall = '';
+  execMockFn = () => 'wave plan initialized\n';
+  mockExecSync.mockClear();
+  mockWriteFileSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('wave_init handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler).toBeDefined();
+    expect(handler.name).toBe('wave_init');
+    expect(typeof handler.description).toBe('string');
+    expect(handler.description.length).toBeGreaterThan(0);
+    expect(handler.inputSchema).toBeDefined();
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  // ---- happy_path ---------------------------------------------------------
+  test('happy_path — invokes wave-status init with plan file', async () => {
+    const planJson = JSON.stringify({ project: 'foo', phases: [] });
+    const result = await handler.execute({ plan_json: planJson });
+    expect(mockExecSync.mock.calls.length).toBe(1);
+    expect(lastExecCall).toContain('wave-status init');
+    expect(lastExecCall).not.toContain('--extend');
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data).toBe('wave plan initialized');
+  });
+
+  test('happy_path — passes --extend flag when extend=true', async () => {
+    const planJson = JSON.stringify({ phases: [{ name: 'extra' }] });
+    await handler.execute({ plan_json: planJson, extend: true });
+    expect(lastExecCall).toContain('wave-status init');
+    expect(lastExecCall).toContain('--extend');
+  });
+
+  test('happy_path — writes plan_json to a temp file', async () => {
+    const planJson = JSON.stringify({ project: 'cc-workflow' });
+    await handler.execute({ plan_json: planJson });
+    expect(mockWriteFileSync.mock.calls.length).toBe(1);
+    const writtenPath = mockWriteFileSync.mock.calls[0][0] as string;
+    const writtenData = mockWriteFileSync.mock.calls[0][1] as string;
+    expect(writtenPath).toMatch(/^\/tmp\/wave-init-plan-/);
+    expect(writtenData).toBe(planJson);
+  });
+
+  // ---- cli_error ----------------------------------------------------------
+  test('cli_error — returns ok:false on non-zero exit, does not throw', async () => {
+    execMockFn = () => {
+      throw new Error('wave-status: refusing to overwrite existing plan');
+    };
+    const result = await handler.execute({ plan_json: '{}' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('refusing to overwrite');
+  });
+
+  // ---- schema_validation --------------------------------------------------
+  test('schema_validation — rejects missing plan_json', async () => {
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error.length).toBeGreaterThan(0);
+  });
+
+  test('schema_validation — rejects empty plan_json string', async () => {
+    const result = await handler.execute({ plan_json: '' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('plan_json');
+  });
+
+  test('schema_validation — rejects non-string plan_json', async () => {
+    const result = await handler.execute({ plan_json: 123 });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the `wave_init` MCP tool — wraps the `wave-status init` CLI subcommand. Part of Wave 1b of the Wave Pattern Family migration (epic Wave-Engineering/claudecode-workflow#289).

## Changes

- `handlers/wave_init.ts` — HandlerDef default export. Schema: `plan_json` (string), `extend` (boolean, default false). Writes plan_json to a temp file, shells out via execSync anchored at `CLAUDE_PROJECT_DIR ?? process.cwd()`. Returns `{ok, data?, error?}` JSON; CLI failures caught, never thrown.
- `tests/wave_init.test.ts` — happy path, --extend passthrough, temp file write, cli error, schema validation (missing/empty/wrong-type plan_json).

Auto-registers via the codegen registry pipeline (no `index.ts` or `tests/routing.test.ts` changes needed).

## Linked Issues

Closes #5

## Test Plan

- [x] `./scripts/ci/validate.sh` green locally (codegen + lint + shellcheck + 44 tests + runtime smoke)
- [ ] CI green on PR
- [ ] Merge queue pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)