### PR TITLE
feat(wave-mcp): implement dod_run_test_suite handler

### DIFF
--- a/handlers/dod_run_test_suite.ts
+++ b/handlers/dod_run_test_suite.ts
@@ -1,0 +1,159 @@
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  command: z.string().optional(),
+});
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  return await Bun.file(path).exists();
+}
+
+async function discoverTestCommand(root: string): Promise<string | null> {
+  if (await fileExists(`${root}/scripts/ci/test.sh`)) {
+    return './scripts/ci/test.sh';
+  }
+  if (await fileExists(`${root}/package.json`)) {
+    try {
+      const pkg = (await Bun.file(`${root}/package.json`).json()) as {
+        scripts?: Record<string, string>;
+        devDependencies?: Record<string, string>;
+        dependencies?: Record<string, string>;
+      };
+      if (pkg.scripts?.test) {
+        return 'npm test';
+      }
+    } catch {
+      // fall through
+    }
+    // Default to bun test if package.json exists but no test script.
+    return 'bun test';
+  }
+  if (await fileExists(`${root}/pytest.ini`) || await fileExists(`${root}/pyproject.toml`)) {
+    return 'pytest';
+  }
+  return null;
+}
+
+interface TestResult {
+  passed: number;
+  failed: number;
+  skipped: number;
+}
+
+function parseBunOutput(output: string): TestResult {
+  // bun test summary lines: " NN pass", " NN fail", " NN skip"
+  const passMatch = /(\d+)\s+pass/.exec(output);
+  const failMatch = /(\d+)\s+fail/.exec(output);
+  const skipMatch = /(\d+)\s+skip/.exec(output);
+  return {
+    passed: passMatch ? parseInt(passMatch[1], 10) : 0,
+    failed: failMatch ? parseInt(failMatch[1], 10) : 0,
+    skipped: skipMatch ? parseInt(skipMatch[1], 10) : 0,
+  };
+}
+
+function parsePytestOutput(output: string): TestResult {
+  // pytest summary: "NN passed, NN failed, NN skipped"
+  const passMatch = /(\d+)\s+passed/.exec(output);
+  const failMatch = /(\d+)\s+failed/.exec(output);
+  const skipMatch = /(\d+)\s+skipped/.exec(output);
+  return {
+    passed: passMatch ? parseInt(passMatch[1], 10) : 0,
+    failed: failMatch ? parseInt(failMatch[1], 10) : 0,
+    skipped: skipMatch ? parseInt(skipMatch[1], 10) : 0,
+  };
+}
+
+function parseTestOutput(command: string, output: string): TestResult {
+  if (command.includes('bun test')) return parseBunOutput(output);
+  if (command.includes('pytest')) return parsePytestOutput(output);
+  // Generic best-effort: try bun format first, fall back to pytest format.
+  const bun = parseBunOutput(output);
+  if (bun.passed + bun.failed + bun.skipped > 0) return bun;
+  return parsePytestOutput(output);
+}
+
+function runCommand(cmd: string, cwd: string): { exitCode: number; output: string; durationMs: number } {
+  const start = Date.now();
+  const proc = Bun.spawnSync({
+    cmd: ['sh', '-c', cmd],
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const out =
+    new TextDecoder().decode(proc.stdout) + new TextDecoder().decode(proc.stderr);
+  return {
+    exitCode: proc.exitCode ?? -1,
+    output: out,
+    durationMs: Date.now() - start,
+  };
+}
+
+const dodRunTestSuiteHandler: HandlerDef = {
+  name: 'dod_run_test_suite',
+  description: "Discover and run the project's test command, return structured pass/fail counts",
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const root = projectDir();
+      const command = args.command ?? (await discoverTestCommand(root));
+      if (!command) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                ok: false,
+                error: 'no test command found (looked for scripts/ci/test.sh, package.json, pytest.ini)',
+              }),
+            },
+          ],
+        };
+      }
+
+      const { exitCode, output, durationMs } = runCommand(command, root);
+      const parsed = parseTestOutput(command, output);
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              command,
+              exit_code: exitCode,
+              passed: parsed.passed,
+              failed: parsed.failed,
+              skipped: parsed.skipped,
+              duration_ms: durationMs,
+              raw_output: output,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default dodRunTestSuiteHandler;

