### PR TITLE
feat(wave-mcp): implement spec_validate_structure handler

### DIFF
--- a/handlers/spec_validate_structure.ts
+++ b/handlers/spec_validate_structure.ts
@@ -1,0 +1,108 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+import { parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
+
+const inputSchema = z.object({
+  issue_ref: z.string().min(1, 'issue_ref must be a non-empty string'),
+});
+
+const REQUIRED_SECTIONS = ['changes', 'tests', 'acceptance_criteria'] as const;
+const OPTIONAL_SECTIONS = ['dependencies'] as const;
+
+function detectPlatform(): 'github' | 'gitlab' {
+  try {
+    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    return url.includes('gitlab') ? 'gitlab' : 'github';
+  } catch {
+    return 'github';
+  }
+}
+
+function fetchBody(ref: IssueRef): string {
+  const platform = detectPlatform();
+  if (platform === 'github') {
+    const repoArg = ref.owner && ref.repo ? `--repo ${ref.owner}/${ref.repo}` : '';
+    const cmd = `gh issue view ${ref.number} ${repoArg} --json body`.trim();
+    const raw = execSync(cmd, { encoding: 'utf8' });
+    return (JSON.parse(raw) as { body: string }).body ?? '';
+  }
+  const cmd =
+    ref.owner && ref.repo
+      ? `glab issue view ${ref.number} --repo ${ref.owner}/${ref.repo} --output json`
+      : `glab issue view ${ref.number} --output json`;
+  const raw = execSync(cmd, { encoding: 'utf8' });
+  return (JSON.parse(raw) as { description?: string }).description ?? '';
+}
+
+const specValidateStructureHandler: HandlerDef = {
+  name: 'spec_validate_structure',
+  description: 'Check for presence of required sections in an issue spec',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    const ref = parseIssueRef(args.issue_ref);
+    if (!ref) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: false,
+              error: `could not parse issue_ref: '${args.issue_ref}'`,
+            }),
+          },
+        ],
+      };
+    }
+
+    try {
+      const body = fetchBody(ref);
+      const { sections } = parseSections(body);
+
+      const presence: Record<string, boolean> = {};
+      const missing: string[] = [];
+      for (const key of REQUIRED_SECTIONS) {
+        const has = Boolean(sections[key] && sections[key].trim().length > 0);
+        presence[`has_${key}`] = has;
+        if (!has) missing.push(key);
+      }
+      for (const key of OPTIONAL_SECTIONS) {
+        presence[`has_${key}`] = Boolean(
+          sections[key] && sections[key].trim().length > 0,
+        );
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              issue_ref: args.issue_ref,
+              ...presence,
+              missing_sections: missing,
+              valid: missing.length === 0,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default specValidateStructureHandler;

--- a/tests/spec_validate_structure.test.ts
+++ b/tests/spec_validate_structure.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string, _opts?: unknown) => execMockFn(cmd));
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/spec_validate_structure.ts');
+
+function resetMocks() {
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+function mockBody(body: string) {
+  execMockFn = (cmd: string) => {
+    if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+    if (cmd.includes('gh issue view')) {
+      return JSON.stringify({ body });
+    }
+    return '';
+  };
+}
+
+describe('spec_validate_structure handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('spec_validate_structure');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('all_sections_present — returns valid=true, missing empty', async () => {
+    mockBody(
+      '## Changes\nstuff\n## Tests\nmore\n## Acceptance Criteria\n- [ ] ok\n## Dependencies\n#1\n',
+    );
+    const result = await handler.execute({ issue_ref: '#42' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.valid).toBe(true);
+    expect(parsed.has_changes).toBe(true);
+    expect(parsed.has_tests).toBe(true);
+    expect(parsed.has_acceptance_criteria).toBe(true);
+    expect(parsed.has_dependencies).toBe(true);
+    expect(parsed.missing_sections).toEqual([]);
+  });
+
+  test('missing_changes — reports changes in missing_sections', async () => {
+    mockBody('## Tests\nt\n## Acceptance Criteria\n- [ ] x\n');
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.valid).toBe(false);
+    expect(parsed.has_changes).toBe(false);
+    expect(parsed.missing_sections).toContain('changes');
+  });
+
+  test('missing_acceptance_criteria — reports AC in missing_sections', async () => {
+    mockBody('## Changes\nc\n## Tests\nt\n');
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.valid).toBe(false);
+    expect(parsed.has_acceptance_criteria).toBe(false);
+    expect(parsed.missing_sections).toContain('acceptance_criteria');
+  });
+
+  test('dependencies_optional — missing dependencies is OK', async () => {
+    mockBody('## Changes\nc\n## Tests\nt\n## Acceptance Criteria\n- [ ] x\n');
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.valid).toBe(true);
+    expect(parsed.has_dependencies).toBe(false);
+    expect(parsed.missing_sections).not.toContain('dependencies');
+  });
+
+  test('empty_section_counts_as_missing', async () => {
+    mockBody('## Changes\n\n## Tests\nt\n## Acceptance Criteria\n- [ ] x\n');
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.has_changes).toBe(false);
+    expect(parsed.missing_sections).toContain('changes');
+  });
+
+  test('schema_validation — rejects missing issue_ref', async () => {
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('malformed_issue_ref_returns_error', async () => {
+    const result = await handler.execute({ issue_ref: 'garbage' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `spec_validate_structure` — mechanical check for required sections in an issue spec. Wave 2.

## Changes

- `handlers/spec_validate_structure.ts` — HandlerDef, schema: `issue_ref`. Shells out to gh/glab, parses body via `lib/spec_parser`, reports presence flags and missing_sections.
- `tests/spec_validate_structure.test.ts` — all present, missing changes, missing AC, optional dependencies, empty section counts as missing, schema validation, malformed ref.

Required: changes, tests, acceptance_criteria. Optional: dependencies.

## Linked Issues

Closes #27

## Test Plan

- [x] `./scripts/ci/validate.sh` green (293 tests + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)