### PR TITLE
feat(wave-mcp): implement spec_get + lib/spec_parser

### DIFF
--- a/handlers/spec_get.ts
+++ b/handlers/spec_get.ts
@@ -1,0 +1,132 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+import { parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
+
+const inputSchema = z.object({
+  issue_ref: z.string().min(1, 'issue_ref must be a non-empty string'),
+});
+
+function detectPlatform(): 'github' | 'gitlab' {
+  try {
+    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    return url.includes('gitlab') ? 'gitlab' : 'github';
+  } catch {
+    return 'github';
+  }
+}
+
+interface IssueInfo {
+  number: number;
+  title: string;
+  body: string;
+  state: string;
+  labels: string[];
+}
+
+function fetchGithub(ref: IssueRef): IssueInfo {
+  const repoArg = ref.owner && ref.repo ? `--repo ${ref.owner}/${ref.repo}` : '';
+  const cmd = `gh issue view ${ref.number} ${repoArg} --json number,title,body,state,labels`.trim();
+  const raw = execSync(cmd, { encoding: 'utf8' });
+  const parsed = JSON.parse(raw) as {
+    number: number;
+    title: string;
+    body: string;
+    state: string;
+    labels: Array<{ name: string }>;
+  };
+  return {
+    number: parsed.number,
+    title: parsed.title,
+    body: parsed.body ?? '',
+    state: parsed.state.toUpperCase(),
+    labels: (parsed.labels ?? []).map(l => l.name),
+  };
+}
+
+function fetchGitlab(ref: IssueRef): IssueInfo {
+  const cmd =
+    ref.owner && ref.repo
+      ? `glab issue view ${ref.number} --repo ${ref.owner}/${ref.repo} --output json`
+      : `glab issue view ${ref.number} --output json`;
+  const raw = execSync(cmd, { encoding: 'utf8' });
+  const parsed = JSON.parse(raw) as {
+    iid?: number;
+    id?: number;
+    title: string;
+    description?: string;
+    state: string;
+    labels?: string[];
+  };
+  const state = parsed.state === 'opened' ? 'OPEN' : parsed.state.toUpperCase();
+  return {
+    number: parsed.iid ?? parsed.id ?? ref.number,
+    title: parsed.title,
+    body: parsed.description ?? '',
+    state,
+    labels: parsed.labels ?? [],
+  };
+}
+
+const specGetHandler: HandlerDef = {
+  name: 'spec_get',
+  description: 'Fetch an issue and return its body parsed into structured sections',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    const ref = parseIssueRef(args.issue_ref);
+    if (!ref) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: false,
+              error: `could not parse issue_ref: '${args.issue_ref}' (expected #N or org/repo#N)`,
+            }),
+          },
+        ],
+      };
+    }
+
+    try {
+      const platform = detectPlatform();
+      const info = platform === 'github' ? fetchGithub(ref) : fetchGitlab(ref);
+      const { sections, order } = parseSections(info.body);
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              number: info.number,
+              title: info.title,
+              state: info.state,
+              labels: info.labels,
+              body: info.body,
+              sections,
+              section_order: order,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default specGetHandler;

--- a/lib/spec_parser.ts
+++ b/lib/spec_parser.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared spec parsing helpers for the `spec_*` tool cluster.
+ *
+ * An "issue spec" (or "work item spec") is a markdown body with
+ * second-level headings (`## Heading`) that partition it into
+ * sections. Wave 2 tools (`spec_validate_structure`,
+ * `spec_acceptance_criteria`, `spec_dependencies`, `epic_sub_issues`)
+ * reuse this module to avoid duplicating the section-parsing logic.
+ *
+ * Lives in `lib/` so the handler registry codegen (which scans
+ * `handlers/*.ts`) ignores it.
+ */
+
+/**
+ * Normalize a heading title into a snake_case section key:
+ *   "Acceptance Criteria" -> "acceptance_criteria"
+ *   "  Tests  "            -> "tests"
+ */
+export function normalizeHeading(title: string): string {
+  return title
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\s_-]+/g, '')
+    .replace(/[\s-]+/g, '_');
+}
+
+export interface ParsedSections {
+  sections: Record<string, string>;
+  order: string[];
+}
+
+/**
+ * Parse a markdown body into `## Heading` sections. Only top-level
+ * H2 headings partition the body; H3 and deeper headings are part
+ * of the content.
+ */
+export function parseSections(markdown: string): ParsedSections {
+  const lines = markdown.split('\n');
+  const sections: Record<string, string> = {};
+  const order: string[] = [];
+  let currentKey: string | null = null;
+  let currentLines: string[] = [];
+
+  const flush = () => {
+    if (currentKey !== null) {
+      sections[currentKey] = currentLines.join('\n').trim();
+    }
+  };
+
+  for (const line of lines) {
+    const h2 = /^##\s+(.*)$/.exec(line);
+    if (h2) {
+      flush();
+      const key = normalizeHeading(h2[1]);
+      currentKey = key;
+      currentLines = [];
+      if (!order.includes(key)) order.push(key);
+      continue;
+    }
+    if (currentKey !== null) {
+      currentLines.push(line);
+    }
+  }
+  flush();
+
+  return { sections, order };
+}
+
+/**
+ * Resolve an issue_ref (`#N` or `org/repo#N`) into an (owner, repo, number)
+ * triple. Returns `null` on parse failure.
+ */
+export interface IssueRef {
+  owner: string | null;
+  repo: string | null;
+  number: number;
+}
+
+export function parseIssueRef(ref: string): IssueRef | null {
+  const full = /^([^/\s]+)\/([^/\s#]+)#(\d+)$/.exec(ref);
+  if (full) {
+    return { owner: full[1], repo: full[2], number: parseInt(full[3], 10) };
+  }
+  const short = /^#?(\d+)$/.exec(ref);
+  if (short) {
+    return { owner: null, repo: null, number: parseInt(short[1], 10) };
+  }
+  return null;
+}

--- a/tests/spec_get.test.ts
+++ b/tests/spec_get.test.ts
@@ -1,0 +1,179 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string, _opts?: unknown) => execMockFn(cmd));
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/spec_get.ts');
+
+function resetMocks() {
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+const FULL_BODY = `## Summary
+
+This is the summary section.
+
+## Changes
+
+- bullet one
+- bullet two
+
+## Tests
+
+- \`test_a\` does a thing
+- \`test_b\` does another
+
+## Acceptance Criteria
+
+- [ ] criterion one
+- [ ] criterion two
+
+## Dependencies
+
+- depends on #5
+`;
+
+describe('spec_get handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('spec_get');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('parses_standard_sections — Summary/Changes/Tests/Acceptance Criteria/Dependencies', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      if (cmd.includes('gh issue view 42')) {
+        return JSON.stringify({
+          number: 42,
+          title: 'Implement foo',
+          body: FULL_BODY,
+          state: 'open',
+          labels: [{ name: 'type::story' }, { name: 'priority::high' }],
+        });
+      }
+      return '';
+    };
+    const result = await handler.execute({ issue_ref: '#42' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.number).toBe(42);
+    expect(parsed.title).toBe('Implement foo');
+    expect(parsed.state).toBe('OPEN');
+    expect(parsed.labels).toEqual(['type::story', 'priority::high']);
+    expect(parsed.sections.summary).toContain('summary section');
+    expect(parsed.sections.changes).toContain('bullet one');
+    expect(parsed.sections.tests).toContain('test_a');
+    expect(parsed.sections.acceptance_criteria).toContain('criterion one');
+    expect(parsed.sections.dependencies).toContain('#5');
+    expect(parsed.section_order).toEqual([
+      'summary',
+      'changes',
+      'tests',
+      'acceptance_criteria',
+      'dependencies',
+    ]);
+  });
+
+  test('handles_cross_repo_ref — org/repo#N format uses --repo flag', async () => {
+    let seenCmd = '';
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/other/thing.git\n';
+      if (cmd.includes('gh issue view')) {
+        seenCmd = cmd;
+        return JSON.stringify({
+          number: 7,
+          title: 'Cross-repo',
+          body: '## Summary\nhello',
+          state: 'open',
+          labels: [],
+        });
+      }
+      return '';
+    };
+    const result = await handler.execute({ issue_ref: 'acme/widgets#7' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(seenCmd).toContain('--repo acme/widgets');
+    expect(seenCmd).toContain(' 7 ');
+  });
+
+  test('handles_missing_sections — body without sections', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      if (cmd.includes('gh issue view')) {
+        return JSON.stringify({
+          number: 1,
+          title: 'Bare',
+          body: 'just prose, no headings',
+          state: 'open',
+          labels: [],
+        });
+      }
+      return '';
+    };
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.sections).toEqual({});
+    expect(parsed.section_order).toEqual([]);
+  });
+
+  test('normalizes_section_headings — "Acceptance Criteria" -> acceptance_criteria', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      if (cmd.includes('gh issue view')) {
+        return JSON.stringify({
+          number: 1,
+          title: 'Norm',
+          body: '## Acceptance Criteria\n- x\n## Test Plan\n- y\n',
+          state: 'open',
+          labels: [],
+        });
+      }
+      return '';
+    };
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.sections.acceptance_criteria).toBeDefined();
+    expect(parsed.sections.test_plan).toBeDefined();
+  });
+
+  test('handles_nonexistent_issue — gh error returns structured error', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      throw new Error('gh: issue #9999 not found');
+    };
+    const result = await handler.execute({ issue_ref: '#9999' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('not found');
+  });
+
+  test('handles_malformed_issue_ref', async () => {
+    const result = await handler.execute({ issue_ref: 'not-a-ref' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('could not parse');
+  });
+
+  test('schema_validation — rejects missing issue_ref', async () => {
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema_validation — rejects empty issue_ref', async () => {
+    const result = await handler.execute({ issue_ref: '' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `spec_get` — fetches an issue and parses its body into structured sections. Establishes `lib/spec_parser.ts` as the shared helper module that Wave 2 tools will reuse. Final story of Wave 1b.

## Changes

- `lib/spec_parser.ts` — `normalizeHeading`, `parseSections`, `parseIssueRef`. Lives in `lib/` so the handler codegen ignores it.
- `handlers/spec_get.ts` — HandlerDef, schema: `issue_ref` (`#N` or `org/repo#N`). Shells out to gh/glab, parses body into sections keyed by normalized headings.
- `tests/spec_get.test.ts` — standard sections, cross-repo ref (`acme/widgets#7`), missing sections, heading normalization, nonexistent issue, malformed ref, schema validation.

## Linked Issues

Closes #26

## Test Plan

- [x] `./scripts/ci/validate.sh` green (280 tests + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)