### PR TITLE
feat(wave-mcp): implement wave_topology handler

### DIFF
--- a/handlers/wave_topology.ts
+++ b/handlers/wave_topology.ts
@@ -1,0 +1,204 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+import { parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
+import { computeWaves, type DepNode } from '../lib/dependency_graph';
+
+const inputSchema = z
+  .object({
+    issue_refs: z.array(z.string().min(1)).optional(),
+    epic_ref: z.string().min(1).optional(),
+  })
+  .refine(
+    data => Boolean(data.issue_refs) !== Boolean(data.epic_ref),
+    'provide exactly one of issue_refs or epic_ref',
+  );
+
+function detectPlatform(): 'github' | 'gitlab' {
+  try {
+    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    return url.includes('gitlab') ? 'gitlab' : 'github';
+  } catch {
+    return 'github';
+  }
+}
+
+function currentRepoSlug(): string | null {
+  try {
+    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    const m = /[/:]([^/]+)\/([^/.]+?)(\.git)?$/.exec(url);
+    if (m) return `${m[1]}/${m[2]}`;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function fetchIssue(ref: IssueRef): { body: string; title: string } {
+  const platform = detectPlatform();
+  if (platform === 'github') {
+    const repoArg = ref.owner && ref.repo ? `--repo ${ref.owner}/${ref.repo}` : '';
+    const cmd = `gh issue view ${ref.number} ${repoArg} --json body,title`.trim();
+    const raw = execSync(cmd, { encoding: 'utf8' });
+    const parsed = JSON.parse(raw) as { body?: string; title: string };
+    return { body: parsed.body ?? '', title: parsed.title };
+  }
+  const cmd =
+    ref.owner && ref.repo
+      ? `glab issue view ${ref.number} --repo ${ref.owner}/${ref.repo} --output json`
+      : `glab issue view ${ref.number} --output json`;
+  const raw = execSync(cmd, { encoding: 'utf8' });
+  const parsed = JSON.parse(raw) as { description?: string; title: string };
+  return { body: parsed.description ?? '', title: parsed.title };
+}
+
+function normalizeRef(ref: string, currentSlug: string | null): string {
+  const urlM =
+    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/.exec(
+      ref,
+    );
+  if (urlM) return `${urlM[1]}/${urlM[2]}#${urlM[3]}`;
+  const crossM = /^([^/\s#]+)\/([^/\s#]+)#(\d+)$/.exec(ref);
+  if (crossM) return ref;
+  const shortM = /^#?(\d+)$/.exec(ref);
+  if (shortM) return currentSlug ? `${currentSlug}#${shortM[1]}` : `#${shortM[1]}`;
+  return ref;
+}
+
+function parseDependencies(section: string, currentSlug: string | null): string[] {
+  if (!section || /^none\b/i.test(section.trim())) return [];
+  const found = new Set<string>();
+  const urlRe =
+    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = urlRe.exec(section)) !== null) {
+    found.add(`${m[1]}/${m[2]}#${m[3]}`);
+  }
+  const crossRe = /\b([^\s/#]+)\/([^\s/#]+)#(\d+)\b/g;
+  while ((m = crossRe.exec(section)) !== null) {
+    if (m[1].startsWith('http') || m[1].includes('.')) continue;
+    found.add(`${m[1]}/${m[2]}#${m[3]}`);
+  }
+  const shortRe = /(?<![/\w])#(\d+)\b/g;
+  while ((m = shortRe.exec(section)) !== null) {
+    found.add(currentSlug ? `${currentSlug}#${m[1]}` : `#${m[1]}`);
+  }
+  return Array.from(found);
+}
+
+function resolveIssueList(
+  issueRefs: string[] | undefined,
+  epicRef: string | undefined,
+  slug: string | null,
+): string[] {
+  if (issueRefs) return issueRefs.map(r => normalizeRef(r, slug));
+  if (!epicRef) return [];
+  const ref = parseIssueRef(epicRef);
+  if (!ref) return [];
+  const epic = fetchIssue(ref);
+  const sections = parseSections(epic.body).sections;
+  const subSection =
+    sections.sub_issues ?? sections.subissues ?? sections.children ?? sections.tasks ?? '';
+  const refs: string[] = [];
+  const re = /(?:^|\s)([^/\s#]+\/[^/\s#]+#\d+|https?:\/\/\S+\/issues\/\d+|#\d+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(subSection)) !== null) {
+    refs.push(normalizeRef(m[1], slug));
+  }
+  // Dedup preserving order.
+  const seen = new Set<string>();
+  return refs.filter(r => !seen.has(r) && (seen.add(r), true));
+}
+
+const waveTopologyHandler: HandlerDef = {
+  name: 'wave_topology',
+  description: 'Classify topology of a dependency graph as serial/parallel/mixed',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const slug = currentRepoSlug();
+      const refs = resolveIssueList(args.issue_refs, args.epic_ref, slug);
+      if (refs.length === 0) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                ok: true,
+                topology: 'serial',
+                wave_count: 0,
+                max_parallelism: 0,
+                issue_count: 0,
+              }),
+            },
+          ],
+        };
+      }
+
+      const nodes: DepNode[] = [];
+      for (const ref of refs) {
+        const parsed = parseIssueRef(ref);
+        if (!parsed) continue;
+        try {
+          const data = fetchIssue(parsed);
+          const sections = parseSections(data.body).sections;
+          nodes.push({
+            ref,
+            depends_on: parseDependencies(sections.dependencies ?? '', slug),
+          });
+        } catch {
+          nodes.push({ ref, depends_on: [] });
+        }
+      }
+
+      const result = computeWaves(nodes);
+      if (result.error) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({ ok: false, error: result.error }),
+            },
+          ],
+        };
+      }
+
+      const maxParallelism = result.waves.reduce(
+        (max, w) => Math.max(max, w.issues.length),
+        0,
+      );
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              topology: result.topology,
+              wave_count: result.waves.length,
+              max_parallelism: maxParallelism,
+              issue_count: result.total_issues,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default waveTopologyHandler;

