### PR TITLE
feat(wave-mcp): implement wave_flight handler

### DIFF
--- a/handlers/wave_flight.ts
+++ b/handlers/wave_flight.ts
@@ -1,0 +1,47 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  flight_number: z.number().int().positive(),
+});
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+const waveFlightHandler: HandlerDef = {
+  name: 'wave_flight',
+  description: 'Signal the start of flight N within the current wave',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const output = execSync(`wave-status flight ${args.flight_number}`, {
+        cwd: projectDir(),
+        encoding: 'utf8',
+      });
+      return {
+        content: [
+          { type: 'text' as const, text: JSON.stringify({ ok: true, data: output.trim() }) },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default waveFlightHandler;

--- a/tests/wave_flight.test.ts
+++ b/tests/wave_flight.test.ts
@@ -1,0 +1,70 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let lastExecCall = '';
+let execMockFn: (cmd: string) => string = () => 'flight started\n';
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  lastExecCall = cmd;
+  return execMockFn(cmd);
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/wave_flight.ts');
+
+function resetMocks() {
+  lastExecCall = '';
+  execMockFn = () => 'flight started\n';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('wave_flight handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('wave_flight');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('happy_path — invokes wave-status flight with N', async () => {
+    const result = await handler.execute({ flight_number: 2 });
+    expect(mockExecSync.mock.calls.length).toBe(1);
+    expect(lastExecCall).toBe('wave-status flight 2');
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data).toBe('flight started');
+  });
+
+  test('cli_error — returns ok:false on non-zero exit, does not throw', async () => {
+    execMockFn = () => {
+      throw new Error("wave-status: flight 2 is 'pending', not 'completed'");
+    };
+    const result = await handler.execute({ flight_number: 3 });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("'pending'");
+  });
+
+  test('schema_validation — rejects missing flight_number', async () => {
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema_validation — rejects non-integer flight_number', async () => {
+    const result = await handler.execute({ flight_number: 1.5 });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema_validation — rejects zero or negative flight_number', async () => {
+    const result = await handler.execute({ flight_number: 0 });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the `wave_flight` MCP tool — wraps `wave-status flight N`. Wave 1b.

## Changes

- `handlers/wave_flight.ts` — HandlerDef, schema: `flight_number` (positive int).
- `tests/wave_flight.test.ts` — happy path, cli error, schema validation (missing, non-integer, zero/negative).

## Linked Issues

Closes #8

## Test Plan

- [x] `./scripts/ci/validate.sh` green locally (73 tests + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)