### PR TITLE
feat(wave-mcp): implement dod_load_manifest handler

### DIFF
--- a/handlers/dod_load_manifest.ts
+++ b/handlers/dod_load_manifest.ts
@@ -1,0 +1,221 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  path: z.string().min(1, 'path must be a non-empty string'),
+});
+
+interface Deliverable {
+  id: string;
+  description: string;
+  evidence_path: string;
+  status: string;
+  category: string;
+}
+
+const ISSUE_REF = /^([^/]+)\/([^/#]+)#(\d+)$/;
+const SHORT_REF = /^#(\d+)$/;
+
+function isIssueRef(path: string): boolean {
+  return ISSUE_REF.test(path) || SHORT_REF.test(path);
+}
+
+function detectPlatform(): 'github' | 'gitlab' {
+  try {
+    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    return url.includes('github') ? 'github' : 'gitlab';
+  } catch {
+    return 'github';
+  }
+}
+
+function fetchIssueBody(ref: string): string {
+  const platform = detectPlatform();
+  if (platform === 'github') {
+    const m1 = ISSUE_REF.exec(ref);
+    const m2 = SHORT_REF.exec(ref);
+    if (m1) {
+      const raw = execSync(`gh issue view ${m1[3]} --repo ${m1[1]}/${m1[2]} --json body`, {
+        encoding: 'utf8',
+      });
+      return (JSON.parse(raw) as { body: string }).body;
+    }
+    if (m2) {
+      const raw = execSync(`gh issue view ${m2[1]} --json body`, { encoding: 'utf8' });
+      return (JSON.parse(raw) as { body: string }).body;
+    }
+  } else {
+    const m2 = SHORT_REF.exec(ref);
+    if (m2) {
+      const raw = execSync(`glab issue view ${m2[1]} --output json`, { encoding: 'utf8' });
+      return (JSON.parse(raw) as { description: string }).description;
+    }
+  }
+  throw new Error(`unsupported issue ref format: ${ref}`);
+}
+
+async function readLocalFile(path: string): Promise<string> {
+  const file = Bun.file(path);
+  if (!(await file.exists())) {
+    throw new Error(`file not found: ${path}`);
+  }
+  return await file.text();
+}
+
+/**
+ * Extract the "Deliverables Manifest" section from a PRD markdown body.
+ *
+ * Looks for a heading matching /^##+\s*deliverables manifest/i, then
+ * captures everything until the next same-or-lower level heading.
+ */
+function extractManifestSection(markdown: string): string | null {
+  const lines = markdown.split('\n');
+  let inSection = false;
+  let sectionLevel = 0;
+  const collected: string[] = [];
+
+  for (const line of lines) {
+    const headingMatch = /^(#+)\s+(.*)$/.exec(line);
+    if (headingMatch) {
+      const level = headingMatch[1].length;
+      const title = headingMatch[2].trim();
+      if (inSection) {
+        if (level <= sectionLevel) break;
+      }
+      if (/^deliverables manifest/i.test(title)) {
+        inSection = true;
+        sectionLevel = level;
+        continue;
+      }
+    }
+    if (inSection) collected.push(line);
+  }
+
+  return inSection ? collected.join('\n').trim() : null;
+}
+
+/**
+ * Parse a GitHub-flavored markdown table of deliverables into structured rows.
+ * Expected columns (flexible order, case-insensitive): id, description,
+ * evidence path, status, category.
+ */
+function parseManifestTable(sectionMd: string): { deliverables: Deliverable[]; warnings: string[] } {
+  const warnings: string[] = [];
+  const deliverables: Deliverable[] = [];
+  const lines = sectionMd.split('\n').map(l => l.trim());
+
+  // Find the first table header row (starts with |).
+  let headerIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith('|') && lines[i].includes('|', 1)) {
+      headerIdx = i;
+      break;
+    }
+  }
+  if (headerIdx === -1) {
+    warnings.push('no markdown table found in Deliverables Manifest section');
+    return { deliverables, warnings };
+  }
+
+  const headerCells = lines[headerIdx]
+    .split('|')
+    .slice(1, -1)
+    .map(c => c.trim().toLowerCase());
+
+  const colIdx = (name: string): number => {
+    return headerCells.findIndex(c => c.includes(name));
+  };
+
+  const idCol = colIdx('id');
+  const descCol = colIdx('description');
+  const pathCol = Math.max(colIdx('evidence'), colIdx('path'));
+  const statusCol = colIdx('status');
+  const catCol = colIdx('category');
+
+  // Skip separator line (|---|---|)
+  let startRow = headerIdx + 1;
+  if (startRow < lines.length && /^\|[\s\-:|]+\|$/.test(lines[startRow])) {
+    startRow += 1;
+  }
+
+  for (let i = startRow; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.startsWith('|')) break;
+    const cells = line.split('|').slice(1, -1).map(c => c.trim());
+    if (cells.length < headerCells.length) {
+      warnings.push(`row ${i - startRow + 1} has fewer cells than header, skipping`);
+      continue;
+    }
+    const get = (idx: number) => (idx >= 0 && idx < cells.length ? cells[idx] : '');
+    deliverables.push({
+      id: get(idCol),
+      description: get(descCol),
+      evidence_path: get(pathCol),
+      status: get(statusCol),
+      category: get(catCol),
+    });
+  }
+
+  return { deliverables, warnings };
+}
+
+const dodLoadManifestHandler: HandlerDef = {
+  name: 'dod_load_manifest',
+  description: 'Load and parse a Deliverables Manifest from a PRD file or issue reference',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const body = isIssueRef(args.path)
+        ? fetchIssueBody(args.path)
+        : await readLocalFile(args.path);
+
+      const section = extractManifestSection(body);
+      if (section === null) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                ok: false,
+                error: 'no Deliverables Manifest section found in PRD',
+              }),
+            },
+          ],
+        };
+      }
+
+      const { deliverables, warnings } = parseManifestTable(section);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              deliverables,
+              warnings,
+              source: args.path,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default dodLoadManifestHandler;

