### PR TITLE
feat(wave-mcp): implement drift_check_symbol_exists handler

### DIFF
--- a/handlers/drift_check_symbol_exists.ts
+++ b/handlers/drift_check_symbol_exists.ts
@@ -1,0 +1,166 @@
+import { isAbsolute, join, extname } from 'path';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const LANGS = ['python', 'typescript', 'javascript', 'go', 'rust', 'bash', 'auto'] as const;
+type Lang = (typeof LANGS)[number];
+
+const inputSchema = z.object({
+  file_path: z.string().min(1, 'file_path must be a non-empty string'),
+  symbol_name: z.string().min(1, 'symbol_name must be a non-empty string'),
+  language: z.enum(LANGS).optional().default('auto'),
+});
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function resolvePath(path: string): string {
+  return isAbsolute(path) ? path : join(projectDir(), path);
+}
+
+function detectLangFromExt(path: string): Exclude<Lang, 'auto'> | null {
+  const ext = extname(path).toLowerCase();
+  switch (ext) {
+    case '.py':
+      return 'python';
+    case '.ts':
+    case '.tsx':
+      return 'typescript';
+    case '.js':
+    case '.jsx':
+    case '.mjs':
+    case '.cjs':
+      return 'javascript';
+    case '.go':
+      return 'go';
+    case '.rs':
+      return 'rust';
+    case '.sh':
+    case '.bash':
+      return 'bash';
+    default:
+      return null;
+  }
+}
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildPattern(lang: Exclude<Lang, 'auto'>, name: string): RegExp {
+  const n = escapeRe(name);
+  switch (lang) {
+    case 'python':
+      return new RegExp(`^\\s*(def|class)\\s+${n}\\b`);
+    case 'typescript':
+    case 'javascript':
+      return new RegExp(
+        `^\\s*(?:export\\s+)?(?:default\\s+)?(?:async\\s+)?(?:function|class|const|let|var|interface|type)\\s+${n}\\b`,
+      );
+    case 'go':
+      return new RegExp(
+        `^\\s*(?:func(?:\\s*\\([^)]*\\))?|type|var|const)\\s+${n}\\b`,
+      );
+    case 'rust':
+      return new RegExp(
+        `^\\s*(?:pub\\s+)?(?:fn|struct|enum|trait|type|const|static)\\s+${n}\\b`,
+      );
+    case 'bash':
+      return new RegExp(`^\\s*(?:function\\s+${n}\\s*\\(?|${n}\\s*\\(\\))`);
+  }
+}
+
+const driftCheckSymbolExistsHandler: HandlerDef = {
+  name: 'drift_check_symbol_exists',
+  description: 'Grep for a symbol definition in a file',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const abs = resolvePath(args.file_path);
+      const file = Bun.file(abs);
+      if (!(await file.exists())) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                ok: false,
+                error: `file not found: ${abs}`,
+              }),
+            },
+          ],
+        };
+      }
+
+      let lang: Exclude<Lang, 'auto'>;
+      if (args.language === 'auto') {
+        const detected = detectLangFromExt(abs);
+        if (!detected) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({
+                  ok: false,
+                  error: `could not detect language from file extension: ${abs}`,
+                }),
+              },
+            ],
+          };
+        }
+        lang = detected;
+      } else {
+        lang = args.language;
+      }
+
+      const pattern = buildPattern(lang, args.symbol_name);
+      const text = await file.text();
+      const lines = text.split('\n');
+      let foundLine: number | null = null;
+      let matchedLine: string | null = null;
+
+      for (let i = 0; i < lines.length; i++) {
+        if (pattern.test(lines[i])) {
+          foundLine = i + 1;
+          matchedLine = lines[i].trim();
+          break;
+        }
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              file_path: args.file_path,
+              symbol_name: args.symbol_name,
+              language: lang,
+              exists: foundLine !== null,
+              line_number: foundLine,
+              matched_pattern: matchedLine,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default driftCheckSymbolExistsHandler;

--- a/tests/drift_check_symbol_exists.test.ts
+++ b/tests/drift_check_symbol_exists.test.ts
@@ -1,0 +1,159 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+
+const { default: handler } = await import('../handlers/drift_check_symbol_exists.ts');
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+let fixtureDir = '';
+const ORIGINAL_ENV = process.env.CLAUDE_PROJECT_DIR;
+
+function restoreEnv() {
+  if (ORIGINAL_ENV === undefined) {
+    delete process.env.CLAUDE_PROJECT_DIR;
+  } else {
+    process.env.CLAUDE_PROJECT_DIR = ORIGINAL_ENV;
+  }
+}
+
+async function writeFile(name: string, content: string): Promise<string> {
+  fixtureDir = `/tmp/drift-symbol-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+  const path = `${fixtureDir}/${name}`;
+  await Bun.write(path, content);
+  process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+  return name;
+}
+
+describe('drift_check_symbol_exists handler', () => {
+  beforeEach(() => {
+    fixtureDir = '';
+  });
+  afterEach(() => {
+    fixtureDir = '';
+    restoreEnv();
+  });
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('drift_check_symbol_exists');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('python_function_found', async () => {
+    const file = await writeFile(
+      'lib.py',
+      'def hello():\n    return 1\n\ndef world():\n    return 2\n',
+    );
+    const result = await handler.execute({
+      file_path: file,
+      symbol_name: 'world',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.exists).toBe(true);
+    expect(parsed.line_number).toBe(4);
+    expect(parsed.language).toBe('python');
+  });
+
+  test('python_class_found', async () => {
+    const file = await writeFile(
+      'cls.py',
+      'class Foo:\n    pass\n\nclass Bar:\n    pass\n',
+    );
+    const result = await handler.execute({
+      file_path: file,
+      symbol_name: 'Bar',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.exists).toBe(true);
+    expect(parsed.line_number).toBe(4);
+  });
+
+  test('typescript_exported_function', async () => {
+    const file = await writeFile(
+      'mod.ts',
+      'export function doThing(x: number): number {\n  return x * 2;\n}\n',
+    );
+    const result = await handler.execute({
+      file_path: file,
+      symbol_name: 'doThing',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.exists).toBe(true);
+    expect(parsed.language).toBe('typescript');
+  });
+
+  test('typescript_interface_found', async () => {
+    const file = await writeFile(
+      'types.ts',
+      'export interface Widget {\n  id: string;\n}\n',
+    );
+    const result = await handler.execute({
+      file_path: file,
+      symbol_name: 'Widget',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.exists).toBe(true);
+  });
+
+  test('bash_function', async () => {
+    const file = await writeFile(
+      'script.sh',
+      '#!/bin/bash\nhello() {\n  echo hi\n}\n\nfunction world {\n  echo bye\n}\n',
+    );
+    const r1 = await handler.execute({ file_path: file, symbol_name: 'hello' });
+    expect(parseResult(r1).exists).toBe(true);
+    const r2 = await handler.execute({ file_path: file, symbol_name: 'world' });
+    expect(parseResult(r2).exists).toBe(true);
+  });
+
+  test('symbol_not_found_returns_false', async () => {
+    const file = await writeFile('a.ts', 'export const x = 1;\n');
+    const result = await handler.execute({
+      file_path: file,
+      symbol_name: 'nonexistent',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.exists).toBe(false);
+    expect(parsed.line_number).toBe(null);
+  });
+
+  test('auto_language_detection_by_extension', async () => {
+    const file = await writeFile('svc.go', 'package main\n\nfunc main() {}\n');
+    const result = await handler.execute({
+      file_path: file,
+      symbol_name: 'main',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.language).toBe('go');
+    expect(parsed.exists).toBe(true);
+  });
+
+  test('missing_file_returns_error', async () => {
+    const result = await handler.execute({
+      file_path: '/tmp/nonexistent-xyz-987654.ts',
+      symbol_name: 'x',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('file not found');
+  });
+
+  test('schema_validation — rejects missing symbol_name', async () => {
+    const result = await handler.execute({ file_path: 'a.ts' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema_validation — rejects invalid language', async () => {
+    const result = await handler.execute({
+      file_path: 'a.ts',
+      symbol_name: 'x',
+      language: 'cobol',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `drift_check_symbol_exists` — grep-based definition check for symbols across 6 languages. Wave 3.

## Changes

- `handlers/drift_check_symbol_exists.ts` — HandlerDef, schema: `file_path`, `symbol_name`, `language` (auto/python/typescript/javascript/go/rust/bash). Auto-detects from file extension.
- `tests/drift_check_symbol_exists.test.ts` — python fn, python class, ts exported fn, ts interface, bash fn (both forms), symbol not found, auto detect, missing file, schema validation.

## Linked Issues

Closes #36

## Test Plan

- [x] `./scripts/ci/validate.sh` green (373 tests + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)