### PR TITLE
feat(wave-mcp): implement wave_waiting handler

### DIFF
--- a/handlers/wave_waiting.ts
+++ b/handlers/wave_waiting.ts
@@ -1,0 +1,52 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  reason: z.string().min(1, 'reason must be a non-empty string'),
+});
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function quoteArg(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+const waveWaitingHandler: HandlerDef = {
+  name: 'wave_waiting',
+  description: 'Signal wave is waiting on external input; reason is logged',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const cmd = `wave-status waiting ${quoteArg(args.reason)}`;
+      const output = execSync(cmd, {
+        cwd: projectDir(),
+        encoding: 'utf8',
+      });
+      return {
+        content: [
+          { type: 'text' as const, text: JSON.stringify({ ok: true, data: output.trim() }) },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default waveWaitingHandler;

--- a/tests/wave_waiting.test.ts
+++ b/tests/wave_waiting.test.ts
@@ -1,0 +1,69 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let lastExecCall = '';
+let execMockFn: (cmd: string) => string = () => 'waiting\n';
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  lastExecCall = cmd;
+  return execMockFn(cmd);
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/wave_waiting.ts');
+
+function resetMocks() {
+  lastExecCall = '';
+  execMockFn = () => 'waiting\n';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('wave_waiting handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('wave_waiting');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('happy_path — invokes wave-status waiting with shell-quoted reason', async () => {
+    const result = await handler.execute({ reason: 'need human review' });
+    expect(lastExecCall).toContain('wave-status waiting');
+    expect(lastExecCall).toContain("'need human review'");
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data).toBe('waiting');
+  });
+
+  test('happy_path — escapes single quotes in reason', async () => {
+    await handler.execute({ reason: "BJ's approval" });
+    expect(lastExecCall).toContain("'BJ'\\''s approval'");
+  });
+
+  test('cli_error — returns ok:false on non-zero exit', async () => {
+    execMockFn = () => {
+      throw new Error('wave-status: cannot transition');
+    };
+    const result = await handler.execute({ reason: 'test' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('cannot transition');
+  });
+
+  test('schema_validation — rejects missing reason', async () => {
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema_validation — rejects empty reason', async () => {
+    const result = await handler.execute({ reason: '' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `wave_waiting` — wraps `wave-status waiting [reason]`. Wave 1b.

## Changes

- `handlers/wave_waiting.ts` — HandlerDef, schema: `reason` (non-empty string). Shell-quotes the reason.
- `tests/wave_waiting.test.ts` — happy path with plain/apostrophe reasons, cli error, schema validation.

## Linked Issues

Closes #15

## Test Plan

- [x] `./scripts/ci/validate.sh` green (smoke included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)