### PR TITLE
feat(wave-mcp): implement drift_check_path_exists handler

### DIFF
--- a/handlers/drift_check_path_exists.ts
+++ b/handlers/drift_check_path_exists.ts
@@ -1,0 +1,84 @@
+import { isAbsolute, join } from 'path';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  path: z.string().min(1, 'path must be a non-empty string'),
+  kind: z.enum(['file', 'directory', 'any']).optional().default('any'),
+});
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function resolvePath(path: string): string {
+  return isAbsolute(path) ? path : join(projectDir(), path);
+}
+
+async function probe(absPath: string): Promise<{ exists: boolean; kind: 'file' | 'directory' | null }> {
+  // Use Bun.spawnSync('stat', ...) to distinguish file vs directory
+  // without touching node:fs or child_process (both have mock collisions
+  // with sibling tests).
+  const proc = Bun.spawnSync({
+    cmd: ['stat', '-c', '%F', absPath],
+    stderr: 'pipe',
+  });
+  if (proc.exitCode !== 0) {
+    return { exists: false, kind: null };
+  }
+  const out = new TextDecoder().decode(proc.stdout).trim();
+  if (out === 'directory') return { exists: true, kind: 'directory' };
+  // 'regular file', 'regular empty file', 'symbolic link' (resolved), etc.
+  return { exists: true, kind: 'file' };
+}
+
+const driftCheckPathExistsHandler: HandlerDef = {
+  name: 'drift_check_path_exists',
+  description: 'Check whether a file path exists in the current working tree',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const abs = resolvePath(args.path);
+      const result = await probe(abs);
+
+      let exists = result.exists;
+      if (exists && args.kind !== 'any' && result.kind !== args.kind) {
+        // Path exists but of the wrong kind — return exists=false to match spec.
+        exists = false;
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              path: args.path,
+              resolved: abs,
+              exists,
+              actual_kind: result.exists ? result.kind : null,
+              requested_kind: args.kind,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default driftCheckPathExistsHandler;

--- a/tests/drift_check_path_exists.test.ts
+++ b/tests/drift_check_path_exists.test.ts
@@ -1,0 +1,109 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+
+// Uses Bun.spawnSync('stat', ...) in the handler, so no module mocks.
+// Tests operate on real files/directories in /tmp.
+
+const { default: handler } = await import('../handlers/drift_check_path_exists.ts');
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+let fixtureDir = '';
+const ORIGINAL_ENV = process.env.CLAUDE_PROJECT_DIR;
+
+function restoreEnv() {
+  if (ORIGINAL_ENV === undefined) {
+    delete process.env.CLAUDE_PROJECT_DIR;
+  } else {
+    process.env.CLAUDE_PROJECT_DIR = ORIGINAL_ENV;
+  }
+}
+
+async function setupProject(files: Record<string, string>) {
+  fixtureDir = `/tmp/drift-path-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+  for (const [name, content] of Object.entries(files)) {
+    await Bun.write(`${fixtureDir}/${name}`, content);
+  }
+  process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+}
+
+describe('drift_check_path_exists handler', () => {
+  beforeEach(() => {
+    fixtureDir = '';
+  });
+  afterEach(() => {
+    fixtureDir = '';
+    restoreEnv();
+  });
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('drift_check_path_exists');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('file_exists — returns exists=true, actual_kind=file', async () => {
+    await setupProject({ 'src/foo.ts': 'export const x = 1;' });
+    const result = await handler.execute({ path: 'src/foo.ts' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.exists).toBe(true);
+    expect(parsed.actual_kind).toBe('file');
+  });
+
+  test('file_missing — exists=false', async () => {
+    await setupProject({ 'a.txt': 'hi' });
+    const result = await handler.execute({ path: 'nonexistent.txt' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.exists).toBe(false);
+    expect(parsed.actual_kind).toBe(null);
+  });
+
+  test('directory_exists_as_directory', async () => {
+    await setupProject({ 'handlers/inner.ts': 'x' });
+    const result = await handler.execute({ path: 'handlers', kind: 'directory' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.exists).toBe(true);
+    expect(parsed.actual_kind).toBe('directory');
+  });
+
+  test('kind_mismatch — file exists but kind=directory → exists=false', async () => {
+    await setupProject({ 'file.txt': 'hi' });
+    const result = await handler.execute({ path: 'file.txt', kind: 'directory' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.exists).toBe(false);
+    expect(parsed.actual_kind).toBe('file');
+  });
+
+  test('relative_path_anchoring — resolved against CLAUDE_PROJECT_DIR', async () => {
+    await setupProject({ 'nested/deep/file.ts': 'x' });
+    const result = await handler.execute({ path: 'nested/deep/file.ts' });
+    const parsed = parseResult(result);
+    expect(parsed.exists).toBe(true);
+    expect(parsed.resolved).toContain(fixtureDir);
+  });
+
+  test('absolute_path_preserved', async () => {
+    await setupProject({ 'a.txt': 'x' });
+    const absPath = `${fixtureDir}/a.txt`;
+    const result = await handler.execute({ path: absPath });
+    const parsed = parseResult(result);
+    expect(parsed.exists).toBe(true);
+    expect(parsed.resolved).toBe(absPath);
+  });
+
+  test('schema_validation — rejects missing path', async () => {
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema_validation — rejects invalid kind', async () => {
+    const result = await handler.execute({ path: 'x', kind: 'bogus' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `drift_check_path_exists` — checks whether a path exists in the working tree, with optional kind filtering. Wave 3.

## Changes

- `handlers/drift_check_path_exists.ts` — HandlerDef, schema: `path` (required), `kind` (file/directory/any, default any). Anchors at CLAUDE_PROJECT_DIR.
- `tests/drift_check_path_exists.test.ts` — file exists, file missing, directory, kind mismatch, relative anchoring, absolute preserved, schema validation.

## Linked Issues

Closes #35

## Test Plan

- [x] `./scripts/ci/validate.sh` green (357 tests + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)