### PR TITLE
feat(wave-mcp): implement spec_acceptance_criteria handler

### DIFF
--- a/handlers/spec_acceptance_criteria.ts
+++ b/handlers/spec_acceptance_criteria.ts
@@ -1,0 +1,119 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+import { parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
+
+const inputSchema = z.object({
+  issue_ref: z.string().min(1, 'issue_ref must be a non-empty string'),
+});
+
+interface ChecklistItem {
+  text: string;
+  checked: boolean;
+  position: number;
+}
+
+function detectPlatform(): 'github' | 'gitlab' {
+  try {
+    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    return url.includes('gitlab') ? 'gitlab' : 'github';
+  } catch {
+    return 'github';
+  }
+}
+
+function fetchBody(ref: IssueRef): string {
+  const platform = detectPlatform();
+  if (platform === 'github') {
+    const repoArg = ref.owner && ref.repo ? `--repo ${ref.owner}/${ref.repo}` : '';
+    const cmd = `gh issue view ${ref.number} ${repoArg} --json body`.trim();
+    const raw = execSync(cmd, { encoding: 'utf8' });
+    return (JSON.parse(raw) as { body: string }).body ?? '';
+  }
+  const cmd =
+    ref.owner && ref.repo
+      ? `glab issue view ${ref.number} --repo ${ref.owner}/${ref.repo} --output json`
+      : `glab issue view ${ref.number} --output json`;
+  const raw = execSync(cmd, { encoding: 'utf8' });
+  return (JSON.parse(raw) as { description?: string }).description ?? '';
+}
+
+/**
+ * Parse markdown checklist items: `- [ ] text` or `- [x] text`.
+ * Position is the order of appearance starting from 1.
+ */
+function parseChecklist(section: string): ChecklistItem[] {
+  const items: ChecklistItem[] = [];
+  if (!section) return items;
+  const re = /^\s*[-*]\s*\[([ xX])\]\s*(.*?)$/gm;
+  let m: RegExpExecArray | null;
+  let position = 1;
+  while ((m = re.exec(section)) !== null) {
+    items.push({
+      text: m[2].trim(),
+      checked: m[1].toLowerCase() === 'x',
+      position: position++,
+    });
+  }
+  return items;
+}
+
+const specAcceptanceCriteriaHandler: HandlerDef = {
+  name: 'spec_acceptance_criteria',
+  description: 'Extract the Acceptance Criteria checklist as structured items',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    const ref = parseIssueRef(args.issue_ref);
+    if (!ref) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: false,
+              error: `could not parse issue_ref: '${args.issue_ref}'`,
+            }),
+          },
+        ],
+      };
+    }
+
+    try {
+      const body = fetchBody(ref);
+      const { sections } = parseSections(body);
+      const acSection = sections.acceptance_criteria ?? '';
+      const items = parseChecklist(acSection);
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              issue_ref: args.issue_ref,
+              criteria: items,
+              count: items.length,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default specAcceptanceCriteriaHandler;

--- a/tests/spec_acceptance_criteria.test.ts
+++ b/tests/spec_acceptance_criteria.test.ts
@@ -1,0 +1,106 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string, _opts?: unknown) => execMockFn(cmd));
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/spec_acceptance_criteria.ts');
+
+function resetMocks() {
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+function mockBody(body: string) {
+  execMockFn = (cmd: string) => {
+    if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+    if (cmd.includes('gh issue view')) return JSON.stringify({ body });
+    return '';
+  };
+}
+
+describe('spec_acceptance_criteria handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('spec_acceptance_criteria');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('parses_unchecked_items', async () => {
+    mockBody(`## Acceptance Criteria
+
+- [ ] criterion one
+- [ ] criterion two
+- [ ] criterion three
+`);
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.count).toBe(3);
+    expect(parsed.criteria.every((c: { checked: boolean }) => !c.checked)).toBe(true);
+    expect(parsed.criteria[0].position).toBe(1);
+    expect(parsed.criteria[2].position).toBe(3);
+  });
+
+  test('parses_checked_items', async () => {
+    mockBody(`## Acceptance Criteria
+
+- [x] done one
+- [x] done two
+`);
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.criteria.every((c: { checked: boolean }) => c.checked)).toBe(true);
+  });
+
+  test('mixed_checked_and_unchecked', async () => {
+    mockBody(`## Acceptance Criteria
+
+- [x] done
+- [ ] todo
+- [X] also done
+`);
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.count).toBe(3);
+    expect(parsed.criteria.map((c: { checked: boolean }) => c.checked)).toEqual([
+      true,
+      false,
+      true,
+    ]);
+  });
+
+  test('nested_items_flattened — nested bullets get sequential positions', async () => {
+    mockBody(`## Acceptance Criteria
+
+- [ ] outer
+  - [ ] nested
+- [ ] another outer
+`);
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.count).toBe(3);
+    expect(parsed.criteria.map((c: { position: number }) => c.position)).toEqual([1, 2, 3]);
+  });
+
+  test('no_ac_section_returns_empty_list', async () => {
+    mockBody('## Summary\nstuff\n');
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.count).toBe(0);
+    expect(parsed.criteria).toEqual([]);
+  });
+
+  test('schema_validation — rejects missing issue_ref', async () => {
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `spec_acceptance_criteria` — extracts the AC checklist as structured items. Wave 2.

## Changes

- `handlers/spec_acceptance_criteria.ts` — HandlerDef. Returns `[{text, checked, position}]`. Handles unchecked, checked (lowercase + uppercase X), mixed, nested, and missing AC sections.
- `tests/spec_acceptance_criteria.test.ts` — full coverage including nested and missing-AC cases.

## Linked Issues

Closes #28

## Test Plan

- [x] `./scripts/ci/validate.sh` green (305 tests + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)