### PR TITLE
feat(wave-mcp): implement dod_check_coverage handler

### DIFF
--- a/handlers/dod_check_coverage.ts
+++ b/handlers/dod_check_coverage.ts
@@ -1,0 +1,175 @@
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  threshold: z.number().min(0).max(100),
+  coverage_file: z.string().optional(),
+});
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  return await Bun.file(path).exists();
+}
+
+async function discoverCoverageFile(root: string): Promise<string | null> {
+  const candidates = [
+    `${root}/coverage.xml`,
+    `${root}/coverage/cobertura.xml`,
+    `${root}/coverage.json`,
+    `${root}/coverage/coverage-summary.json`,
+  ];
+  for (const p of candidates) {
+    if (await fileExists(p)) return p;
+  }
+  return null;
+}
+
+interface CoverageResult {
+  percentage: number;
+  files_below_threshold: Array<{ path: string; percentage: number }>;
+}
+
+/**
+ * Parse a Cobertura-style XML file. Extracts line-rate attributes from
+ * `<coverage>` (overall) and `<class filename="...">` elements.
+ */
+function parseCobertura(xml: string, threshold: number): CoverageResult {
+  const overallMatch = /<coverage[^>]*\bline-rate="([\d.]+)"/.exec(xml);
+  const overall = overallMatch ? parseFloat(overallMatch[1]) * 100 : 0;
+
+  const files: Array<{ path: string; percentage: number }> = [];
+  const classRe = /<class\s+([^>]*)\/?>/g;
+  let m: RegExpExecArray | null;
+  while ((m = classRe.exec(xml)) !== null) {
+    const attrs = m[1];
+    const fn = /filename="([^"]+)"/.exec(attrs);
+    const lr = /line-rate="([\d.]+)"/.exec(attrs);
+    if (fn && lr) {
+      const pct = parseFloat(lr[1]) * 100;
+      if (pct < threshold) {
+        files.push({ path: fn[1], percentage: pct });
+      }
+    }
+  }
+
+  return { percentage: overall, files_below_threshold: files };
+}
+
+/**
+ * Parse a JSON coverage summary in the Istanbul/Jest format:
+ *   { total: { lines: { pct: 85.3 } }, "path/to/file.ts": { lines: { pct: 72 } }, ... }
+ */
+function parseJsonCoverage(obj: unknown, threshold: number): CoverageResult {
+  const record = obj as Record<string, { lines?: { pct?: number } }>;
+  const total = record.total?.lines?.pct ?? 0;
+
+  const files: Array<{ path: string; percentage: number }> = [];
+  for (const [key, val] of Object.entries(record)) {
+    if (key === 'total') continue;
+    const pct = val?.lines?.pct;
+    if (typeof pct === 'number' && pct < threshold) {
+      files.push({ path: key, percentage: pct });
+    }
+  }
+
+  return { percentage: total, files_below_threshold: files };
+}
+
+const dodCheckCoverageHandler: HandlerDef = {
+  name: 'dod_check_coverage',
+  description: 'Measure test coverage and compare against a threshold',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const root = projectDir();
+      const file = args.coverage_file ?? (await discoverCoverageFile(root));
+      if (!file) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                ok: false,
+                error: 'no coverage file found (looked for coverage.xml, coverage.json, coverage/...)',
+              }),
+            },
+          ],
+        };
+      }
+
+      if (!(await fileExists(file))) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                ok: false,
+                error: `coverage file not found: ${file}`,
+              }),
+            },
+          ],
+        };
+      }
+
+      const content = await Bun.file(file).text();
+      let result: CoverageResult;
+      if (file.endsWith('.xml') || content.trimStart().startsWith('<')) {
+        result = parseCobertura(content, args.threshold);
+      } else {
+        try {
+          const obj = JSON.parse(content);
+          result = parseJsonCoverage(obj, args.threshold);
+        } catch (err) {
+          const error = err instanceof Error ? err.message : String(err);
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({
+                  ok: false,
+                  error: `failed to parse coverage JSON: ${error}`,
+                }),
+              },
+            ],
+          };
+        }
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              percentage: result.percentage,
+              threshold: args.threshold,
+              passed: result.percentage >= args.threshold,
+              files_below_threshold: result.files_below_threshold,
+              source: file,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default dodCheckCoverageHandler;

