### PR TITLE
feat(wave-mcp): implement flight_overlap + lib/flight_overlap

### DIFF
--- a/handlers/flight_overlap.ts
+++ b/handlers/flight_overlap.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+import { computePairConflicts, conflictFreeGroups } from '../lib/flight_overlap';
+
+const manifestSchema = z.object({
+  issue_ref: z.string().min(1),
+  files_to_create: z.array(z.string()).optional(),
+  files_to_modify: z.array(z.string()).optional(),
+});
+
+const inputSchema = z.object({
+  manifests: z.array(manifestSchema),
+});
+
+const flightOverlapHandler: HandlerDef = {
+  name: 'flight_overlap',
+  description: 'Compute file-overlap conflicts between a set of issue target manifests',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const conflicts = computePairConflicts(args.manifests);
+      const groups = conflictFreeGroups(args.manifests, conflicts);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              conflicts,
+              conflict_free_groups: groups,
+              manifest_count: args.manifests.length,
+              conflict_count: conflicts.length,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default flightOverlapHandler;

--- a/lib/flight_overlap.ts
+++ b/lib/flight_overlap.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared file-overlap computation for flight_overlap (#37) and
+ * flight_partition (#38). Lives in lib/ so the handler codegen ignores it.
+ */
+
+export interface Manifest {
+  issue_ref: string;
+  files_to_create?: string[];
+  files_to_modify?: string[];
+}
+
+export interface Conflict {
+  a: string;
+  b: string;
+  files: string[];
+  severity: 'hard';
+}
+
+export function manifestFiles(m: Manifest): Set<string> {
+  const files = new Set<string>();
+  for (const f of m.files_to_create ?? []) files.add(f);
+  for (const f of m.files_to_modify ?? []) files.add(f);
+  return files;
+}
+
+/**
+ * Compute pairwise file conflicts. Any shared file path between two
+ * manifests is a hard conflict (symbol-level refinement is v2).
+ */
+export function computePairConflicts(manifests: Manifest[]): Conflict[] {
+  const conflicts: Conflict[] = [];
+  const fileSets = manifests.map(m => manifestFiles(m));
+  for (let i = 0; i < manifests.length; i++) {
+    for (let j = i + 1; j < manifests.length; j++) {
+      const shared: string[] = [];
+      for (const f of fileSets[i]) {
+        if (fileSets[j].has(f)) shared.push(f);
+      }
+      if (shared.length > 0) {
+        conflicts.push({
+          a: manifests[i].issue_ref,
+          b: manifests[j].issue_ref,
+          files: shared,
+          severity: 'hard',
+        });
+      }
+    }
+  }
+  return conflicts;
+}
+
+/**
+ * Group issues into conflict-free sets greedily: for each issue, assign
+ * it to the first group that has no conflict with any existing member.
+ */
+export function conflictFreeGroups(
+  manifests: Manifest[],
+  conflicts: Conflict[],
+): string[][] {
+  const conflictSet = new Set<string>();
+  for (const c of conflicts) {
+    // Store bidirectional edges.
+    conflictSet.add(`${c.a}|${c.b}`);
+    conflictSet.add(`${c.b}|${c.a}`);
+  }
+
+  const groups: string[][] = [];
+  for (const m of manifests) {
+    const ref = m.issue_ref;
+    let placed = false;
+    for (const group of groups) {
+      const conflicts = group.some(other => conflictSet.has(`${ref}|${other}`));
+      if (!conflicts) {
+        group.push(ref);
+        placed = true;
+        break;
+      }
+    }
+    if (!placed) groups.push([ref]);
+  }
+  return groups;
+}

--- a/tests/flight_overlap.test.ts
+++ b/tests/flight_overlap.test.ts
@@ -1,0 +1,100 @@
+import { describe, test, expect } from 'bun:test';
+
+const { default: handler } = await import('../handlers/flight_overlap.ts');
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('flight_overlap handler', () => {
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('flight_overlap');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('no_overlap_returns_empty_conflicts', async () => {
+    const result = await handler.execute({
+      manifests: [
+        { issue_ref: '#1', files_to_create: ['a.ts'] },
+        { issue_ref: '#2', files_to_create: ['b.ts'] },
+        { issue_ref: '#3', files_to_modify: ['c.ts'] },
+      ],
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.conflicts).toEqual([]);
+    expect(parsed.conflict_free_groups).toHaveLength(1);
+    expect(parsed.conflict_free_groups[0]).toEqual(['#1', '#2', '#3']);
+  });
+
+  test('single_pair_overlap — shared file creates one conflict', async () => {
+    const result = await handler.execute({
+      manifests: [
+        { issue_ref: '#1', files_to_modify: ['shared.ts'] },
+        { issue_ref: '#2', files_to_modify: ['shared.ts'] },
+        { issue_ref: '#3', files_to_create: ['unique.ts'] },
+      ],
+    });
+    const parsed = parseResult(result);
+    expect(parsed.conflicts).toHaveLength(1);
+    expect(parsed.conflicts[0].a).toBe('#1');
+    expect(parsed.conflicts[0].b).toBe('#2');
+    expect(parsed.conflicts[0].files).toEqual(['shared.ts']);
+    expect(parsed.conflicts[0].severity).toBe('hard');
+    // Groups: #1 in first, #2 in second, #3 can fit in first (no conflict with #1)
+    expect(parsed.conflict_free_groups.length).toBe(2);
+  });
+
+  test('transitive_chain — A↔B, B↔C but A!↔C → two groups', async () => {
+    const result = await handler.execute({
+      manifests: [
+        { issue_ref: '#A', files_to_modify: ['ab.ts'] },
+        { issue_ref: '#B', files_to_modify: ['ab.ts', 'bc.ts'] },
+        { issue_ref: '#C', files_to_modify: ['bc.ts'] },
+      ],
+    });
+    const parsed = parseResult(result);
+    expect(parsed.conflicts).toHaveLength(2);
+    // Greedy grouping: A in grp1, B conflicts with A → grp2, C conflicts with B → grp1 (no conflict with A)
+    expect(parsed.conflict_free_groups.length).toBe(2);
+    expect(parsed.conflict_free_groups[0]).toContain('#A');
+    expect(parsed.conflict_free_groups[0]).toContain('#C');
+    expect(parsed.conflict_free_groups[1]).toContain('#B');
+  });
+
+  test('conflict_free_groups_maximize_parallelism — all independent → single group', async () => {
+    const result = await handler.execute({
+      manifests: [
+        { issue_ref: '#1', files_to_create: ['a.ts'] },
+        { issue_ref: '#2', files_to_create: ['b.ts'] },
+        { issue_ref: '#3', files_to_create: ['c.ts'] },
+        { issue_ref: '#4', files_to_create: ['d.ts'] },
+      ],
+    });
+    const parsed = parseResult(result);
+    expect(parsed.conflicts).toEqual([]);
+    expect(parsed.conflict_free_groups).toEqual([['#1', '#2', '#3', '#4']]);
+  });
+
+  test('empty_manifests_returns_empty_state', async () => {
+    const result = await handler.execute({ manifests: [] });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.conflicts).toEqual([]);
+    expect(parsed.conflict_free_groups).toEqual([]);
+  });
+
+  test('schema_validation — rejects missing manifests', async () => {
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema_validation — rejects manifest without issue_ref', async () => {
+    const result = await handler.execute({
+      manifests: [{ files_to_create: ['a.ts'] }],
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `flight_overlap` — file-level conflict detection between issue manifests. Foundation for #38 flight_partition. Wave 4.

## Changes

- `lib/flight_overlap.ts` — `computePairConflicts`, `conflictFreeGroups` (greedy graph coloring for conflict-free groupings).
- `handlers/flight_overlap.ts` — HandlerDef, schema: `manifests` array with `{issue_ref, files_to_create?, files_to_modify?}`.
- `tests/flight_overlap.test.ts` — no overlap, single pair, transitive (verifies greedy grouping), max parallelism, empty, schema validation.

## Linked Issues

Closes #37

## Test Plan

- [x] `./scripts/ci/validate.sh` green (422 tests + smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)