--- a/tests/dod_run_test_suite.test.ts
+++ b/tests/dod_run_test_suite.test.ts
@@ -1,0 +1,122 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+
+// This handler uses Bun.spawnSync + Bun.file (native APIs), so tests
+// work against real tempdirs and real shell commands. No module mocks.
+
+const { default: handler } = await import('../handlers/dod_run_test_suite.ts');
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+let fixtureDir = '';
+const ORIGINAL_ENV = process.env.CLAUDE_PROJECT_DIR;
+
+function restoreEnv() {
+  if (ORIGINAL_ENV === undefined) {
+    delete process.env.CLAUDE_PROJECT_DIR;
+  } else {
+    process.env.CLAUDE_PROJECT_DIR = ORIGINAL_ENV;
+  }
+}
+
+async function makeFixture(files: Record<string, string>): Promise<string> {
+  const dir = `/tmp/dod-test-suite-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+  for (const [name, content] of Object.entries(files)) {
+    await Bun.write(`${dir}/${name}`, content);
+  }
+  return dir;
+}
+
+describe('dod_run_test_suite handler', () => {
+  beforeEach(() => {
+    fixtureDir = '';
+  });
+  afterEach(() => {
+    fixtureDir = '';
+    restoreEnv();
+  });
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('dod_run_test_suite');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('explicit_command_override — input command bypasses discovery', async () => {
+    fixtureDir = await makeFixture({
+      'package.json': JSON.stringify({ scripts: { test: 'echo should-not-run' } }),
+    });
+    process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+    const result = await handler.execute({ command: 'echo "1 passed, 0 failed"' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.command).toBe('echo "1 passed, 0 failed"');
+    expect(parsed.exit_code).toBe(0);
+    expect(parsed.passed).toBe(1);
+    expect(parsed.failed).toBe(0);
+  });
+
+  test('discovers_scripts_ci_test — prefers scripts/ci/test.sh when present', async () => {
+    fixtureDir = await makeFixture({
+      'scripts/ci/test.sh': '#!/bin/sh\necho "5 pass\\n0 fail"\n',
+      'package.json': JSON.stringify({ scripts: { test: 'should-not-see' } }),
+    });
+    // Make it executable.
+    Bun.spawnSync({ cmd: ['chmod', '+x', `${fixtureDir}/scripts/ci/test.sh`] });
+    process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.command).toBe('./scripts/ci/test.sh');
+  });
+
+  test('parses_bun_test_output', async () => {
+    fixtureDir = await makeFixture({ 'noop.txt': 'x' });
+    process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+    const result = await handler.execute({
+      command: 'echo " 42 pass\\n 3 fail\\n 1 skip"',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.passed).toBe(42);
+    expect(parsed.failed).toBe(3);
+    expect(parsed.skipped).toBe(1);
+  });
+
+  test('parses_pytest_output', async () => {
+    fixtureDir = await makeFixture({ 'noop.txt': 'x' });
+    process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+    const result = await handler.execute({
+      command: 'echo "===== 10 passed, 2 failed, 1 skipped in 3.21s ====="',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.passed).toBe(10);
+    expect(parsed.failed).toBe(2);
+    expect(parsed.skipped).toBe(1);
+  });
+
+  test('exit_code_nonzero_sets_failed — command fails, structured response not thrown', async () => {
+    fixtureDir = await makeFixture({ 'noop.txt': 'x' });
+    process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+    const result = await handler.execute({
+      command: 'sh -c "echo \\"0 passed, 5 failed\\"; exit 1"',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.exit_code).not.toBe(0);
+    expect(parsed.failed).toBe(5);
+  });
+
+  test('no_test_command_found_returns_error', async () => {
+    fixtureDir = `/tmp/dod-test-suite-empty-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+    // Ensure dir exists.
+    await Bun.write(`${fixtureDir}/.keep`, '');
+    Bun.spawnSync({ cmd: ['rm', `${fixtureDir}/.keep`] });
+    process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('no test command found');
+  });
+});


### PR DESCRIPTION
## Summary

Implements `dod_run_test_suite` — discovers + runs the project's test command, parses pass/fail counts. Wave 1b.

## Changes

- `handlers/dod_run_test_suite.ts` — HandlerDef, schema: `command` (optional). Discovery order: explicit → scripts/ci/test.sh → npm test → bun test → pytest → error. Parses bun and pytest output formats.
- `tests/dod_run_test_suite.test.ts` — explicit override, discovery order, bun parse, pytest parse, nonzero exit, no command found.

## Linked Issues

Closes #22

## Test Plan

- [x] `./scripts/ci/validate.sh` green (225 tests + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)