### PR TITLE
feat(wave-mcp): implement spec_dependencies handler

### DIFF
--- a/handlers/spec_dependencies.ts
+++ b/handlers/spec_dependencies.ts
@@ -1,0 +1,164 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+import { parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
+
+const inputSchema = z.object({
+  issue_ref: z.string().min(1, 'issue_ref must be a non-empty string'),
+});
+
+interface Dependency {
+  ref: string;
+  kind: 'blocks' | 'none';
+}
+
+function detectPlatform(): 'github' | 'gitlab' {
+  try {
+    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    return url.includes('gitlab') ? 'gitlab' : 'github';
+  } catch {
+    return 'github';
+  }
+}
+
+function currentRepoSlug(): string | null {
+  try {
+    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    const m = /[/:]([^/]+)\/([^/.]+?)(\.git)?$/.exec(url);
+    if (m) return `${m[1]}/${m[2]}`;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function fetchBody(ref: IssueRef): string {
+  const platform = detectPlatform();
+  if (platform === 'github') {
+    const repoArg = ref.owner && ref.repo ? `--repo ${ref.owner}/${ref.repo}` : '';
+    const cmd = `gh issue view ${ref.number} ${repoArg} --json body`.trim();
+    const raw = execSync(cmd, { encoding: 'utf8' });
+    return (JSON.parse(raw) as { body: string }).body ?? '';
+  }
+  const cmd =
+    ref.owner && ref.repo
+      ? `glab issue view ${ref.number} --repo ${ref.owner}/${ref.repo} --output json`
+      : `glab issue view ${ref.number} --output json`;
+  const raw = execSync(cmd, { encoding: 'utf8' });
+  return (JSON.parse(raw) as { description?: string }).description ?? '';
+}
+
+/**
+ * Parse a Dependencies section and extract issue references in any
+ * of these formats:
+ *   #123
+ *   org/repo#123
+ *   https://github.com/org/repo/issues/123
+ *   https://gitlab.com/org/repo/-/issues/123
+ *
+ * Normalized to `org/repo#N`. If a `#N` ref is seen, use the current
+ * repo slug. "None" or empty content returns an empty list.
+ */
+function parseDependenciesSection(section: string, currentSlug: string | null): Dependency[] {
+  if (!section) return [];
+  const trimmed = section.trim();
+  if (/^none\b/i.test(trimmed) || trimmed.length === 0) return [];
+
+  const found = new Set<string>();
+  const deps: Dependency[] = [];
+
+  const urlRe =
+    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = urlRe.exec(section)) !== null) {
+    const ref = `${m[1]}/${m[2]}#${m[3]}`;
+    if (!found.has(ref)) {
+      found.add(ref);
+      deps.push({ ref, kind: 'blocks' });
+    }
+  }
+
+  const crossRe = /\b([^\s/#]+)\/([^\s/#]+)#(\d+)\b/g;
+  while ((m = crossRe.exec(section)) !== null) {
+    // Skip if this text is inside a URL we already consumed.
+    const candidate = `${m[1]}/${m[2]}#${m[3]}`;
+    if (m[1].startsWith('http') || m[1].includes('.')) continue;
+    if (!found.has(candidate)) {
+      found.add(candidate);
+      deps.push({ ref: candidate, kind: 'blocks' });
+    }
+  }
+
+  // Short #N — only match at word boundary not preceded by a /.
+  const shortRe = /(?<![/\w])#(\d+)\b/g;
+  while ((m = shortRe.exec(section)) !== null) {
+    const num = m[1];
+    const ref = currentSlug ? `${currentSlug}#${num}` : `#${num}`;
+    if (!found.has(ref)) {
+      found.add(ref);
+      deps.push({ ref, kind: 'blocks' });
+    }
+  }
+
+  return deps;
+}
+
+const specDependenciesHandler: HandlerDef = {
+  name: 'spec_dependencies',
+  description: 'Extract the list of dependency issue references from an issue spec',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    const ref = parseIssueRef(args.issue_ref);
+    if (!ref) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: false,
+              error: `could not parse issue_ref: '${args.issue_ref}'`,
+            }),
+          },
+        ],
+      };
+    }
+
+    try {
+      const body = fetchBody(ref);
+      const { sections } = parseSections(body);
+      const depsSection = sections.dependencies ?? '';
+      const deps = parseDependenciesSection(depsSection, currentRepoSlug());
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              issue_ref: args.issue_ref,
+              dependencies: deps,
+              count: deps.length,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default specDependenciesHandler;

--- a/tests/spec_dependencies.test.ts
+++ b/tests/spec_dependencies.test.ts
@@ -1,0 +1,120 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string, _opts?: unknown) => execMockFn(cmd));
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/spec_dependencies.ts');
+
+function resetMocks() {
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+function mockBody(body: string, originUrl = 'https://github.com/myorg/myrepo.git') {
+  execMockFn = (cmd: string) => {
+    if (cmd.startsWith('git remote')) return originUrl + '\n';
+    if (cmd.includes('gh issue view')) return JSON.stringify({ body });
+    return '';
+  };
+}
+
+describe('spec_dependencies handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('spec_dependencies');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('parses_same_repo_refs — #N normalized to current repo slug', async () => {
+    mockBody(`## Dependencies
+
+- #284
+- #285
+`);
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.dependencies.map((d: { ref: string }) => d.ref)).toEqual([
+      'myorg/myrepo#284',
+      'myorg/myrepo#285',
+    ]);
+  });
+
+  test('parses_cross_repo_refs — org/repo#N preserved', async () => {
+    mockBody(`## Dependencies
+
+- Wave-Engineering/mcp-server-sdlc#26
+- acme/widgets#42
+`);
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.dependencies.map((d: { ref: string }) => d.ref)).toEqual([
+      'Wave-Engineering/mcp-server-sdlc#26',
+      'acme/widgets#42',
+    ]);
+  });
+
+  test('parses_full_urls — github URL normalized to org/repo#N', async () => {
+    mockBody(`## Dependencies
+
+- https://github.com/Wave-Engineering/claudecode-workflow/issues/289
+`);
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.dependencies[0].ref).toBe('Wave-Engineering/claudecode-workflow#289');
+  });
+
+  test('parses_gitlab_urls', async () => {
+    mockBody(`## Dependencies
+
+- https://gitlab.com/mygroup/myproject/-/issues/12
+`);
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.dependencies[0].ref).toBe('mygroup/myproject#12');
+  });
+
+  test('none_keyword — returns empty list', async () => {
+    mockBody(`## Dependencies
+
+None
+`);
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.dependencies).toEqual([]);
+    expect(parsed.count).toBe(0);
+  });
+
+  test('no_dependencies_section — returns empty list', async () => {
+    mockBody('## Summary\nstuff\n');
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.count).toBe(0);
+  });
+
+  test('deduplicates_refs', async () => {
+    mockBody(`## Dependencies
+
+- #5
+- #5
+- myorg/myrepo#5
+`);
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.count).toBe(1);
+  });
+
+  test('schema_validation — rejects missing issue_ref', async () => {
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `spec_dependencies` — extracts dependency refs from an issue spec's Dependencies section, normalized to `org/repo#N`. Wave 2.

## Changes

- `handlers/spec_dependencies.ts` — HandlerDef, schema: `issue_ref`. Parses `#N`, `org/repo#N`, and GitHub/GitLab URLs. "None" keyword returns empty list. Deduplicates.
- `tests/spec_dependencies.test.ts` — same-repo refs, cross-repo, github URLs, gitlab URLs, None keyword, missing section, dedup.

## Linked Issues

Closes #29

## Test Plan

- [x] `./scripts/ci/validate.sh` green (319 tests + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)