### PR TITLE
feat(wave-mcp): implement wave_dependency_graph handler

### DIFF
--- a/handlers/wave_dependency_graph.ts
+++ b/handlers/wave_dependency_graph.ts
@@ -1,0 +1,180 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+import { parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
+import { buildGraph, type DepNode } from '../lib/dependency_graph';
+
+const inputSchema = z
+  .object({
+    issue_refs: z.array(z.string().min(1)).optional(),
+    epic_ref: z.string().min(1).optional(),
+  })
+  .refine(
+    data => Boolean(data.issue_refs) !== Boolean(data.epic_ref),
+    'provide exactly one of issue_refs or epic_ref',
+  );
+
+function detectPlatform(): 'github' | 'gitlab' {
+  try {
+    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    return url.includes('gitlab') ? 'gitlab' : 'github';
+  } catch {
+    return 'github';
+  }
+}
+
+function currentRepoSlug(): string | null {
+  try {
+    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    const m = /[/:]([^/]+)\/([^/.]+?)(\.git)?$/.exec(url);
+    if (m) return `${m[1]}/${m[2]}`;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function fetchIssue(ref: IssueRef): { body: string; title: string } {
+  const platform = detectPlatform();
+  if (platform === 'github') {
+    const repoArg = ref.owner && ref.repo ? `--repo ${ref.owner}/${ref.repo}` : '';
+    const cmd = `gh issue view ${ref.number} ${repoArg} --json body,title`.trim();
+    const raw = execSync(cmd, { encoding: 'utf8' });
+    const parsed = JSON.parse(raw) as { body?: string; title: string };
+    return { body: parsed.body ?? '', title: parsed.title };
+  }
+  const cmd =
+    ref.owner && ref.repo
+      ? `glab issue view ${ref.number} --repo ${ref.owner}/${ref.repo} --output json`
+      : `glab issue view ${ref.number} --output json`;
+  const raw = execSync(cmd, { encoding: 'utf8' });
+  const parsed = JSON.parse(raw) as { description?: string; title: string };
+  return { body: parsed.description ?? '', title: parsed.title };
+}
+
+function normalizeRef(ref: string, currentSlug: string | null): string {
+  const urlM =
+    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/.exec(
+      ref,
+    );
+  if (urlM) return `${urlM[1]}/${urlM[2]}#${urlM[3]}`;
+  const crossM = /^([^/\s#]+)\/([^/\s#]+)#(\d+)$/.exec(ref);
+  if (crossM) return ref;
+  const shortM = /^#?(\d+)$/.exec(ref);
+  if (shortM) return currentSlug ? `${currentSlug}#${shortM[1]}` : `#${shortM[1]}`;
+  return ref;
+}
+
+function parseDependencies(section: string, currentSlug: string | null): string[] {
+  if (!section || /^none\b/i.test(section.trim())) return [];
+  const found = new Set<string>();
+  const urlRe =
+    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = urlRe.exec(section)) !== null) {
+    found.add(`${m[1]}/${m[2]}#${m[3]}`);
+  }
+  const crossRe = /\b([^\s/#]+)\/([^\s/#]+)#(\d+)\b/g;
+  while ((m = crossRe.exec(section)) !== null) {
+    if (m[1].startsWith('http') || m[1].includes('.')) continue;
+    found.add(`${m[1]}/${m[2]}#${m[3]}`);
+  }
+  const shortRe = /(?<![/\w])#(\d+)\b/g;
+  while ((m = shortRe.exec(section)) !== null) {
+    found.add(currentSlug ? `${currentSlug}#${m[1]}` : `#${m[1]}`);
+  }
+  return Array.from(found);
+}
+
+function resolveIssueList(
+  issueRefs: string[] | undefined,
+  epicRef: string | undefined,
+  slug: string | null,
+): string[] {
+  if (issueRefs) return issueRefs.map(r => normalizeRef(r, slug));
+  if (!epicRef) return [];
+  const ref = parseIssueRef(epicRef);
+  if (!ref) return [];
+  const epic = fetchIssue(ref);
+  const sections = parseSections(epic.body).sections;
+  const subSection =
+    sections.sub_issues ?? sections.subissues ?? sections.children ?? sections.tasks ?? '';
+  const refs: string[] = [];
+  const re = /(?:^|\s)([^/\s#]+\/[^/\s#]+#\d+|https?:\/\/\S+\/issues\/\d+|#\d+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(subSection)) !== null) {
+    refs.push(normalizeRef(m[1], slug));
+  }
+  const seen = new Set<string>();
+  return refs.filter(r => !seen.has(r) && (seen.add(r), true));
+}
+
+const waveDependencyGraphHandler: HandlerDef = {
+  name: 'wave_dependency_graph',
+  description: 'Return the dependency graph of an issue set as nodes and edges',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const slug = currentRepoSlug();
+      const refs = resolveIssueList(args.issue_refs, args.epic_ref, slug);
+      if (refs.length === 0) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                ok: true,
+                nodes: [],
+                edges: [],
+              }),
+            },
+          ],
+        };
+      }
+
+      const nodes: DepNode[] = [];
+      for (const ref of refs) {
+        const parsed = parseIssueRef(ref);
+        if (!parsed) continue;
+        try {
+          const data = fetchIssue(parsed);
+          const sections = parseSections(data.body).sections;
+          nodes.push({
+            ref,
+            title: data.title,
+            depends_on: parseDependencies(sections.dependencies ?? '', slug),
+          });
+        } catch {
+          nodes.push({ ref, depends_on: [] });
+        }
+      }
+
+      const graph = buildGraph(nodes);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({ ok: true, ...graph }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default waveDependencyGraphHandler;

--- a/tests/wave_dependency_graph.test.ts
+++ b/tests/wave_dependency_graph.test.ts
@@ -1,0 +1,116 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string, _opts?: unknown) => execMockFn(cmd));
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/wave_dependency_graph.ts');
+
+function resetMocks() {
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+function mockIssues(bodies: Record<string, string>, origin = 'https://github.com/org/repo.git') {
+  execMockFn = (cmd: string) => {
+    if (cmd.startsWith('git remote')) return origin + '\n';
+    if (cmd.includes('gh issue view')) {
+      const m = /gh issue view (\S+)/.exec(cmd);
+      if (m) {
+        const n = m[1];
+        return JSON.stringify({ body: bodies[n] ?? '', title: `Issue ${n}` });
+      }
+    }
+    return '';
+  };
+}
+
+describe('wave_dependency_graph handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('wave_dependency_graph');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('empty_graph — no issues returns empty nodes/edges', async () => {
+    mockIssues({});
+    const result = await handler.execute({ issue_refs: [] });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.nodes).toEqual([]);
+    expect(parsed.edges).toEqual([]);
+  });
+
+  test('single_edge', async () => {
+    mockIssues({
+      '5': '## Dependencies\nNone\n',
+      '6': '## Dependencies\n- #5\n',
+    });
+    const result = await handler.execute({ issue_refs: ['#5', '#6'] });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.nodes.length).toBe(2);
+    expect(parsed.edges.length).toBe(1);
+    expect(parsed.edges[0].from).toBe('org/repo#5');
+    expect(parsed.edges[0].to).toBe('org/repo#6');
+    expect(parsed.edges[0].kind).toBe('blocks');
+  });
+
+  test('multiple_edges — diamond', async () => {
+    mockIssues({
+      '5': '## Dependencies\nNone\n',
+      '6': '## Dependencies\nNone\n',
+      '7': '## Dependencies\n- #5\n- #6\n',
+      '8': '## Dependencies\n- #7\n',
+    });
+    const result = await handler.execute({ issue_refs: ['#5', '#6', '#7', '#8'] });
+    const parsed = parseResult(result);
+    expect(parsed.nodes.length).toBe(4);
+    expect(parsed.edges.length).toBe(3);
+  });
+
+  test('disconnected_components — two independent islands', async () => {
+    mockIssues({
+      '5': '## Dependencies\nNone\n',
+      '6': '## Dependencies\n- #5\n',
+      '10': '## Dependencies\nNone\n',
+      '11': '## Dependencies\n- #10\n',
+    });
+    const result = await handler.execute({ issue_refs: ['#5', '#6', '#10', '#11'] });
+    const parsed = parseResult(result);
+    expect(parsed.nodes.length).toBe(4);
+    expect(parsed.edges.length).toBe(2);
+  });
+
+  test('cross_repo_nodes — org/repo#N preserved', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      if (cmd.includes('gh issue view 5')) {
+        return JSON.stringify({ body: '## Dependencies\n- acme/widgets#42\n', title: 'five' });
+      }
+      if (cmd.includes('gh issue view 42') && cmd.includes('--repo acme/widgets')) {
+        return JSON.stringify({ body: '## Dependencies\nNone\n', title: 'external' });
+      }
+      return JSON.stringify({ body: '', title: '' });
+    };
+    const result = await handler.execute({ issue_refs: ['#5', 'acme/widgets#42'] });
+    const parsed = parseResult(result);
+    expect(parsed.nodes.some((n: { ref: string }) => n.ref === 'acme/widgets#42')).toBe(
+      true,
+    );
+    expect(parsed.edges[0].from).toBe('acme/widgets#42');
+    expect(parsed.edges[0].to).toBe('org/repo#5');
+  });
+
+  test('schema_validation — rejects both inputs', async () => {
+    const result = await handler.execute({ issue_refs: ['#1'], epic_ref: '#2' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `wave_dependency_graph` — returns nodes + edges representation. Wave 3.

## Changes

- `handlers/wave_dependency_graph.ts` — HandlerDef, same input schema as wave_topology. Returns `{nodes, edges}`.
- `tests/wave_dependency_graph.test.ts` — empty, single edge, diamond, disconnected components, cross-repo nodes, mutex schema.

## Linked Issues

Closes #33

## Test Plan

- [x] `./scripts/ci/validate.sh` green (409 tests + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)