### PR TITLE
feat(wave-mcp): implement epic_sub_issues handler

### DIFF
--- a/handlers/epic_sub_issues.ts
+++ b/handlers/epic_sub_issues.ts
@@ -1,0 +1,229 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+import { parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
+
+const inputSchema = z.object({
+  epic_ref: z.string().min(1, 'epic_ref must be a non-empty string'),
+});
+
+interface SubIssue {
+  ref: string;
+  title?: string;
+  order?: number;
+}
+
+function detectPlatform(): 'github' | 'gitlab' {
+  try {
+    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    return url.includes('gitlab') ? 'gitlab' : 'github';
+  } catch {
+    return 'github';
+  }
+}
+
+function currentRepoSlug(): string | null {
+  try {
+    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    const m = /[/:]([^/]+)\/([^/.]+?)(\.git)?$/.exec(url);
+    if (m) return `${m[1]}/${m[2]}`;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function fetchBody(ref: IssueRef): string {
+  const platform = detectPlatform();
+  if (platform === 'github') {
+    const repoArg = ref.owner && ref.repo ? `--repo ${ref.owner}/${ref.repo}` : '';
+    const cmd = `gh issue view ${ref.number} ${repoArg} --json body`.trim();
+    const raw = execSync(cmd, { encoding: 'utf8' });
+    return (JSON.parse(raw) as { body: string }).body ?? '';
+  }
+  const cmd =
+    ref.owner && ref.repo
+      ? `glab issue view ${ref.number} --repo ${ref.owner}/${ref.repo} --output json`
+      : `glab issue view ${ref.number} --output json`;
+  const raw = execSync(cmd, { encoding: 'utf8' });
+  return (JSON.parse(raw) as { description?: string }).description ?? '';
+}
+
+function normalizeRef(ref: string, currentSlug: string | null): string {
+  // URL
+  const urlM =
+    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/.exec(
+      ref,
+    );
+  if (urlM) return `${urlM[1]}/${urlM[2]}#${urlM[3]}`;
+
+  const crossM = /^([^/\s#]+)\/([^/\s#]+)#(\d+)$/.exec(ref);
+  if (crossM) return ref;
+
+  const shortM = /^#?(\d+)$/.exec(ref);
+  if (shortM) {
+    return currentSlug ? `${currentSlug}#${shortM[1]}` : `#${shortM[1]}`;
+  }
+  return ref;
+}
+
+/**
+ * Find which section of the parsed body contains the sub-issues.
+ * Accepts "Sub-Issues", "Sub Issues", "Sub-issues", "Children", "Tasks".
+ */
+function findSubIssueSection(sections: Record<string, string>): string | null {
+  const keys = ['sub_issues', 'subissues', 'children', 'tasks', 'task_list'];
+  for (const k of keys) {
+    if (sections[k]) return sections[k];
+  }
+  return null;
+}
+
+function parseTableRows(section: string, currentSlug: string | null): SubIssue[] {
+  const lines = section.split('\n').map(l => l.trim());
+  const subs: SubIssue[] = [];
+  let headerIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith('|') && lines[i].includes('|', 1)) {
+      headerIdx = i;
+      break;
+    }
+  }
+  if (headerIdx === -1) return [];
+  const headerCells = lines[headerIdx]
+    .split('|')
+    .slice(1, -1)
+    .map(c => c.trim().toLowerCase());
+  const colIdx = (name: string) => headerCells.findIndex(c => c.includes(name));
+  const orderCol = colIdx('order');
+  const issueCol = colIdx('issue');
+  const titleCol = colIdx('title');
+
+  let startRow = headerIdx + 1;
+  if (startRow < lines.length && /^\|[\s\-:|]+\|$/.test(lines[startRow])) startRow += 1;
+
+  for (let i = startRow; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.startsWith('|')) break;
+    const cells = line.split('|').slice(1, -1).map(c => c.trim());
+    const getCell = (idx: number) => (idx >= 0 && idx < cells.length ? cells[idx] : '');
+    const issueRaw = getCell(issueCol);
+    const refM = /#?(\d+)|([^/\s#]+)\/([^/\s#]+)#(\d+)/.exec(issueRaw);
+    if (!refM) continue;
+    const ref = normalizeRef(issueRaw, currentSlug);
+    const order = orderCol >= 0 ? parseInt(getCell(orderCol), 10) : undefined;
+    const title = titleCol >= 0 ? getCell(titleCol) : undefined;
+    subs.push({
+      ref,
+      title: title && title.length > 0 ? title : undefined,
+      order: Number.isFinite(order) ? (order as number) : undefined,
+    });
+  }
+  return subs;
+}
+
+function parseChecklistOrBullets(section: string, currentSlug: string | null): SubIssue[] {
+  const subs: SubIssue[] = [];
+  const checklistRe = /^\s*[-*]\s*(?:\[[ xX]\]\s*)?([^\n]*)$/gm;
+  let m: RegExpExecArray | null;
+  let position = 1;
+  while ((m = checklistRe.exec(section)) !== null) {
+    const text = m[1].trim();
+    if (!text) continue;
+    const refM =
+      /(?:^|\s)([^/\s#]+\/[^/\s#]+#\d+|https?:\/\/\S+\/issues\/\d+|#\d+)/.exec(text);
+    if (!refM) continue;
+    const raw = refM[1];
+    const ref = normalizeRef(raw, currentSlug);
+    // Title = text with the ref token stripped out.
+    const title = text.replace(refM[0], '').trim().replace(/^[-:*\s]+/, '').trim();
+    subs.push({
+      ref,
+      title: title.length > 0 ? title : undefined,
+      order: position,
+    });
+    position += 1;
+  }
+  return subs;
+}
+
+const epicSubIssuesHandler: HandlerDef = {
+  name: 'epic_sub_issues',
+  description: "Extract sub-issue references from an epic's body",
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    const ref = parseIssueRef(args.epic_ref);
+    if (!ref) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: false,
+              error: `could not parse epic_ref: '${args.epic_ref}'`,
+            }),
+          },
+        ],
+      };
+    }
+
+    try {
+      const body = fetchBody(ref);
+      const { sections } = parseSections(body);
+      const section = findSubIssueSection(sections);
+      if (!section) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                ok: true,
+                epic_ref: args.epic_ref,
+                sub_issues: [],
+                count: 0,
+              }),
+            },
+          ],
+        };
+      }
+
+      const slug = currentRepoSlug();
+      // Try table format first; if it yields nothing, fall back to checklist/bullets.
+      let subs = parseTableRows(section, slug);
+      if (subs.length === 0) {
+        subs = parseChecklistOrBullets(section, slug);
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              epic_ref: args.epic_ref,
+              sub_issues: subs,
+              count: subs.length,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default epicSubIssuesHandler;

--- a/tests/epic_sub_issues.test.ts
+++ b/tests/epic_sub_issues.test.ts
@@ -1,0 +1,111 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string, _opts?: unknown) => execMockFn(cmd));
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/epic_sub_issues.ts');
+
+function resetMocks() {
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+function mockBody(body: string) {
+  execMockFn = (cmd: string) => {
+    if (cmd.startsWith('git remote')) return 'https://github.com/myorg/myrepo.git\n';
+    if (cmd.includes('gh issue view')) return JSON.stringify({ body });
+    return '';
+  };
+}
+
+describe('epic_sub_issues handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('epic_sub_issues');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('parses_table_format — order/issue/title columns', async () => {
+    mockBody(`## Sub-Issues
+
+| Order | Issue | Title | Deps |
+|-------|-------|-------|------|
+| 1 | #5 | wave_init | none |
+| 2 | #6 | wave_preflight | none |
+| 3 | Wave-Engineering/other#42 | cross repo | #5 |
+`);
+    const result = await handler.execute({ epic_ref: '#100' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.count).toBe(3);
+    expect(parsed.sub_issues[0]).toEqual({
+      ref: 'myorg/myrepo#5',
+      title: 'wave_init',
+      order: 1,
+    });
+    expect(parsed.sub_issues[2].ref).toBe('Wave-Engineering/other#42');
+  });
+
+  test('parses_checklist_format — - [ ] #N Title', async () => {
+    mockBody(`## Sub-Issues
+
+- [ ] #5 wave_init
+- [x] #6 wave_preflight
+- [ ] Wave-Engineering/other#42 cross-repo task
+`);
+    const result = await handler.execute({ epic_ref: '#100' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.count).toBe(3);
+    expect(parsed.sub_issues[0].ref).toBe('myorg/myrepo#5');
+    expect(parsed.sub_issues[0].title).toBe('wave_init');
+  });
+
+  test('parses_bullet_format — - #N Title', async () => {
+    mockBody(`## Sub-Issues
+
+- #5 wave_init
+- #6 wave_preflight
+`);
+    const result = await handler.execute({ epic_ref: '#100' });
+    const parsed = parseResult(result);
+    expect(parsed.count).toBe(2);
+    expect(parsed.sub_issues[1].ref).toBe('myorg/myrepo#6');
+    expect(parsed.sub_issues[1].order).toBe(2);
+  });
+
+  test('preserves_order_from_table', async () => {
+    mockBody(`## Sub-Issues
+
+| Order | Issue |
+|-------|-------|
+| 3 | #5 |
+| 1 | #6 |
+| 2 | #7 |
+`);
+    const result = await handler.execute({ epic_ref: '#100' });
+    const parsed = parseResult(result);
+    expect(parsed.sub_issues.map((s: { order?: number }) => s.order)).toEqual([3, 1, 2]);
+  });
+
+  test('no_sub_issues_section_returns_empty', async () => {
+    mockBody('## Summary\nNo sub-issues here.\n');
+    const result = await handler.execute({ epic_ref: '#100' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.count).toBe(0);
+  });
+
+  test('schema_validation — rejects missing epic_ref', async () => {
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `epic_sub_issues` — extracts sub-issue refs from an epic's body. Final story of Wave 2.

## Changes

- `handlers/epic_sub_issues.ts` — HandlerDef, schema: `epic_ref`. Tries table format first, falls back to checklist/bullets. Normalizes refs to `org/repo#N`.
- `tests/epic_sub_issues.test.ts` — table, checklist, bullets, order preservation, empty section, schema validation.

## Linked Issues

Closes #30

## Test Plan

- [x] `./scripts/ci/validate.sh` green (331 tests + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)