### PR TITLE
feat(wave-mcp): implement wave_flight_done handler

### DIFF
--- a/handlers/wave_flight_done.ts
+++ b/handlers/wave_flight_done.ts
@@ -1,0 +1,47 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  flight_number: z.number().int().positive(),
+});
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+const waveFlightDoneHandler: HandlerDef = {
+  name: 'wave_flight_done',
+  description: 'Mark flight N as complete',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const output = execSync(`wave-status flight-done ${args.flight_number}`, {
+        cwd: projectDir(),
+        encoding: 'utf8',
+      });
+      return {
+        content: [
+          { type: 'text' as const, text: JSON.stringify({ ok: true, data: output.trim() }) },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default waveFlightDoneHandler;

--- a/tests/wave_flight_done.test.ts
+++ b/tests/wave_flight_done.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let lastExecCall = '';
+let execMockFn: (cmd: string) => string = () => 'flight done\n';
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  lastExecCall = cmd;
+  return execMockFn(cmd);
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/wave_flight_done.ts');
+
+function resetMocks() {
+  lastExecCall = '';
+  execMockFn = () => 'flight done\n';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('wave_flight_done handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('wave_flight_done');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('happy_path — invokes wave-status flight-done with N', async () => {
+    const result = await handler.execute({ flight_number: 1 });
+    expect(lastExecCall).toBe('wave-status flight-done 1');
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data).toBe('flight done');
+  });
+
+  test('cli_error — returns ok:false on non-zero exit', async () => {
+    execMockFn = () => {
+      throw new Error("wave-status: flight 1 is 'pending', not 'running'");
+    };
+    const result = await handler.execute({ flight_number: 1 });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("'running'");
+  });
+
+  test('schema_validation — rejects missing flight_number', async () => {
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema_validation — rejects negative flight_number', async () => {
+    const result = await handler.execute({ flight_number: -1 });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `wave_flight_done` — wraps `wave-status flight-done N`. Wave 1b.

## Changes

- `handlers/wave_flight_done.ts` — HandlerDef, schema: `flight_number` (positive int).
- `tests/wave_flight_done.test.ts` — happy path, cli error, schema validation.

## Linked Issues

Closes #10

## Test Plan

- [x] `./scripts/ci/validate.sh` green (smoke included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)