### PR TITLE
feat(wave-mcp): implement wave_compute + lib/dependency_graph

### DIFF
--- a/handlers/wave_compute.ts
+++ b/handlers/wave_compute.ts
@@ -1,0 +1,260 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+import { parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
+import { computeWaves, type DepNode } from '../lib/dependency_graph';
+
+const inputSchema = z.object({
+  epic_ref: z.string().min(1, 'epic_ref must be a non-empty string'),
+});
+
+function detectPlatform(): 'github' | 'gitlab' {
+  try {
+    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    return url.includes('gitlab') ? 'gitlab' : 'github';
+  } catch {
+    return 'github';
+  }
+}
+
+function currentRepoSlug(): string | null {
+  try {
+    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    const m = /[/:]([^/]+)\/([^/.]+?)(\.git)?$/.exec(url);
+    if (m) return `${m[1]}/${m[2]}`;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function fetchIssue(ref: IssueRef): { body: string; title: string } {
+  const platform = detectPlatform();
+  if (platform === 'github') {
+    const repoArg = ref.owner && ref.repo ? `--repo ${ref.owner}/${ref.repo}` : '';
+    const cmd = `gh issue view ${ref.number} ${repoArg} --json body,title`.trim();
+    const raw = execSync(cmd, { encoding: 'utf8' });
+    const parsed = JSON.parse(raw) as { body?: string; title: string };
+    return { body: parsed.body ?? '', title: parsed.title };
+  }
+  const cmd =
+    ref.owner && ref.repo
+      ? `glab issue view ${ref.number} --repo ${ref.owner}/${ref.repo} --output json`
+      : `glab issue view ${ref.number} --output json`;
+  const raw = execSync(cmd, { encoding: 'utf8' });
+  const parsed = JSON.parse(raw) as { description?: string; title: string };
+  return { body: parsed.description ?? '', title: parsed.title };
+}
+
+function normalizeRef(ref: string, currentSlug: string | null): string {
+  const urlM =
+    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/.exec(
+      ref,
+    );
+  if (urlM) return `${urlM[1]}/${urlM[2]}#${urlM[3]}`;
+
+  const crossM = /^([^/\s#]+)\/([^/\s#]+)#(\d+)$/.exec(ref);
+  if (crossM) return ref;
+
+  const shortM = /^#?(\d+)$/.exec(ref);
+  if (shortM) return currentSlug ? `${currentSlug}#${shortM[1]}` : `#${shortM[1]}`;
+  return ref;
+}
+
+interface SubIssue {
+  ref: string;
+  title?: string;
+}
+
+function parseTableSubIssues(section: string, currentSlug: string | null): SubIssue[] {
+  const lines = section.split('\n').map(l => l.trim());
+  const subs: SubIssue[] = [];
+  let headerIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith('|') && lines[i].includes('|', 1)) {
+      headerIdx = i;
+      break;
+    }
+  }
+  if (headerIdx === -1) return [];
+  const headerCells = lines[headerIdx]
+    .split('|')
+    .slice(1, -1)
+    .map(c => c.trim().toLowerCase());
+  const issueCol = headerCells.findIndex(c => c.includes('issue'));
+  const titleCol = headerCells.findIndex(c => c.includes('title'));
+
+  let startRow = headerIdx + 1;
+  if (startRow < lines.length && /^\|[\s\-:|]+\|$/.test(lines[startRow])) startRow += 1;
+
+  for (let i = startRow; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.startsWith('|')) break;
+    const cells = line.split('|').slice(1, -1).map(c => c.trim());
+    const getCell = (idx: number) => (idx >= 0 && idx < cells.length ? cells[idx] : '');
+    const issueRaw = getCell(issueCol);
+    if (!issueRaw) continue;
+    subs.push({
+      ref: normalizeRef(issueRaw, currentSlug),
+      title: titleCol >= 0 ? getCell(titleCol) || undefined : undefined,
+    });
+  }
+  return subs;
+}
+
+function parseBulletSubIssues(section: string, currentSlug: string | null): SubIssue[] {
+  const subs: SubIssue[] = [];
+  const re = /^\s*[-*]\s*(?:\[[ xX]\]\s*)?([^\n]*)$/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(section)) !== null) {
+    const text = m[1].trim();
+    if (!text) continue;
+    const refM =
+      /(?:^|\s)([^/\s#]+\/[^/\s#]+#\d+|https?:\/\/\S+\/issues\/\d+|#\d+)/.exec(text);
+    if (!refM) continue;
+    const ref = normalizeRef(refM[1], currentSlug);
+    const title = text.replace(refM[0], '').trim().replace(/^[-:*\s]+/, '').trim();
+    subs.push({ ref, title: title || undefined });
+  }
+  return subs;
+}
+
+function parseDependencies(section: string, currentSlug: string | null): string[] {
+  if (!section) return [];
+  if (/^none\b/i.test(section.trim())) return [];
+  const found = new Set<string>();
+
+  const urlRe =
+    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = urlRe.exec(section)) !== null) {
+    found.add(`${m[1]}/${m[2]}#${m[3]}`);
+  }
+  const crossRe = /\b([^\s/#]+)\/([^\s/#]+)#(\d+)\b/g;
+  while ((m = crossRe.exec(section)) !== null) {
+    if (m[1].startsWith('http') || m[1].includes('.')) continue;
+    found.add(`${m[1]}/${m[2]}#${m[3]}`);
+  }
+  const shortRe = /(?<![/\w])#(\d+)\b/g;
+  while ((m = shortRe.exec(section)) !== null) {
+    const normalized = currentSlug ? `${currentSlug}#${m[1]}` : `#${m[1]}`;
+    found.add(normalized);
+  }
+  return Array.from(found);
+}
+
+const waveComputeHandler: HandlerDef = {
+  name: 'wave_compute',
+  description: "Compute dependency-ordered waves for an epic's sub-issues",
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    const ref = parseIssueRef(args.epic_ref);
+    if (!ref) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: false,
+              error: `could not parse epic_ref: '${args.epic_ref}'`,
+            }),
+          },
+        ],
+      };
+    }
+
+    try {
+      const slug = currentRepoSlug();
+      const epicData = fetchIssue(ref);
+      const epicSections = parseSections(epicData.body).sections;
+      const subIssuesSection =
+        epicSections.sub_issues ??
+        epicSections.subissues ??
+        epicSections.children ??
+        epicSections.tasks ??
+        '';
+
+      const subs = [
+        ...parseTableSubIssues(subIssuesSection, slug),
+        ...parseBulletSubIssues(subIssuesSection, slug),
+      ];
+      // Dedup by ref.
+      const seen = new Set<string>();
+      const dedupedSubs: SubIssue[] = [];
+      for (const s of subs) {
+        if (!seen.has(s.ref)) {
+          seen.add(s.ref);
+          dedupedSubs.push(s);
+        }
+      }
+
+      // Fetch dependencies for each sub-issue.
+      const nodes: DepNode[] = [];
+      for (const sub of dedupedSubs) {
+        const subRefParsed = parseIssueRef(sub.ref);
+        if (!subRefParsed) continue;
+        try {
+          const subData = fetchIssue(subRefParsed);
+          const subSections = parseSections(subData.body).sections;
+          const deps = parseDependencies(subSections.dependencies ?? '', slug);
+          nodes.push({
+            ref: sub.ref,
+            title: sub.title ?? subData.title,
+            depends_on: deps,
+          });
+        } catch {
+          nodes.push({ ref: sub.ref, title: sub.title, depends_on: [] });
+        }
+      }
+
+      const result = computeWaves(nodes);
+      if (result.error) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                ok: false,
+                error: result.error,
+                waves: result.waves,
+                total_issues: result.total_issues,
+              }),
+            },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              epic_ref: args.epic_ref,
+              waves: result.waves,
+              topology: result.topology,
+              total_issues: result.total_issues,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default waveComputeHandler;

