### PR TITLE
feat(wave-mcp): implement wave_planning handler

### DIFF
--- a/handlers/wave_planning.ts
+++ b/handlers/wave_planning.ts
@@ -1,0 +1,44 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({}).strict();
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+const wavePlanningHandler: HandlerDef = {
+  name: 'wave_planning',
+  description: 'Signal transition to planning phase for the current wave',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    try {
+      inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const output = execSync('wave-status planning', {
+        cwd: projectDir(),
+        encoding: 'utf8',
+      });
+      return {
+        content: [
+          { type: 'text' as const, text: JSON.stringify({ ok: true, data: output.trim() }) },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default wavePlanningHandler;

--- a/tests/wave_planning.test.ts
+++ b/tests/wave_planning.test.ts
@@ -1,0 +1,60 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let lastExecCall = '';
+let execMockFn: (cmd: string) => string = () => 'planning ok\n';
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  lastExecCall = cmd;
+  return execMockFn(cmd);
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/wave_planning.ts');
+
+function resetMocks() {
+  lastExecCall = '';
+  execMockFn = () => 'planning ok\n';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('wave_planning handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('wave_planning');
+    expect(typeof handler.description).toBe('string');
+    expect(handler.description.length).toBeGreaterThan(0);
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('happy_path — invokes wave-status planning', async () => {
+    const result = await handler.execute({});
+    expect(mockExecSync.mock.calls.length).toBe(1);
+    expect(lastExecCall).toBe('wave-status planning');
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data).toBe('planning ok');
+  });
+
+  test('cli_error — returns ok:false on non-zero exit, does not throw', async () => {
+    execMockFn = () => {
+      throw new Error('wave-status: cannot enter planning');
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('cannot enter planning');
+  });
+
+  test('schema_validation — rejects unknown input fields', async () => {
+    const result = await handler.execute({ wave: 'foo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the `wave_planning` MCP tool — wraps `wave-status planning`. Wave 1b of epic Wave-Engineering/claudecode-workflow#289.

## Changes

- `handlers/wave_planning.ts` — HandlerDef export, no input, shells out, returns structured `{ok, data?, error?}`.
- `tests/wave_planning.test.ts` — happy path, cli error, schema validation.

## Linked Issues

Closes #7

## Test Plan

- [x] `./scripts/ci/validate.sh` green locally (62 tests + smoke)
- [ ] CI green, merge queue green

🤖 Generated with [Claude Code](https://claude.com/claude-code)