### PR TITLE
feat(wave-mcp): implement wave_review handler

### DIFF
--- a/handlers/wave_review.ts
+++ b/handlers/wave_review.ts
@@ -1,0 +1,44 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({}).strict();
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+const waveReviewHandler: HandlerDef = {
+  name: 'wave_review',
+  description: 'Signal transition to drift-check review phase',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    try {
+      inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const output = execSync('wave-status review', {
+        cwd: projectDir(),
+        encoding: 'utf8',
+      });
+      return {
+        content: [
+          { type: 'text' as const, text: JSON.stringify({ ok: true, data: output.trim() }) },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default waveReviewHandler;

--- a/tests/wave_review.test.ts
+++ b/tests/wave_review.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let lastExecCall = '';
+let execMockFn: (cmd: string) => string = () => 'review phase\n';
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  lastExecCall = cmd;
+  return execMockFn(cmd);
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/wave_review.ts');
+
+function resetMocks() {
+  lastExecCall = '';
+  execMockFn = () => 'review phase\n';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('wave_review handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('wave_review');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('happy_path — invokes wave-status review', async () => {
+    const result = await handler.execute({});
+    expect(lastExecCall).toBe('wave-status review');
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data).toBe('review phase');
+  });
+
+  test('cli_error — returns ok:false on non-zero exit', async () => {
+    execMockFn = () => {
+      throw new Error('wave-status: cannot enter review from current state');
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('cannot enter review');
+  });
+
+  test('schema_validation — rejects unknown fields', async () => {
+    const result = await handler.execute({ wave: 'foo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `wave_review` — wraps `wave-status review`. Wave 1b.

## Changes

- `handlers/wave_review.ts` — HandlerDef, no input.
- `tests/wave_review.test.ts` — happy path, cli error, schema validation.

## Linked Issues

Closes #13

## Test Plan

- [x] `./scripts/ci/validate.sh` green (smoke included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)