--- a/tests/dod_load_manifest.test.ts
+++ b/tests/dod_load_manifest.test.ts
@@ -1,0 +1,140 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+// Mock child_process for gh shell-outs.
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string, _opts?: unknown) => execMockFn(cmd));
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/dod_load_manifest.ts');
+
+function resetMocks() {
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+const SAMPLE_PRD = `# Some PRD
+
+Intro text.
+
+## Deliverables Manifest
+
+| ID | Description | Evidence Path | Status | Category |
+|----|-------------|---------------|--------|----------|
+| D-01 | Wave init handler | handlers/wave_init.ts | done | code |
+| D-02 | Docs updated | docs/WAVE.md | pending | docs |
+
+## Next Section
+
+Out of scope for manifest parsing.
+`;
+
+async function writeTempFile(content: string): Promise<string> {
+  const path = `/tmp/dod-manifest-${Date.now()}-${Math.floor(Math.random() * 1e9)}.md`;
+  await Bun.write(path, content);
+  return path;
+}
+
+describe('dod_load_manifest handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('dod_load_manifest');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('parses_valid_manifest — local file with well-formed table', async () => {
+    const path = await writeTempFile(SAMPLE_PRD);
+    const result = await handler.execute({ path });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.deliverables.length).toBe(2);
+    expect(parsed.deliverables[0]).toEqual({
+      id: 'D-01',
+      description: 'Wave init handler',
+      evidence_path: 'handlers/wave_init.ts',
+      status: 'done',
+      category: 'code',
+    });
+    expect(parsed.deliverables[1].id).toBe('D-02');
+  });
+
+  test('handles_missing_manifest_section — PRD with no manifest returns error', async () => {
+    const path = await writeTempFile('# PRD\n\nNo manifest here.\n');
+    const result = await handler.execute({ path });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('no Deliverables Manifest');
+  });
+
+  test('handles_malformed_rows — warns on short rows, continues parsing', async () => {
+    const md = `## Deliverables Manifest
+
+| ID | Description | Evidence Path | Status | Category |
+|----|-------------|---------------|--------|----------|
+| D-01 | Only has three cells |
+| D-02 | Valid row | path/thing | done | code |
+`;
+    const path = await writeTempFile(md);
+    const result = await handler.execute({ path });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.warnings.length).toBeGreaterThan(0);
+    expect(parsed.deliverables.length).toBe(1);
+    expect(parsed.deliverables[0].id).toBe('D-02');
+  });
+
+  test('reads_from_gh_issue — #N format shells out to gh issue view', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      if (cmd.includes('gh issue view 42')) {
+        return JSON.stringify({ body: SAMPLE_PRD });
+      }
+      return '';
+    };
+    const result = await handler.execute({ path: '#42' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.deliverables.length).toBe(2);
+  });
+
+  test('reads_from_gh_issue — org/repo#N format uses --repo flag', async () => {
+    let seenCmd = '';
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      if (cmd.includes('gh issue view')) {
+        seenCmd = cmd;
+        return JSON.stringify({ body: SAMPLE_PRD });
+      }
+      return '';
+    };
+    const result = await handler.execute({ path: 'acme/widgets#7' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(seenCmd).toContain('--repo acme/widgets');
+    expect(seenCmd).toContain('7');
+  });
+
+  test('missing_file_returns_structured_error', async () => {
+    const result = await handler.execute({ path: '/tmp/nonexistent-prd-file-xyz.md' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('file not found');
+  });
+
+  test('schema_validation — rejects missing path', async () => {
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema_validation — rejects empty path', async () => {
+    const result = await handler.execute({ path: '' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `dod_load_manifest` — parses a PRD's Deliverables Manifest section. Foundation for `dod_verify_deliverable`. Wave 1b.

## Changes

- `handlers/dod_load_manifest.ts` — HandlerDef, schema: `path` (local file OR `#N` / `org/repo#N` issue ref). Extracts "Deliverables Manifest" section, parses GFM table.
- `tests/dod_load_manifest.test.ts` — valid manifest, missing section, malformed rows, #N gh path, org/repo#N path, missing file, schema validation.

## Linked Issues

Closes #20

## Test Plan

- [x] `./scripts/ci/validate.sh` green (200 tests + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)