### PR TITLE
feat(wave-mcp): implement wave_preflight handler

### DIFF
--- a/handlers/wave_preflight.ts
+++ b/handlers/wave_preflight.ts
@@ -1,0 +1,44 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({}).strict();
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+const wavePreflightHandler: HandlerDef = {
+  name: 'wave_preflight',
+  description: 'Signal that pre-flight checks are underway',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    try {
+      inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const output = execSync('wave-status preflight', {
+        cwd: projectDir(),
+        encoding: 'utf8',
+      });
+      return {
+        content: [
+          { type: 'text' as const, text: JSON.stringify({ ok: true, data: output.trim() }) },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default wavePreflightHandler;

--- a/tests/wave_preflight.test.ts
+++ b/tests/wave_preflight.test.ts
@@ -1,0 +1,60 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let lastExecCall = '';
+let execMockFn: (cmd: string) => string = () => 'preflight ok\n';
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  lastExecCall = cmd;
+  return execMockFn(cmd);
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/wave_preflight.ts');
+
+function resetMocks() {
+  lastExecCall = '';
+  execMockFn = () => 'preflight ok\n';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('wave_preflight handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('wave_preflight');
+    expect(typeof handler.description).toBe('string');
+    expect(handler.description.length).toBeGreaterThan(0);
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('happy_path — invokes wave-status preflight', async () => {
+    const result = await handler.execute({});
+    expect(mockExecSync.mock.calls.length).toBe(1);
+    expect(lastExecCall).toBe('wave-status preflight');
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data).toBe('preflight ok');
+  });
+
+  test('cli_error — returns ok:false on non-zero exit, does not throw', async () => {
+    execMockFn = () => {
+      throw new Error('wave-status: state file missing');
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('state file missing');
+  });
+
+  test('schema_validation — rejects unknown input fields', async () => {
+    const result = await handler.execute({ unexpected: 'field' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the `wave_preflight` MCP tool — wraps `wave-status preflight`. Wave 1b of epic Wave-Engineering/claudecode-workflow#289.

## Changes

- `handlers/wave_preflight.ts` — HandlerDef export. No input schema (strict empty object). Shells out, returns `{ok, data?, error?}`.
- `tests/wave_preflight.test.ts` — happy path, cli error, schema validation.

## Linked Issues

Closes #6

## Test Plan

- [x] `./scripts/ci/validate.sh` green locally (53 tests + smoke)
- [ ] CI green
- [ ] Merge queue green

🤖 Generated with [Claude Code](https://claude.com/claude-code)