### PR TITLE
feat(wave-mcp): implement dod_verify_deliverable handler

### DIFF
--- a/handlers/dod_verify_deliverable.ts
+++ b/handlers/dod_verify_deliverable.ts
@@ -1,0 +1,107 @@
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  id: z.string().min(1, 'id must be a non-empty string'),
+  evidence_path: z.string().min(1, 'evidence_path must be a non-empty string'),
+});
+
+interface FsInfo {
+  exists: boolean;
+  is_directory: boolean;
+  empty: boolean;
+  size_bytes: number;
+  last_modified: string | null;
+}
+
+/**
+ * Use Bun.spawnSync('stat', ...) to probe a path. Avoids node:fs so we
+ * dodge mock.module('fs') pollution from sibling test files, and avoids
+ * child_process so we dodge mock.module('child_process') pollution from
+ * sibling test files that mock execSync.
+ */
+function probePath(path: string): FsInfo {
+  const proc = Bun.spawnSync({
+    cmd: ['stat', '-c', '%F|%s|%Y', path],
+    stderr: 'pipe',
+  });
+
+  if (proc.exitCode !== 0) {
+    return {
+      exists: false,
+      is_directory: false,
+      empty: true,
+      size_bytes: 0,
+      last_modified: null,
+    };
+  }
+
+  const out = new TextDecoder().decode(proc.stdout).trim();
+  const parts = out.split('|');
+  const kind = parts[0] ?? '';
+  const sizeBytes = parseInt(parts[1] ?? '0', 10) || 0;
+  const mtimeSecs = parseInt(parts[2] ?? '0', 10) || 0;
+  const isDirectory = kind === 'directory';
+
+  let empty: boolean;
+  if (isDirectory) {
+    // For a directory, "empty" means no entries.
+    const ls = Bun.spawnSync({
+      cmd: ['sh', '-c', `ls -A ${JSON.stringify(path)}`],
+      stderr: 'pipe',
+    });
+    const lsOut = new TextDecoder().decode(ls.stdout).trim();
+    empty = lsOut.length === 0;
+  } else {
+    empty = sizeBytes === 0;
+  }
+
+  return {
+    exists: true,
+    is_directory: isDirectory,
+    empty,
+    size_bytes: sizeBytes,
+    last_modified: mtimeSecs > 0 ? new Date(mtimeSecs * 1000).toISOString() : null,
+  };
+}
+
+const dodVerifyDeliverableHandler: HandlerDef = {
+  name: 'dod_verify_deliverable',
+  description: "Check whether a deliverable's evidence path exists and is non-empty",
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const info = probePath(args.evidence_path);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              id: args.id,
+              evidence_path: args.evidence_path,
+              ...info,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default dodVerifyDeliverableHandler;

--- a/tests/dod_verify_deliverable.test.ts
+++ b/tests/dod_verify_deliverable.test.ts
@@ -1,0 +1,109 @@
+import { describe, test, expect } from 'bun:test';
+
+// This handler uses Bun.spawnSync('stat', ...) directly rather than any
+// mockable module, so tests operate against real files/directories in /tmp.
+
+const { default: handler } = await import('../handlers/dod_verify_deliverable.ts');
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+async function tempFile(content: string): Promise<string> {
+  const path = `/tmp/dod-verify-${Date.now()}-${Math.floor(Math.random() * 1e9)}.txt`;
+  await Bun.write(path, content);
+  return path;
+}
+
+async function tempEmptyFile(): Promise<string> {
+  const path = `/tmp/dod-verify-empty-${Date.now()}-${Math.floor(Math.random() * 1e9)}.txt`;
+  await Bun.write(path, '');
+  return path;
+}
+
+async function tempDirWithFile(): Promise<string> {
+  const dir = `/tmp/dod-verify-dir-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+  await Bun.write(`${dir}/inner.txt`, 'hello');
+  return dir;
+}
+
+async function tempEmptyDir(): Promise<string> {
+  const dir = `/tmp/dod-verify-empty-dir-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+  // Create the directory by writing and removing a sentinel via Bun shell.
+  await Bun.write(`${dir}/.keep`, '');
+  // Now delete the file but keep the directory.
+  Bun.spawnSync({ cmd: ['rm', `${dir}/.keep`] });
+  return dir;
+}
+
+describe('dod_verify_deliverable handler', () => {
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('dod_verify_deliverable');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('existing_file — returns exists=true, empty=false, size>0', async () => {
+    const path = await tempFile('some content');
+    const result = await handler.execute({ id: 'D-01', evidence_path: path });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.exists).toBe(true);
+    expect(parsed.empty).toBe(false);
+    expect(parsed.size_bytes).toBeGreaterThan(0);
+    expect(parsed.is_directory).toBe(false);
+    expect(parsed.id).toBe('D-01');
+  });
+
+  test('existing_empty_file — exists=true, empty=true', async () => {
+    const path = await tempEmptyFile();
+    const result = await handler.execute({ id: 'D-02', evidence_path: path });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.exists).toBe(true);
+    expect(parsed.empty).toBe(true);
+    expect(parsed.size_bytes).toBe(0);
+  });
+
+  test('missing_path — exists=false', async () => {
+    const result = await handler.execute({
+      id: 'D-03',
+      evidence_path: '/tmp/definitely-nonexistent-path-xyz-987654321',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.exists).toBe(false);
+    expect(parsed.empty).toBe(true);
+  });
+
+  test('directory_with_contents — exists=true, is_directory=true, empty=false', async () => {
+    const dir = await tempDirWithFile();
+    const result = await handler.execute({ id: 'D-04', evidence_path: dir });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.exists).toBe(true);
+    expect(parsed.is_directory).toBe(true);
+    expect(parsed.empty).toBe(false);
+  });
+
+  test('empty_directory — exists=true, is_directory=true, empty=true', async () => {
+    const dir = await tempEmptyDir();
+    const result = await handler.execute({ id: 'D-05', evidence_path: dir });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.exists).toBe(true);
+    expect(parsed.is_directory).toBe(true);
+    expect(parsed.empty).toBe(true);
+  });
+
+  test('schema_validation — rejects missing id', async () => {
+    const result = await handler.execute({ evidence_path: '/tmp/x' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema_validation — rejects missing evidence_path', async () => {
+    const result = await handler.execute({ id: 'D-01' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `dod_verify_deliverable` — mechanical check that a deliverable's evidence path exists and is non-empty. Handles both files and directories. Wave 1b.

## Changes

- `handlers/dod_verify_deliverable.ts` — HandlerDef, schema: `id` + `evidence_path`. Uses `Bun.spawnSync('stat', ...)` so we don't hit node:fs or child_process mock collisions.
- `tests/dod_verify_deliverable.test.ts` — existing file (non-empty), empty file, missing path, directory with contents, empty directory, schema validation.

## Linked Issues

Closes #21

## Test Plan

- [x] `./scripts/ci/validate.sh` green (213 tests + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)