--- a/lib/dependency_graph.ts
+++ b/lib/dependency_graph.ts
@@ -1,0 +1,120 @@
+/**
+ * Shared dependency-graph helpers for the wave_compute / wave_topology /
+ * wave_dependency_graph handlers.
+ *
+ * Lives in `lib/` so the handler registry codegen ignores it.
+ */
+
+export interface DepNode {
+  ref: string;
+  title?: string;
+  depends_on: string[]; // refs of prerequisites
+}
+
+export interface WavePartition {
+  id: string;
+  issues: DepNode[];
+}
+
+export interface ComputeResult {
+  waves: WavePartition[];
+  topology: 'serial' | 'parallel' | 'mixed';
+  total_issues: number;
+  error?: string;
+}
+
+/**
+ * Partition nodes into waves via dependency-order Kahn's algorithm.
+ * Each wave is a set of nodes whose remaining in-degree is zero
+ * after previous waves have been removed.
+ */
+export function computeWaves(nodes: DepNode[]): ComputeResult {
+  const byRef = new Map<string, DepNode>();
+  for (const n of nodes) byRef.set(n.ref, n);
+
+  // Sanitize deps: drop any dependency not in the node set (out-of-scope).
+  const remaining = new Map<string, Set<string>>();
+  for (const n of nodes) {
+    const deps = new Set<string>();
+    for (const d of n.depends_on) {
+      if (byRef.has(d)) deps.add(d);
+    }
+    remaining.set(n.ref, deps);
+  }
+
+  const waves: WavePartition[] = [];
+  const resolved = new Set<string>();
+  let waveIdx = 1;
+
+  while (resolved.size < nodes.length) {
+    const currentWave: DepNode[] = [];
+    for (const n of nodes) {
+      if (resolved.has(n.ref)) continue;
+      const deps = remaining.get(n.ref) ?? new Set();
+      let ready = true;
+      for (const d of deps) {
+        if (!resolved.has(d)) {
+          ready = false;
+          break;
+        }
+      }
+      if (ready) currentWave.push(n);
+    }
+    if (currentWave.length === 0) {
+      // Cycle detected — remaining nodes all have unresolved deps.
+      const remainingRefs = nodes
+        .filter(n => !resolved.has(n.ref))
+        .map(n => n.ref);
+      return {
+        waves,
+        topology: 'serial',
+        total_issues: nodes.length,
+        error: `circular dependency detected among: ${remainingRefs.join(', ')}`,
+      };
+    }
+    waves.push({
+      id: `wave-${waveIdx}`,
+      issues: currentWave,
+    });
+    for (const n of currentWave) resolved.add(n.ref);
+    waveIdx += 1;
+  }
+
+  const hasParallel = waves.some(w => w.issues.length > 1);
+  const hasSerial = waves.some(w => w.issues.length === 1);
+  let topology: 'serial' | 'parallel' | 'mixed';
+  if (hasParallel && hasSerial) topology = 'mixed';
+  else if (hasParallel) topology = 'parallel';
+  else topology = 'serial';
+
+  return {
+    waves,
+    topology,
+    total_issues: nodes.length,
+  };
+}
+
+/**
+ * Build a nodes + edges representation for visualization.
+ */
+export interface GraphEdge {
+  from: string;
+  to: string;
+  kind: 'blocks';
+}
+
+export function buildGraph(nodes: DepNode[]): { nodes: Array<{ ref: string; title?: string }>; edges: GraphEdge[] } {
+  const edges: GraphEdge[] = [];
+  const refSet = new Set(nodes.map(n => n.ref));
+  for (const n of nodes) {
+    for (const d of n.depends_on) {
+      if (refSet.has(d)) {
+        edges.push({ from: d, to: n.ref, kind: 'blocks' });
+      }
+    }
+  }
+  return {
+    nodes: nodes.map(n => ({ ref: n.ref, title: n.title })),
+    edges,
+  };
+}

