### PR TITLE
feat(wave-mcp): implement wave_show handler

### DIFF
--- a/handlers/wave_show.ts
+++ b/handlers/wave_show.ts
@@ -1,0 +1,44 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({}).strict();
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+const waveShowHandler: HandlerDef = {
+  name: 'wave_show',
+  description: 'Return the full wave-status state',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    try {
+      inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const output = execSync('wave-status show', {
+        cwd: projectDir(),
+        encoding: 'utf8',
+      });
+      return {
+        content: [
+          { type: 'text' as const, text: JSON.stringify({ ok: true, data: output.trim() }) },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default waveShowHandler;

--- a/tests/wave_show.test.ts
+++ b/tests/wave_show.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let lastExecCall = '';
+let execMockFn: (cmd: string) => string = () =>
+  'Project: test\nPhase: 1/1\nWave: 1/1\n';
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  lastExecCall = cmd;
+  return execMockFn(cmd);
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/wave_show.ts');
+
+function resetMocks() {
+  lastExecCall = '';
+  execMockFn = () => 'Project: test\nPhase: 1/1\nWave: 1/1\n';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('wave_show handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('wave_show');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('happy_path — invokes wave-status show', async () => {
+    const result = await handler.execute({});
+    expect(lastExecCall).toBe('wave-status show');
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data).toContain('Project');
+  });
+
+  test('cli_error — returns ok:false on non-zero exit', async () => {
+    execMockFn = () => {
+      throw new Error('wave-status: state file not found');
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('state file not found');
+  });
+
+  test('schema_validation — rejects unknown fields', async () => {
+    const result = await handler.execute({ wave: 'foo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `wave_show` — wraps `wave-status show`. Wave 1b.

## Changes

- `handlers/wave_show.ts` — HandlerDef, no input. Returns trimmed CLI output in `data` field.
- `tests/wave_show.test.ts` — happy path, cli error, schema validation.

Note: the CLI's `show` returns human-readable text, not JSON. A future enhancement (out of scope here) would add a `--json` flag to wave-status and have this handler parse it.

## Linked Issues

Closes #17

## Test Plan

- [x] `./scripts/ci/validate.sh` green (smoke included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)