### PR TITLE
feat(wave-mcp): implement wave_close_issue handler

### DIFF
--- a/handlers/wave_close_issue.ts
+++ b/handlers/wave_close_issue.ts
@@ -1,0 +1,47 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  issue_number: z.number().int().positive(),
+});
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+const waveCloseIssueHandler: HandlerDef = {
+  name: 'wave_close_issue',
+  description: 'Record that a wave issue has been closed',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const output = execSync(`wave-status close-issue ${args.issue_number}`, {
+        cwd: projectDir(),
+        encoding: 'utf8',
+      });
+      return {
+        content: [
+          { type: 'text' as const, text: JSON.stringify({ ok: true, data: output.trim() }) },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default waveCloseIssueHandler;

--- a/tests/wave_close_issue.test.ts
+++ b/tests/wave_close_issue.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let lastExecCall = '';
+let execMockFn: (cmd: string) => string = () => 'issue closed\n';
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  lastExecCall = cmd;
+  return execMockFn(cmd);
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/wave_close_issue.ts');
+
+function resetMocks() {
+  lastExecCall = '';
+  execMockFn = () => 'issue closed\n';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('wave_close_issue handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('wave_close_issue');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('happy_path — invokes wave-status close-issue with N', async () => {
+    const result = await handler.execute({ issue_number: 42 });
+    expect(lastExecCall).toBe('wave-status close-issue 42');
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data).toBe('issue closed');
+  });
+
+  test('cli_error — returns ok:false on non-zero exit', async () => {
+    execMockFn = () => {
+      throw new Error('wave-status: issue #42 does not exist in the plan');
+    };
+    const result = await handler.execute({ issue_number: 42 });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('does not exist');
+  });
+
+  test('schema_validation — rejects missing issue_number', async () => {
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema_validation — rejects non-integer issue_number', async () => {
+    const result = await handler.execute({ issue_number: 'abc' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `wave_close_issue` — wraps `wave-status close-issue N`. Wave 1b.

## Changes

- `handlers/wave_close_issue.ts` — HandlerDef, schema: `issue_number` (positive int).
- `tests/wave_close_issue.test.ts` — happy path, cli error, schema validation.

## Linked Issues

Closes #11

## Test Plan

- [x] `./scripts/ci/validate.sh` green (smoke included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)