--- a/tests/wave_compute.test.ts
+++ b/tests/wave_compute.test.ts
@@ -1,0 +1,147 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string, _opts?: unknown) => execMockFn(cmd));
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/wave_compute.ts');
+
+function resetMocks() {
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+/**
+ * Build a mock that serves an epic body plus a set of sub-issue bodies.
+ * The epic body should list sub-issues; each sub-issue's body lists its
+ * own Dependencies section.
+ */
+function mockGraph(
+  epicBody: string,
+  subIssues: Record<string, { body: string; title?: string }>,
+) {
+  execMockFn = (cmd: string) => {
+    if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+    if (cmd.includes('gh issue view')) {
+      // Detect which issue is being asked for.
+      const m = /gh issue view (\S+)/.exec(cmd);
+      if (!m) return JSON.stringify({ body: '', title: '' });
+      const n = m[1];
+      if (n === '100') {
+        return JSON.stringify({ body: epicBody, title: 'Epic 100' });
+      }
+      // Match #N within sub issues OR a full org/repo#N (if cmd contains --repo).
+      for (const [ref, data] of Object.entries(subIssues)) {
+        // Extract number from ref (org/repo#N or #N).
+        const refM = /#(\d+)$/.exec(ref);
+        if (refM && refM[1] === n) {
+          return JSON.stringify({ body: data.body, title: data.title ?? `Issue ${n}` });
+        }
+      }
+      return JSON.stringify({ body: '', title: `Issue ${n}` });
+    }
+    return '';
+  };
+}
+
+describe('wave_compute handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('wave_compute');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('linear_chain_produces_serial_topology', async () => {
+    const epicBody = `## Sub-Issues
+
+- #5 first
+- #6 second
+- #7 third
+`;
+    const subs: Record<string, { body: string; title?: string }> = {
+      'org/repo#5': { body: '## Dependencies\nNone\n', title: 'first' },
+      'org/repo#6': { body: '## Dependencies\n- #5\n', title: 'second' },
+      'org/repo#7': { body: '## Dependencies\n- #6\n', title: 'third' },
+    };
+    mockGraph(epicBody, subs);
+    const result = await handler.execute({ epic_ref: '#100' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.topology).toBe('serial');
+    expect(parsed.waves.length).toBe(3);
+    expect(parsed.waves[0].issues.length).toBe(1);
+    expect(parsed.waves[2].issues[0].ref).toBe('org/repo#7');
+  });
+
+  test('independent_issues_produce_single_parallel_wave', async () => {
+    const epicBody = `## Sub-Issues
+
+- #5 a
+- #6 b
+- #7 c
+`;
+    const subs: Record<string, { body: string; title?: string }> = {
+      'org/repo#5': { body: '## Dependencies\nNone\n' },
+      'org/repo#6': { body: '## Dependencies\nNone\n' },
+      'org/repo#7': { body: '## Dependencies\nNone\n' },
+    };
+    mockGraph(epicBody, subs);
+    const result = await handler.execute({ epic_ref: '#100' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.topology).toBe('parallel');
+    expect(parsed.waves.length).toBe(1);
+    expect(parsed.waves[0].issues.length).toBe(3);
+  });
+
+  test('diamond_dependency — 2 waves (A,B parallel; C after)', async () => {
+    const epicBody = `## Sub-Issues
+
+- #5 A
+- #6 B
+- #7 C
+`;
+    const subs: Record<string, { body: string; title?: string }> = {
+      'org/repo#5': { body: '## Dependencies\nNone\n' },
+      'org/repo#6': { body: '## Dependencies\nNone\n' },
+      'org/repo#7': { body: '## Dependencies\n- #5\n- #6\n' },
+    };
+    mockGraph(epicBody, subs);
+    const result = await handler.execute({ epic_ref: '#100' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.waves.length).toBe(2);
+    expect(parsed.waves[0].issues.length).toBe(2);
+    expect(parsed.waves[1].issues.length).toBe(1);
+    expect(parsed.topology).toBe('mixed');
+  });
+
+  test('circular_dependency_returns_error', async () => {
+    const epicBody = `## Sub-Issues
+
+- #5 A
+- #6 B
+`;
+    const subs: Record<string, { body: string; title?: string }> = {
+      'org/repo#5': { body: '## Dependencies\n- #6\n' },
+      'org/repo#6': { body: '## Dependencies\n- #5\n' },
+    };
+    mockGraph(epicBody, subs);
+    const result = await handler.execute({ epic_ref: '#100' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('circular');
+  });
+
+  test('schema_validation — rejects missing epic_ref', async () => {
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `wave_compute` — computes dependency-ordered waves for an epic's sub-issues. Establishes `lib/dependency_graph.ts` as the shared helper for Wave 3's topology tools. Wave 3.

## Changes

- `lib/dependency_graph.ts` — `DepNode`, `computeWaves` (Kahn's algorithm with cycle detection), `buildGraph`, topology classifier.
- `handlers/wave_compute.ts` — HandlerDef, schema: `epic_ref`. Fetches epic + sub-issues + their dependencies, builds graph, partitions into waves.
- `tests/wave_compute.test.ts` — linear chain, independent parallel, diamond, circular deps, schema validation.

Wave 3 tools #32 `wave_topology` and #33 `wave_dependency_graph` will reuse `lib/dependency_graph.ts`.

## Linked Issues

Closes #31

## Test Plan

- [x] `./scripts/ci/validate.sh` green (384 tests + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)