### PR TITLE
feat(wave-mcp): implement wave_complete handler

### DIFF
--- a/handlers/wave_complete.ts
+++ b/handlers/wave_complete.ts
@@ -1,0 +1,44 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({}).strict();
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+const waveCompleteHandler: HandlerDef = {
+  name: 'wave_complete',
+  description: 'Mark the current wave as complete',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    try {
+      inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const output = execSync('wave-status complete', {
+        cwd: projectDir(),
+        encoding: 'utf8',
+      });
+      return {
+        content: [
+          { type: 'text' as const, text: JSON.stringify({ ok: true, data: output.trim() }) },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default waveCompleteHandler;

--- a/tests/wave_complete.test.ts
+++ b/tests/wave_complete.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let lastExecCall = '';
+let execMockFn: (cmd: string) => string = () => 'wave complete\n';
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  lastExecCall = cmd;
+  return execMockFn(cmd);
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/wave_complete.ts');
+
+function resetMocks() {
+  lastExecCall = '';
+  execMockFn = () => 'wave complete\n';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('wave_complete handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('wave_complete');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('happy_path — invokes wave-status complete', async () => {
+    const result = await handler.execute({});
+    expect(lastExecCall).toBe('wave-status complete');
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data).toBe('wave complete');
+  });
+
+  test('cli_error — returns ok:false on non-zero exit', async () => {
+    execMockFn = () => {
+      throw new Error('wave-status: no current wave is set');
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('no current wave');
+  });
+
+  test('schema_validation — rejects unknown fields', async () => {
+    const result = await handler.execute({ wave: 'foo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `wave_complete` — wraps `wave-status complete`. Wave 1b.

## Changes

- `handlers/wave_complete.ts` — HandlerDef, no input.
- `tests/wave_complete.test.ts` — happy path, cli error, schema validation.

## Linked Issues

Closes #14

## Test Plan

- [x] `./scripts/ci/validate.sh` green (smoke included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)