### PR TITLE
feat(wave-mcp): implement wave_record_mr handler

### DIFF
--- a/handlers/wave_record_mr.ts
+++ b/handlers/wave_record_mr.ts
@@ -1,0 +1,54 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  issue_number: z.number().int().positive(),
+  mr_ref: z.string().min(1, 'mr_ref must be a non-empty string'),
+});
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function quoteArg(s: string): string {
+  // Single-quote the arg and escape any embedded single quotes.
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+const waveRecordMrHandler: HandlerDef = {
+  name: 'wave_record_mr',
+  description: 'Record the PR/MR reference that closed a wave issue',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const cmd = `wave-status record-mr ${args.issue_number} ${quoteArg(args.mr_ref)}`;
+      const output = execSync(cmd, {
+        cwd: projectDir(),
+        encoding: 'utf8',
+      });
+      return {
+        content: [
+          { type: 'text' as const, text: JSON.stringify({ ok: true, data: output.trim() }) },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default waveRecordMrHandler;

--- a/tests/wave_record_mr.test.ts
+++ b/tests/wave_record_mr.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let lastExecCall = '';
+let execMockFn: (cmd: string) => string = () => 'mr recorded\n';
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  lastExecCall = cmd;
+  return execMockFn(cmd);
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/wave_record_mr.ts');
+
+function resetMocks() {
+  lastExecCall = '';
+  execMockFn = () => 'mr recorded\n';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('wave_record_mr handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('wave_record_mr');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('happy_path — invokes wave-status record-mr with issue + mr ref', async () => {
+    const result = await handler.execute({
+      issue_number: 42,
+      mr_ref: '#99',
+    });
+    expect(lastExecCall).toContain('wave-status record-mr 42');
+    expect(lastExecCall).toContain("'#99'");
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data).toBe('mr recorded');
+  });
+
+  test('happy_path — handles URL-style mr_ref', async () => {
+    await handler.execute({
+      issue_number: 5,
+      mr_ref: 'https://github.com/org/repo/pull/42',
+    });
+    expect(lastExecCall).toContain('wave-status record-mr 5');
+    expect(lastExecCall).toContain("'https://github.com/org/repo/pull/42'");
+  });
+
+  test('cli_error — returns ok:false on non-zero exit', async () => {
+    execMockFn = () => {
+      throw new Error('wave-status: no current wave is set');
+    };
+    const result = await handler.execute({ issue_number: 1, mr_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('no current wave');
+  });
+
+  test('schema_validation — rejects missing issue_number', async () => {
+    const result = await handler.execute({ mr_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema_validation — rejects missing mr_ref', async () => {
+    const result = await handler.execute({ issue_number: 1 });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema_validation — rejects empty mr_ref', async () => {
+    const result = await handler.execute({ issue_number: 1, mr_ref: '' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `wave_record_mr` — wraps `wave-status record-mr N mr_ref`. Wave 1b.

## Changes

- `handlers/wave_record_mr.ts` — HandlerDef, schema: `issue_number` (positive int), `mr_ref` (non-empty string). Shell-quotes the mr_ref to handle URLs and special chars.
- `tests/wave_record_mr.test.ts` — happy path (#ref and URL), cli error, schema validation.

## Linked Issues

Closes #12

## Test Plan

- [x] `./scripts/ci/validate.sh` green (smoke included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)