### PR TITLE
feat(wave-mcp): implement drift_files_changed handler

### DIFF
--- a/handlers/drift_files_changed.ts
+++ b/handlers/drift_files_changed.ts
@@ -1,0 +1,66 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  from_ref: z.string().min(1, 'from_ref must be a non-empty string'),
+  to_ref: z.string().optional().default('HEAD'),
+});
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function quoteArg(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+const driftFilesChangedHandler: HandlerDef = {
+  name: 'drift_files_changed',
+  description: 'List files changed between two git refs',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const cmd = `git diff --name-only ${quoteArg(args.from_ref)}..${quoteArg(args.to_ref)}`;
+      const output = execSync(cmd, {
+        cwd: projectDir(),
+        encoding: 'utf8',
+      });
+      const files = output
+        .split('\n')
+        .map(s => s.trim())
+        .filter(s => s.length > 0);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              from_ref: args.from_ref,
+              to_ref: args.to_ref,
+              files,
+              count: files.length,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default driftFilesChangedHandler;

--- a/tests/drift_files_changed.test.ts
+++ b/tests/drift_files_changed.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let lastExecCall = '';
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  lastExecCall = cmd;
+  return execMockFn(cmd);
+});
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/drift_files_changed.ts');
+
+function resetMocks() {
+  lastExecCall = '';
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('drift_files_changed handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('drift_files_changed');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('basic_diff — returns parsed file list', async () => {
+    execMockFn = () => 'src/foo.ts\nsrc/bar.ts\nREADME.md\n';
+    const result = await handler.execute({ from_ref: 'abc123', to_ref: 'def456' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.files).toEqual(['src/foo.ts', 'src/bar.ts', 'README.md']);
+    expect(parsed.count).toBe(3);
+    expect(lastExecCall).toContain('git diff --name-only');
+    expect(lastExecCall).toContain("'abc123'");
+    expect(lastExecCall).toContain("'def456'");
+  });
+
+  test('default_to_head — to_ref defaults to HEAD when omitted', async () => {
+    execMockFn = () => 'a.ts\n';
+    await handler.execute({ from_ref: 'main' });
+    expect(lastExecCall).toContain("'main'..'HEAD'");
+  });
+
+  test('empty_diff — no changes returns empty list', async () => {
+    execMockFn = () => '';
+    const result = await handler.execute({ from_ref: 'main', to_ref: 'HEAD' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.files).toEqual([]);
+    expect(parsed.count).toBe(0);
+  });
+
+  test('invalid_ref_returns_error — structured error, does not throw', async () => {
+    execMockFn = () => {
+      throw new Error("fatal: bad revision 'nonexistent'");
+    };
+    const result = await handler.execute({ from_ref: 'nonexistent' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('bad revision');
+  });
+
+  test('schema_validation — rejects missing from_ref', async () => {
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema_validation — rejects empty from_ref', async () => {
+    const result = await handler.execute({ from_ref: '' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `drift_files_changed` — lists files changed between two git refs. Primitive for drift detection. Wave 3.

## Changes

- `handlers/drift_files_changed.ts` — HandlerDef, schema: `from_ref` (required), `to_ref` (optional, default HEAD). Shells out `git diff --name-only`.
- `tests/drift_files_changed.test.ts` — basic diff, default to_ref=HEAD, empty diff, invalid ref, schema validation.

## Linked Issues

Closes #34

## Test Plan

- [x] `./scripts/ci/validate.sh` green (343 tests + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)