### PR TITLE
feat(wave-mcp): implement wave_next_pending handler

### DIFF
--- a/handlers/wave_next_pending.ts
+++ b/handlers/wave_next_pending.ts
@@ -1,0 +1,133 @@
+import { join } from 'path';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({}).strict();
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  return await Bun.file(path).exists();
+}
+
+async function readJson(path: string): Promise<unknown> {
+  return await Bun.file(path).json();
+}
+
+async function statusDir(root: string): Promise<string> {
+  // Prefer .sdlc/waves/ if .sdlc/ exists; otherwise fall back to .claude/status/.
+  const sdlc = join(root, '.sdlc');
+  if (await fileExists(sdlc)) return join(sdlc, 'waves');
+  return join(root, '.claude', 'status');
+}
+
+interface PlanIssue {
+  number: number;
+  title?: string;
+}
+
+interface PlanWave {
+  id: string;
+  issues?: PlanIssue[];
+  depends_on?: string[];
+  topology?: string;
+}
+
+interface PlanPhase {
+  name?: string;
+  waves?: PlanWave[];
+}
+
+interface PlanData {
+  phases?: PlanPhase[];
+}
+
+interface StateData {
+  waves?: Record<string, { status?: string }>;
+}
+
+interface NextPendingResult {
+  id: string;
+  issues: Array<{ number: number; title: string }>;
+  depends_on: string[];
+  topology: string | null;
+}
+
+function findNextPending(plan: PlanData, state: StateData): NextPendingResult | null {
+  const waves = state.waves ?? {};
+  for (const phase of plan.phases ?? []) {
+    for (const wave of phase.waves ?? []) {
+      const status = waves[wave.id]?.status ?? 'pending';
+      if (status === 'pending') {
+        return {
+          id: wave.id,
+          issues: (wave.issues ?? []).map(i => ({
+            number: i.number,
+            title: i.title ?? '',
+          })),
+          depends_on: wave.depends_on ?? [],
+          topology: wave.topology ?? null,
+        };
+      }
+    }
+  }
+  return null;
+}
+
+const waveNextPendingHandler: HandlerDef = {
+  name: 'wave_next_pending',
+  description: "Return the next pending wave's metadata, or null if no pending waves",
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    try {
+      inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const dir = await statusDir(projectDir());
+      const planPath = join(dir, 'phases-waves.json');
+      const statePath = join(dir, 'state.json');
+
+      if (!(await fileExists(planPath)) || !(await fileExists(statePath))) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                ok: false,
+                error: `state files not found in ${dir}`,
+              }),
+            },
+          ],
+        };
+      }
+
+      const plan = (await readJson(planPath)) as PlanData;
+      const state = (await readJson(statePath)) as StateData;
+      const next = findNextPending(plan, state);
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({ ok: true, wave: next }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default waveNextPendingHandler;

--- a/tests/wave_next_pending.test.ts
+++ b/tests/wave_next_pending.test.ts
@@ -1,0 +1,131 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+
+// Avoid importing anything from 'fs' OR 'child_process' — both get
+// mock.module'd by sibling test files, which would break our fixture setup.
+// Use Bun.write / Bun.file which are native Bun APIs bypassing the fs module.
+
+let fixtureDir = '';
+const ORIGINAL_ENV = process.env.CLAUDE_PROJECT_DIR;
+
+const { default: handler } = await import('../handlers/wave_next_pending.ts');
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+async function setupFixture(plan: object, state: object) {
+  fixtureDir = `/tmp/wave-next-pending-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+  const statusDir = `${fixtureDir}/.claude/status`;
+  await Bun.write(`${statusDir}/phases-waves.json`, JSON.stringify(plan));
+  await Bun.write(`${statusDir}/state.json`, JSON.stringify(state));
+  process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+}
+
+async function teardown() {
+  if (fixtureDir) {
+    try {
+      // Bun shell would use child_process; avoid it. Use Bun's $ is the same.
+      // Just leave the tempdir — OS will clean /tmp eventually.
+      // Reset fixtureDir so next test uses a fresh path.
+    } catch {
+      // ignore
+    }
+  }
+  fixtureDir = '';
+  if (ORIGINAL_ENV === undefined) {
+    delete process.env.CLAUDE_PROJECT_DIR;
+  } else {
+    process.env.CLAUDE_PROJECT_DIR = ORIGINAL_ENV;
+  }
+}
+
+describe('wave_next_pending handler', () => {
+  beforeEach(() => {
+    fixtureDir = '';
+  });
+  afterEach(teardown);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('wave_next_pending');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('returns_first_pending_wave — skips completed/in_progress, returns first pending', async () => {
+    const plan = {
+      phases: [
+        {
+          name: 'phase1',
+          waves: [
+            { id: 'w1', issues: [{ number: 1, title: 't1' }] },
+            { id: 'w2', issues: [{ number: 2, title: 't2' }] },
+            {
+              id: 'w3',
+              issues: [{ number: 3, title: 't3' }],
+              depends_on: ['w2'],
+              topology: 'parallel',
+            },
+          ],
+        },
+      ],
+    };
+    const state = {
+      waves: {
+        w1: { status: 'completed' },
+        w2: { status: 'in_progress' },
+        w3: { status: 'pending' },
+      },
+    };
+    await setupFixture(plan, state);
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.wave).toEqual({
+      id: 'w3',
+      issues: [{ number: 3, title: 't3' }],
+      depends_on: ['w2'],
+      topology: 'parallel',
+    });
+  });
+
+  test('returns_null_when_all_complete', async () => {
+    const plan = {
+      phases: [
+        {
+          waves: [
+            { id: 'w1', issues: [{ number: 1 }] },
+            { id: 'w2', issues: [{ number: 2 }] },
+          ],
+        },
+      ],
+    };
+    const state = {
+      waves: {
+        w1: { status: 'completed' },
+        w2: { status: 'completed' },
+      },
+    };
+    await setupFixture(plan, state);
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.wave).toBe(null);
+  });
+
+  test('handles_missing_state_files — returns structured error', async () => {
+    // Point at a fresh tempdir with nothing in it. No need to mkdir;
+    // the handler will simply observe the two JSON files don't exist.
+    fixtureDir = `/tmp/wave-next-pending-empty-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+    process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('state files not found');
+  });
+
+  test('schema_validation — rejects unknown fields', async () => {
+    await setupFixture({ phases: [] }, { waves: {} });
+    const result = await handler.execute({ foo: 'bar' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `wave_next_pending` — read-only query helper that returns the next pending wave from wave-status state files. Used by `/nextwave` pre-flight. Wave 1b.

## Changes

- `handlers/wave_next_pending.ts` — HandlerDef, no input. Reads `phases-waves.json` + `state.json` from CLAUDE_PROJECT_DIR. Returns `{ok, wave: {id, issues, depends_on, topology} | null}`.
- `tests/wave_next_pending.test.ts` — uses Bun.write/Bun.file with real tempdirs to avoid cross-test fs mock collisions.

**Implementation note:** this handler uses `Bun.file()` instead of `import { readFileSync } from 'fs'`. Sibling test files use `mock.module('fs', ...)` with partial exports (only `writeFileSync`), which would break any handler that imports `readFileSync` / `existsSync` from `'fs'` globally. Using Bun.file sidesteps the fs module entirely. Future read-handlers should follow the same pattern.

## Linked Issues

Closes #18

## Test Plan

- [x] `./scripts/ci/validate.sh` green locally (175 tests + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)