### PR TITLE
feat(wave-mcp): implement wave_defer handler

### DIFF
--- a/handlers/wave_defer.ts
+++ b/handlers/wave_defer.ts
@@ -1,0 +1,53 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  description: z.string().min(1, 'description must be a non-empty string'),
+  risk: z.enum(['low', 'medium', 'high']),
+});
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function quoteArg(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+const waveDeferHandler: HandlerDef = {
+  name: 'wave_defer',
+  description: 'Record a deferral with description and risk level',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const cmd = `wave-status defer ${quoteArg(args.description)} ${args.risk}`;
+      const output = execSync(cmd, {
+        cwd: projectDir(),
+        encoding: 'utf8',
+      });
+      return {
+        content: [
+          { type: 'text' as const, text: JSON.stringify({ ok: true, data: output.trim() }) },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default waveDeferHandler;

--- a/tests/wave_defer.test.ts
+++ b/tests/wave_defer.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let lastExecCall = '';
+let execMockFn: (cmd: string) => string = () => 'deferral recorded\n';
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  lastExecCall = cmd;
+  return execMockFn(cmd);
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/wave_defer.ts');
+
+function resetMocks() {
+  lastExecCall = '';
+  execMockFn = () => 'deferral recorded\n';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('wave_defer handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('wave_defer');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('happy_path — invokes wave-status defer with description + risk', async () => {
+    const result = await handler.execute({
+      description: 'flaky test',
+      risk: 'low',
+    });
+    expect(lastExecCall).toContain('wave-status defer');
+    expect(lastExecCall).toContain("'flaky test'");
+    expect(lastExecCall).toContain(' low');
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data).toBe('deferral recorded');
+  });
+
+  test('happy_path — accepts medium and high risk', async () => {
+    await handler.execute({ description: 'a', risk: 'medium' });
+    expect(lastExecCall).toContain(' medium');
+    await handler.execute({ description: 'b', risk: 'high' });
+    expect(lastExecCall).toContain(' high');
+  });
+
+  test('cli_error — returns ok:false on non-zero exit', async () => {
+    execMockFn = () => {
+      throw new Error('wave-status: invalid risk');
+    };
+    const result = await handler.execute({ description: 'x', risk: 'low' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('invalid risk');
+  });
+
+  test('schema_validation — rejects missing description', async () => {
+    const result = await handler.execute({ risk: 'low' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema_validation — rejects missing risk', async () => {
+    const result = await handler.execute({ description: 'x' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema_validation — rejects invalid risk level', async () => {
+    const result = await handler.execute({ description: 'x', risk: 'critical' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `wave_defer` — wraps `wave-status defer desc risk`. Wave 1b.

## Changes

- `handlers/wave_defer.ts` — HandlerDef, schema: `description` (non-empty), `risk` (enum low/medium/high).
- `tests/wave_defer.test.ts` — happy path (all 3 risks), cli error, schema validation.

## Linked Issues

Closes #16

## Test Plan

- [x] `./scripts/ci/validate.sh` green (smoke included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)