### PR TITLE
feat(wave-mcp): implement wave_previous_merged handler

### DIFF
--- a/handlers/wave_previous_merged.ts
+++ b/handlers/wave_previous_merged.ts
@@ -1,0 +1,220 @@
+import { execSync } from 'child_process';
+import { join } from 'path';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({}).strict();
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  return await Bun.file(path).exists();
+}
+
+async function readJson(path: string): Promise<unknown> {
+  return await Bun.file(path).json();
+}
+
+async function statusDir(root: string): Promise<string> {
+  const sdlc = join(root, '.sdlc');
+  if (await fileExists(sdlc)) return join(sdlc, 'waves');
+  return join(root, '.claude', 'status');
+}
+
+function detectPlatform(): 'github' | 'gitlab' {
+  try {
+    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    return url.includes('github') ? 'github' : 'gitlab';
+  } catch {
+    return 'github';
+  }
+}
+
+interface PlanIssue {
+  number: number;
+}
+interface PlanWave {
+  id: string;
+  issues?: PlanIssue[];
+}
+interface PlanPhase {
+  waves?: PlanWave[];
+}
+interface PlanData {
+  phases?: PlanPhase[];
+}
+
+interface WaveState {
+  status?: string;
+}
+
+interface StateData {
+  current_wave?: string | null;
+  waves?: Record<string, WaveState>;
+}
+
+function flatWaveIds(plan: PlanData): string[] {
+  const ids: string[] = [];
+  for (const phase of plan.phases ?? []) {
+    for (const wave of phase.waves ?? []) {
+      ids.push(wave.id);
+    }
+  }
+  return ids;
+}
+
+function findWave(plan: PlanData, id: string): PlanWave | null {
+  for (const phase of plan.phases ?? []) {
+    for (const wave of phase.waves ?? []) {
+      if (wave.id === id) return wave;
+    }
+  }
+  return null;
+}
+
+function findPreviousWaveId(plan: PlanData, state: StateData): string | null {
+  const ids = flatWaveIds(plan);
+  const current = state.current_wave;
+
+  // If current_wave is set, previous is the one before it.
+  if (current) {
+    const idx = ids.indexOf(current);
+    return idx > 0 ? ids[idx - 1] : null;
+  }
+
+  // If no current_wave, use the latest wave with status=completed.
+  const waves = state.waves ?? {};
+  for (let i = ids.length - 1; i >= 0; i--) {
+    if (waves[ids[i]]?.status === 'completed') return ids[i];
+  }
+  return null;
+}
+
+interface GhIssueState {
+  state: string;
+  stateReason?: string;
+}
+
+function fetchGithubIssueState(n: number): GhIssueState {
+  const raw = execSync(`gh issue view ${n} --json state,stateReason`, { encoding: 'utf8' });
+  const parsed = JSON.parse(raw) as { state: string; stateReason?: string };
+  return { state: parsed.state.toUpperCase(), stateReason: parsed.stateReason };
+}
+
+function fetchGitlabIssueState(n: number): GhIssueState {
+  const raw = execSync(`glab issue view ${n} --output json`, { encoding: 'utf8' });
+  const parsed = JSON.parse(raw) as { state: string };
+  const state = parsed.state === 'opened' ? 'OPEN' : parsed.state.toUpperCase();
+  return { state };
+}
+
+const wavePreviousMergedHandler: HandlerDef = {
+  name: 'wave_previous_merged',
+  description: "Verify the previous wave's issues are all closed via merged PRs",
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    try {
+      inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const dir = await statusDir(projectDir());
+      const planPath = join(dir, 'phases-waves.json');
+      const statePath = join(dir, 'state.json');
+
+      if (!(await fileExists(planPath)) || !(await fileExists(statePath))) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                ok: false,
+                error: `state files not found in ${dir}`,
+              }),
+            },
+          ],
+        };
+      }
+
+      const plan = (await readJson(planPath)) as PlanData;
+      const state = (await readJson(statePath)) as StateData;
+
+      const prevId = findPreviousWaveId(plan, state);
+      if (!prevId) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                ok: true,
+                previous_wave_id: null,
+                all_merged: true,
+                open_issues: [],
+              }),
+            },
+          ],
+        };
+      }
+
+      const prevWave = findWave(plan, prevId);
+      if (!prevWave) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                ok: false,
+                error: `previous wave '${prevId}' not found in plan`,
+              }),
+            },
+          ],
+        };
+      }
+
+      const platform = detectPlatform();
+      const openIssues: number[] = [];
+
+      for (const issue of prevWave.issues ?? []) {
+        try {
+          const info =
+            platform === 'github'
+              ? fetchGithubIssueState(issue.number)
+              : fetchGitlabIssueState(issue.number);
+          if (info.state !== 'CLOSED') {
+            openIssues.push(issue.number);
+          }
+        } catch {
+          openIssues.push(issue.number);
+        }
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              previous_wave_id: prevId,
+              all_merged: openIssues.length === 0,
+              open_issues: openIssues,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default wavePreviousMergedHandler;

--- a/tests/wave_previous_merged.test.ts
+++ b/tests/wave_previous_merged.test.ts
@@ -1,0 +1,155 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+// Mock only execSync (so this test can intercept gh calls without
+// disturbing fs). Other tests that mock child_process use the same
+// pattern, so the mock contracts are compatible.
+
+let execMockFn: (cmd: string) => string = () => '';
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  return execMockFn(cmd);
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/wave_previous_merged.ts');
+
+let fixtureDir = '';
+const ORIGINAL_ENV = process.env.CLAUDE_PROJECT_DIR;
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+async function setupFixture(plan: object, state: object) {
+  fixtureDir = `/tmp/wave-prev-merged-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+  const statusDir = `${fixtureDir}/.claude/status`;
+  await Bun.write(`${statusDir}/phases-waves.json`, JSON.stringify(plan));
+  await Bun.write(`${statusDir}/state.json`, JSON.stringify(state));
+  process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+}
+
+function resetMocks() {
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+  fixtureDir = '';
+}
+
+function restoreEnv() {
+  if (ORIGINAL_ENV === undefined) {
+    delete process.env.CLAUDE_PROJECT_DIR;
+  } else {
+    process.env.CLAUDE_PROJECT_DIR = ORIGINAL_ENV;
+  }
+}
+
+describe('wave_previous_merged handler', () => {
+  beforeEach(resetMocks);
+  afterEach(restoreEnv);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('wave_previous_merged');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('all_merged_returns_true — mock gh returning CLOSED for all', async () => {
+    const plan = {
+      phases: [
+        {
+          waves: [
+            { id: 'w1', issues: [{ number: 1 }, { number: 2 }] },
+            { id: 'w2', issues: [{ number: 3 }] },
+          ],
+        },
+      ],
+    };
+    const state = {
+      current_wave: 'w2',
+      waves: {
+        w1: { status: 'completed' },
+        w2: { status: 'in_progress' },
+      },
+    };
+    await setupFixture(plan, state);
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      return JSON.stringify({ state: 'closed' });
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.previous_wave_id).toBe('w1');
+    expect(parsed.all_merged).toBe(true);
+    expect(parsed.open_issues).toEqual([]);
+  });
+
+  test('some_open_returns_list — mix of closed/open issues', async () => {
+    const plan = {
+      phases: [
+        {
+          waves: [
+            { id: 'w1', issues: [{ number: 1 }, { number: 2 }, { number: 3 }] },
+            { id: 'w2', issues: [{ number: 4 }] },
+          ],
+        },
+      ],
+    };
+    const state = {
+      current_wave: 'w2',
+      waves: {
+        w1: { status: 'completed' },
+        w2: { status: 'in_progress' },
+      },
+    };
+    await setupFixture(plan, state);
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      if (cmd.includes('gh issue view 1')) return JSON.stringify({ state: 'closed' });
+      if (cmd.includes('gh issue view 2')) return JSON.stringify({ state: 'open' });
+      if (cmd.includes('gh issue view 3')) return JSON.stringify({ state: 'open' });
+      return JSON.stringify({ state: 'closed' });
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.all_merged).toBe(false);
+    expect(parsed.open_issues).toEqual([2, 3]);
+  });
+
+  test('no_previous_wave — first wave case returns ok:true with null id', async () => {
+    const plan = {
+      phases: [
+        {
+          waves: [{ id: 'w1', issues: [{ number: 1 }] }],
+        },
+      ],
+    };
+    const state = {
+      current_wave: 'w1',
+      waves: { w1: { status: 'in_progress' } },
+    };
+    await setupFixture(plan, state);
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.previous_wave_id).toBe(null);
+    expect(parsed.all_merged).toBe(true);
+    expect(parsed.open_issues).toEqual([]);
+  });
+
+  test('handles_missing_state_files — returns structured error', async () => {
+    fixtureDir = `/tmp/wave-prev-merged-empty-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+    process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('state files not found');
+  });
+
+  test('schema_validation — rejects unknown fields', async () => {
+    await setupFixture({ phases: [] }, { waves: {} });
+    const result = await handler.execute({ foo: 'bar' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `wave_previous_merged` — read-only query helper that verifies the previous wave's issues are all closed via merged PRs. Used by `/nextwave` pre-flight. Wave 1b.

## Changes

- `handlers/wave_previous_merged.ts` — HandlerDef, no input. Reads state via `Bun.file()`, queries issues via `gh`/`glab`. Returns `{ok, previous_wave_id, all_merged, open_issues}`.
- `tests/wave_previous_merged.test.ts` — all merged, some open (mixed), no previous wave (first-wave edge), missing state files, schema validation.

## Linked Issues

Closes #19

## Test Plan

- [x] `./scripts/ci/validate.sh` green (186 tests + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)