### PR TITLE
feat(wave-mcp): implement wave_flight_plan handler

### DIFF
--- a/handlers/wave_flight_plan.ts
+++ b/handlers/wave_flight_plan.ts
@@ -1,0 +1,55 @@
+import { execSync } from 'child_process';
+import { writeFileSync } from 'fs';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  plan_json: z.string().min(1, 'plan_json must be a non-empty JSON string'),
+});
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function writePlanFile(planJson: string): string {
+  const path = `/tmp/wave-flight-plan-${Date.now()}-${Math.floor(Math.random() * 1e6)}.json`;
+  writeFileSync(path, planJson);
+  return path;
+}
+
+const waveFlightPlanHandler: HandlerDef = {
+  name: 'wave_flight_plan',
+  description: 'Store the flight plan for the current wave',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const planFile = writePlanFile(args.plan_json);
+      const output = execSync(`wave-status flight-plan ${planFile}`, {
+        cwd: projectDir(),
+        encoding: 'utf8',
+      });
+      return {
+        content: [
+          { type: 'text' as const, text: JSON.stringify({ ok: true, data: output.trim() }) },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default waveFlightPlanHandler;

--- a/tests/wave_flight_plan.test.ts
+++ b/tests/wave_flight_plan.test.ts
@@ -1,0 +1,73 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let lastExecCall = '';
+let execMockFn: (cmd: string) => string = () => 'flight plan stored\n';
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  lastExecCall = cmd;
+  return execMockFn(cmd);
+});
+
+const mockWriteFileSync = mock((_path: unknown, _data: unknown) => undefined);
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+mock.module('fs', () => ({ writeFileSync: mockWriteFileSync }));
+
+const { default: handler } = await import('../handlers/wave_flight_plan.ts');
+
+function resetMocks() {
+  lastExecCall = '';
+  execMockFn = () => 'flight plan stored\n';
+  mockExecSync.mockClear();
+  mockWriteFileSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('wave_flight_plan handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('wave_flight_plan');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('happy_path — writes plan to temp file and invokes wave-status flight-plan', async () => {
+    const planJson = JSON.stringify([{ issues: [5, 6], status: 'pending' }]);
+    const result = await handler.execute({ plan_json: planJson });
+    expect(mockWriteFileSync.mock.calls.length).toBe(1);
+    const writtenPath = mockWriteFileSync.mock.calls[0][0] as string;
+    expect(writtenPath).toMatch(/^\/tmp\/wave-flight-plan-/);
+    expect(mockWriteFileSync.mock.calls[0][1]).toBe(planJson);
+    expect(lastExecCall).toContain('wave-status flight-plan');
+    expect(lastExecCall).toContain(writtenPath);
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data).toBe('flight plan stored');
+  });
+
+  test('cli_error — returns ok:false on non-zero exit', async () => {
+    execMockFn = () => {
+      throw new Error('wave-status: no current wave');
+    };
+    const result = await handler.execute({ plan_json: '[]' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('no current wave');
+  });
+
+  test('schema_validation — rejects missing plan_json', async () => {
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema_validation — rejects empty plan_json string', async () => {
+    const result = await handler.execute({ plan_json: '' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `wave_flight_plan` — wraps `wave-status flight-plan`. Wave 1b.

## Changes

- `handlers/wave_flight_plan.ts` — HandlerDef, schema: `plan_json` (non-empty string). Writes to temp file then invokes CLI.
- `tests/wave_flight_plan.test.ts` — happy path (verifies temp-file write + CLI invocation), cli error, schema validation.

## Linked Issues

Closes #9

## Test Plan

- [x] `./scripts/ci/validate.sh` green (83 tests + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)