--- a/tests/wave_topology.test.ts
+++ b/tests/wave_topology.test.ts
@@ -1,0 +1,126 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string, _opts?: unknown) => execMockFn(cmd));
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/wave_topology.ts');
+
+function resetMocks() {
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+function mockIssues(bodies: Record<string, string>, origin = 'https://github.com/org/repo.git') {
+  execMockFn = (cmd: string) => {
+    if (cmd.startsWith('git remote')) return origin + '\n';
+    if (cmd.includes('gh issue view')) {
+      const m = /gh issue view (\S+)/.exec(cmd);
+      if (m) {
+        const n = m[1];
+        return JSON.stringify({ body: bodies[n] ?? '', title: `Issue ${n}` });
+      }
+    }
+    return '';
+  };
+}
+
+describe('wave_topology handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('wave_topology');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('linear_chain_serial', async () => {
+    mockIssues({
+      '5': '## Dependencies\nNone\n',
+      '6': '## Dependencies\n- #5\n',
+      '7': '## Dependencies\n- #6\n',
+    });
+    const result = await handler.execute({ issue_refs: ['#5', '#6', '#7'] });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.topology).toBe('serial');
+    expect(parsed.wave_count).toBe(3);
+    expect(parsed.max_parallelism).toBe(1);
+  });
+
+  test('independent_issues_parallel', async () => {
+    mockIssues({
+      '5': '## Dependencies\nNone\n',
+      '6': '## Dependencies\nNone\n',
+      '7': '## Dependencies\nNone\n',
+    });
+    const result = await handler.execute({ issue_refs: ['#5', '#6', '#7'] });
+    const parsed = parseResult(result);
+    expect(parsed.topology).toBe('parallel');
+    expect(parsed.wave_count).toBe(1);
+    expect(parsed.max_parallelism).toBe(3);
+  });
+
+  test('mixed_topology — parallel then serial', async () => {
+    mockIssues({
+      '5': '## Dependencies\nNone\n',
+      '6': '## Dependencies\nNone\n',
+      '7': '## Dependencies\n- #5\n- #6\n',
+    });
+    const result = await handler.execute({ issue_refs: ['#5', '#6', '#7'] });
+    const parsed = parseResult(result);
+    expect(parsed.topology).toBe('mixed');
+    expect(parsed.wave_count).toBe(2);
+    expect(parsed.max_parallelism).toBe(2);
+  });
+
+  test('single_issue — serial with wave_count=1', async () => {
+    mockIssues({ '5': '## Dependencies\nNone\n' });
+    const result = await handler.execute({ issue_refs: ['#5'] });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.wave_count).toBe(1);
+    expect(parsed.max_parallelism).toBe(1);
+    expect(parsed.topology).toBe('serial');
+  });
+
+  test('accepts_epic_ref_alternative', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      if (cmd.includes('gh issue view 100')) {
+        return JSON.stringify({
+          body: '## Sub-Issues\n- #5 a\n- #6 b\n',
+          title: 'Epic',
+        });
+      }
+      if (cmd.includes('gh issue view 5')) {
+        return JSON.stringify({ body: '## Dependencies\nNone\n', title: '5' });
+      }
+      if (cmd.includes('gh issue view 6')) {
+        return JSON.stringify({ body: '## Dependencies\nNone\n', title: '6' });
+      }
+      return '';
+    };
+    const result = await handler.execute({ epic_ref: '#100' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.wave_count).toBe(1);
+    expect(parsed.topology).toBe('parallel');
+  });
+
+  test('schema_validation — rejects both issue_refs and epic_ref', async () => {
+    const result = await handler.execute({ issue_refs: ['#1'], epic_ref: '#2' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema_validation — rejects neither issue_refs nor epic_ref', async () => {
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `wave_topology` — lightweight topology classifier. Accepts issue_refs list or epic_ref. Wave 3.

## Changes

- `handlers/wave_topology.ts` — HandlerDef. Zod refine enforces exactly-one-of constraint. Reuses lib/dependency_graph.ts.
- `tests/wave_topology.test.ts` — serial chain, parallel, mixed, single issue, epic_ref alt, mutex schema validation.

## Linked Issues

Closes #32

## Test Plan

- [x] `./scripts/ci/validate.sh` green (397 tests + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)