--- a/tests/dod_check_coverage.test.ts
+++ b/tests/dod_check_coverage.test.ts
@@ -1,0 +1,140 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+
+// Uses Bun.file / Bun.write exclusively — no module mocks.
+
+const { default: handler } = await import('../handlers/dod_check_coverage.ts');
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+let fixtureDir = '';
+const ORIGINAL_ENV = process.env.CLAUDE_PROJECT_DIR;
+
+function restoreEnv() {
+  if (ORIGINAL_ENV === undefined) {
+    delete process.env.CLAUDE_PROJECT_DIR;
+  } else {
+    process.env.CLAUDE_PROJECT_DIR = ORIGINAL_ENV;
+  }
+}
+
+async function tempFile(name: string, content: string): Promise<string> {
+  fixtureDir = `/tmp/dod-coverage-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+  const path = `${fixtureDir}/${name}`;
+  await Bun.write(path, content);
+  process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+  return path;
+}
+
+const COBERTURA_XML = `<?xml version="1.0" ?>
+<coverage line-rate="0.85" branch-rate="0.80">
+  <packages>
+    <package name="src">
+      <classes>
+        <class filename="src/good.ts" line-rate="0.92"/>
+        <class filename="src/bad.ts" line-rate="0.55"/>
+        <class filename="src/okay.ts" line-rate="0.81"/>
+      </classes>
+    </package>
+  </packages>
+</coverage>
+`;
+
+const JSON_COVERAGE = {
+  total: { lines: { pct: 88.5 } },
+  'src/foo.ts': { lines: { pct: 95 } },
+  'src/bar.ts': { lines: { pct: 60 } },
+  'src/baz.ts': { lines: { pct: 80 } },
+};
+
+describe('dod_check_coverage handler', () => {
+  beforeEach(() => {
+    fixtureDir = '';
+  });
+  afterEach(() => {
+    fixtureDir = '';
+    restoreEnv();
+  });
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('dod_check_coverage');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('parses_coverage_xml — cobertura format, passing threshold', async () => {
+    const path = await tempFile('coverage.xml', COBERTURA_XML);
+    const result = await handler.execute({ threshold: 80, coverage_file: path });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.percentage).toBe(85);
+    expect(parsed.passed).toBe(true);
+    expect(parsed.files_below_threshold.map((f: { path: string }) => f.path)).toEqual([
+      'src/bad.ts',
+    ]);
+  });
+
+  test('parses_coverage_json — istanbul summary format', async () => {
+    const path = await tempFile('coverage.json', JSON.stringify(JSON_COVERAGE));
+    const result = await handler.execute({ threshold: 85, coverage_file: path });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.percentage).toBe(88.5);
+    expect(parsed.passed).toBe(true);
+    expect(parsed.files_below_threshold.length).toBe(2);
+  });
+
+  test('identifies_files_below_threshold — xml', async () => {
+    const path = await tempFile('coverage.xml', COBERTURA_XML);
+    const result = await handler.execute({ threshold: 90, coverage_file: path });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.passed).toBe(false);
+    // bad.ts (55) and okay.ts (81) are below 90
+    expect(parsed.files_below_threshold.length).toBe(2);
+  });
+
+  test('missing_coverage_file_returns_error', async () => {
+    const result = await handler.execute({
+      threshold: 80,
+      coverage_file: '/tmp/nonexistent-coverage-xyz.xml',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('not found');
+  });
+
+  test('threshold_boundary — exactly at threshold is passed', async () => {
+    const path = await tempFile(
+      'coverage.json',
+      JSON.stringify({ total: { lines: { pct: 80 } } }),
+    );
+    const result = await handler.execute({ threshold: 80, coverage_file: path });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.passed).toBe(true);
+  });
+
+  test('no_coverage_file_discovery_fails', async () => {
+    fixtureDir = `/tmp/dod-coverage-empty-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+    await Bun.write(`${fixtureDir}/.keep`, '');
+    Bun.spawnSync({ cmd: ['rm', `${fixtureDir}/.keep`] });
+    process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+    const result = await handler.execute({ threshold: 80 });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('no coverage file found');
+  });
+
+  test('schema_validation — rejects missing threshold', async () => {
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema_validation — rejects threshold outside 0-100', async () => {
+    const result = await handler.execute({ threshold: 120 });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `dod_check_coverage` — parses coverage reports, compares overall percentage against a threshold, identifies files below threshold. Supports cobertura XML and Istanbul/Jest JSON formats. Wave 1b.

## Changes

- `handlers/dod_check_coverage.ts` — HandlerDef, schema: `threshold` (0-100), `coverage_file` (optional, discovers from common paths).
- `tests/dod_check_coverage.test.ts` — XML parsing, JSON parsing, files below threshold, missing file, boundary case, discovery failure, schema validation.

## Linked Issues

Closes #23

## Test Plan

- [x] `./scripts/ci/validate.sh` green (239 tests + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)