### PR TITLE
feat(wave-mcp): implement wave_ci_trust_level handler

### DIFF
--- a/handlers/wave_ci_trust_level.ts
+++ b/handlers/wave_ci_trust_level.ts
@@ -1,0 +1,198 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({}).strict();
+
+type TrustLevel = 'pre_merge_authoritative' | 'post_merge_required' | 'unknown';
+
+interface TrustResult {
+  level: TrustLevel;
+  reason: string;
+  cache_ttl_seconds: number;
+}
+
+// Per-process cache keyed by project root.
+const cache = new Map<string, TrustResult>();
+
+function projectRoot(): string {
+  try {
+    return execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
+  } catch {
+    return process.cwd();
+  }
+}
+
+function detectPlatform(): 'github' | 'gitlab' | 'unknown' {
+  try {
+    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    if (url.includes('github')) return 'github';
+    if (url.includes('gitlab')) return 'gitlab';
+    return 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+function parseRepoSlug(): string | null {
+  try {
+    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    // Match https or ssh origin URLs.
+    const httpsMatch = /github\.com[/:]([^/]+)\/([^/.]+)/.exec(url);
+    if (httpsMatch) return `${httpsMatch[1]}/${httpsMatch[2]}`;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function checkGithubTrust(): TrustResult {
+  const slug = parseRepoSlug();
+  if (!slug) {
+    return {
+      level: 'unknown',
+      reason: 'could not parse github repo slug from origin url',
+      cache_ttl_seconds: 3600,
+    };
+  }
+
+  // Try rulesets first (merge queue lives in a ruleset).
+  try {
+    const raw = execSync(`gh api repos/${slug}/rulesets`, { encoding: 'utf8' });
+    const rulesets = JSON.parse(raw) as Array<{ id: number; enforcement?: string }>;
+    for (const rs of rulesets) {
+      try {
+        const rsRaw = execSync(`gh api repos/${slug}/rulesets/${rs.id}`, {
+          encoding: 'utf8',
+        });
+        const detail = JSON.parse(rsRaw) as { rules?: Array<{ type?: string }> };
+        for (const rule of detail.rules ?? []) {
+          if (rule.type === 'merge_queue') {
+            return {
+              level: 'pre_merge_authoritative',
+              reason: 'github merge queue ruleset present',
+              cache_ttl_seconds: 3600,
+            };
+          }
+        }
+      } catch {
+        // continue
+      }
+    }
+  } catch {
+    // rulesets unavailable or API error — fall through
+  }
+
+  // Fall back to branch protection strict check.
+  try {
+    const raw = execSync(`gh api repos/${slug}/branches/main/protection`, {
+      encoding: 'utf8',
+    });
+    const prot = JSON.parse(raw) as {
+      required_status_checks?: { strict?: boolean };
+    };
+    if (prot.required_status_checks?.strict === true) {
+      return {
+        level: 'pre_merge_authoritative',
+        reason: 'github branch protection strict=true on main',
+        cache_ttl_seconds: 3600,
+      };
+    }
+    return {
+      level: 'post_merge_required',
+      reason: 'github branch protection without strict mode',
+      cache_ttl_seconds: 3600,
+    };
+  } catch {
+    return {
+      level: 'unknown',
+      reason: 'github api call failed',
+      cache_ttl_seconds: 3600,
+    };
+  }
+}
+
+function checkGitlabTrust(): TrustResult {
+  // Detect project via glab repo view --output json
+  try {
+    const raw = execSync('glab repo view --output json', { encoding: 'utf8' });
+    const info = JSON.parse(raw) as {
+      merge_pipelines_enabled?: boolean;
+      merge_trains_enabled?: boolean;
+    };
+    if (info.merge_pipelines_enabled && info.merge_trains_enabled) {
+      return {
+        level: 'pre_merge_authoritative',
+        reason: 'gitlab merge pipelines + merge trains enabled',
+        cache_ttl_seconds: 3600,
+      };
+    }
+    return {
+      level: 'post_merge_required',
+      reason: 'gitlab without merge trains',
+      cache_ttl_seconds: 3600,
+    };
+  } catch {
+    return {
+      level: 'unknown',
+      reason: 'glab api call failed',
+      cache_ttl_seconds: 3600,
+    };
+  }
+}
+
+function computeTrust(): TrustResult {
+  const platform = detectPlatform();
+  if (platform === 'github') return checkGithubTrust();
+  if (platform === 'gitlab') return checkGitlabTrust();
+  return {
+    level: 'unknown',
+    reason: 'unrecognized platform',
+    cache_ttl_seconds: 3600,
+  };
+}
+
+const waveCiTrustLevelHandler: HandlerDef = {
+  name: 'wave_ci_trust_level',
+  description: 'Detect whether the platform guarantees pre-merge CI == post-merge CI',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    try {
+      inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const key = projectRoot();
+      let result = cache.get(key);
+      if (!result) {
+        result = computeTrust();
+        cache.set(key, result);
+      }
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({ ok: true, ...result }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+// Exported for tests to reset cache between cases.
+export function __resetCache() {
+  cache.clear();
+}
+
+export default waveCiTrustLevelHandler;

--- a/tests/wave_ci_trust_level.test.ts
+++ b/tests/wave_ci_trust_level.test.ts
@@ -1,0 +1,161 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string, _opts?: unknown) => execMockFn(cmd));
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const handlerModule = await import('../handlers/wave_ci_trust_level.ts');
+const handler = handlerModule.default;
+const resetCache = handlerModule.__resetCache;
+
+function resetMocks() {
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+  resetCache();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('wave_ci_trust_level handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('wave_ci_trust_level');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('github_merge_queue_enabled — pre_merge_authoritative', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git rev-parse')) return '/tmp/repo\n';
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      if (cmd.includes('rulesets') && !cmd.match(/rulesets\/\d+/)) {
+        return JSON.stringify([{ id: 1, enforcement: 'active' }]);
+      }
+      if (cmd.includes('rulesets/1')) {
+        return JSON.stringify({ rules: [{ type: 'merge_queue' }] });
+      }
+      return '{}';
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.level).toBe('pre_merge_authoritative');
+    expect(parsed.reason).toContain('merge queue');
+  });
+
+  test('github_strict_protection_only — pre_merge_authoritative', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git rev-parse')) return '/tmp/repo2\n';
+      if (cmd.startsWith('git remote')) return 'git@github.com:org/repo.git\n';
+      if (cmd.includes('rulesets') && !cmd.match(/rulesets\/\d+/)) {
+        return JSON.stringify([]);
+      }
+      if (cmd.includes('branches/main/protection')) {
+        return JSON.stringify({ required_status_checks: { strict: true } });
+      }
+      return '{}';
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.level).toBe('pre_merge_authoritative');
+    expect(parsed.reason).toContain('strict');
+  });
+
+  test('github_no_strict — post_merge_required', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git rev-parse')) return '/tmp/repo3\n';
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      if (cmd.includes('rulesets') && !cmd.match(/rulesets\/\d+/)) {
+        return JSON.stringify([]);
+      }
+      if (cmd.includes('branches/main/protection')) {
+        return JSON.stringify({ required_status_checks: { strict: false } });
+      }
+      return '{}';
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.level).toBe('post_merge_required');
+  });
+
+  test('gitlab_trains_enabled — pre_merge_authoritative', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git rev-parse')) return '/tmp/repo4\n';
+      if (cmd.startsWith('git remote')) return 'https://gitlab.com/org/repo.git\n';
+      if (cmd.startsWith('glab repo view')) {
+        return JSON.stringify({
+          merge_pipelines_enabled: true,
+          merge_trains_enabled: true,
+        });
+      }
+      return '{}';
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.level).toBe('pre_merge_authoritative');
+  });
+
+  test('gitlab_pipelines_only — post_merge_required', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git rev-parse')) return '/tmp/repo5\n';
+      if (cmd.startsWith('git remote')) return 'https://gitlab.com/org/repo.git\n';
+      if (cmd.startsWith('glab repo view')) {
+        return JSON.stringify({
+          merge_pipelines_enabled: true,
+          merge_trains_enabled: false,
+        });
+      }
+      return '{}';
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.level).toBe('post_merge_required');
+  });
+
+  test('api_failure_returns_unknown', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git rev-parse')) return '/tmp/repo6\n';
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      throw new Error('gh api: not authenticated');
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.level).toBe('unknown');
+  });
+
+  test('caches_result_per_project', async () => {
+    let ghCallCount = 0;
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git rev-parse')) return '/tmp/repo7\n';
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      if (cmd.includes('rulesets') && !cmd.match(/rulesets\/\d+/)) {
+        ghCallCount++;
+        return JSON.stringify([{ id: 1, enforcement: 'active' }]);
+      }
+      if (cmd.includes('rulesets/1')) {
+        ghCallCount++;
+        return JSON.stringify({ rules: [{ type: 'merge_queue' }] });
+      }
+      return '{}';
+    };
+    await handler.execute({});
+    const firstCount = ghCallCount;
+    await handler.execute({});
+    // Second call should hit cache, not increment count further.
+    expect(ghCallCount).toBe(firstCount);
+  });
+
+  test('schema_validation — rejects unknown fields', async () => {
+    const result = await handler.execute({ foo: 'bar' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `wave_ci_trust_level` — platform trust detection for merge-queue / strict-mode CI guarantees. Wave 1b.

## Changes

- `handlers/wave_ci_trust_level.ts` — HandlerDef, no input. Detects platform, probes rulesets/branch protection (GitHub) or merge_trains (GitLab). Returns `{level, reason, cache_ttl_seconds}`.
- `tests/wave_ci_trust_level.test.ts` — github merge queue, github strict, github no protection, gitlab trains, gitlab pipelines only, API failure, caching, schema validation.

Per-process cache keyed by project root.

## Linked Issues

Closes #25

## Test Plan

- [x] `./scripts/ci/validate.sh` green (266 tests + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)