### PR TITLE
feat(wave-mcp): implement flight_partition handler

### DIFF
--- a/handlers/flight_partition.ts
+++ b/handlers/flight_partition.ts
@@ -1,0 +1,101 @@
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+import {
+  computePairConflicts,
+  conflictFreeGroups,
+  type Manifest,
+} from '../lib/flight_overlap';
+
+const manifestSchema = z.object({
+  issue_ref: z.string().min(1),
+  files_to_create: z.array(z.string()).optional(),
+  files_to_modify: z.array(z.string()).optional(),
+});
+
+const inputSchema = z.object({
+  manifests: z.array(manifestSchema),
+  strategy: z.enum(['safe', 'aggressive']).optional().default('safe'),
+});
+
+interface Flight {
+  number: number;
+  issues: string[];
+  reason: string;
+}
+
+const flightPartitionHandler: HandlerDef = {
+  name: 'flight_partition',
+  description: 'Partition issues into conflict-free flights',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const manifests: Manifest[] = args.manifests;
+      if (manifests.length === 0) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                ok: true,
+                flights: [],
+                strategy_used: args.strategy,
+                conflict_count: 0,
+              }),
+            },
+          ],
+        };
+      }
+
+      const conflicts = computePairConflicts(manifests);
+      const groups = conflictFreeGroups(manifests, conflicts);
+
+      const flights: Flight[] = groups.map((issues, idx) => {
+        let reason: string;
+        if (issues.length === manifests.length) {
+          reason = 'all issues are conflict-free; single parallel flight';
+        } else if (issues.length === 1) {
+          reason = `isolated due to file conflicts with other issues`;
+        } else {
+          reason = `${issues.length} issues grouped as conflict-free subset (${args.strategy} strategy)`;
+        }
+        return {
+          number: idx + 1,
+          issues,
+          reason,
+        };
+      });
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              flights,
+              strategy_used: args.strategy,
+              conflict_count: conflicts.length,
+              total_issues: manifests.length,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default flightPartitionHandler;

--- a/tests/flight_partition.test.ts
+++ b/tests/flight_partition.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect } from 'bun:test';
+
+const { default: handler } = await import('../handlers/flight_partition.ts');
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('flight_partition handler', () => {
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('flight_partition');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('all_independent_single_flight — no conflicts → 1 flight with all issues', async () => {
+    const result = await handler.execute({
+      manifests: [
+        { issue_ref: '#1', files_to_create: ['a.ts'] },
+        { issue_ref: '#2', files_to_create: ['b.ts'] },
+        { issue_ref: '#3', files_to_create: ['c.ts'] },
+      ],
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.flights.length).toBe(1);
+    expect(parsed.flights[0].issues).toEqual(['#1', '#2', '#3']);
+    expect(parsed.flights[0].reason).toContain('conflict-free');
+  });
+
+  test('all_conflict_sequential_flights — every pair conflicts → 1 issue per flight', async () => {
+    const result = await handler.execute({
+      manifests: [
+        { issue_ref: '#1', files_to_modify: ['shared.ts'] },
+        { issue_ref: '#2', files_to_modify: ['shared.ts'] },
+        { issue_ref: '#3', files_to_modify: ['shared.ts'] },
+      ],
+    });
+    const parsed = parseResult(result);
+    expect(parsed.flights.length).toBe(3);
+    expect(parsed.flights.every((f: { issues: string[] }) => f.issues.length === 1)).toBe(true);
+    expect(parsed.conflict_count).toBe(3);
+  });
+
+  test('mixed_partitioning — partial conflict graph', async () => {
+    // #1 and #2 conflict on shared.ts, #3 is independent, #4 conflicts with #3
+    const result = await handler.execute({
+      manifests: [
+        { issue_ref: '#1', files_to_modify: ['shared.ts'] },
+        { issue_ref: '#2', files_to_modify: ['shared.ts'] },
+        { issue_ref: '#3', files_to_modify: ['other.ts'] },
+        { issue_ref: '#4', files_to_modify: ['other.ts'] },
+      ],
+    });
+    const parsed = parseResult(result);
+    // Greedy: #1 → flight 1; #2 conflicts → flight 2; #3 doesn't conflict with #1 → flight 1; #4 conflicts with #3 → flight 2
+    expect(parsed.flights.length).toBe(2);
+    expect(parsed.flights[0].issues).toContain('#1');
+    expect(parsed.flights[0].issues).toContain('#3');
+    expect(parsed.flights[1].issues).toContain('#2');
+    expect(parsed.flights[1].issues).toContain('#4');
+  });
+
+  test('empty_input_returns_empty', async () => {
+    const result = await handler.execute({ manifests: [] });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.flights).toEqual([]);
+    expect(parsed.conflict_count).toBe(0);
+  });
+
+  test('preserves_input_order_within_flights', async () => {
+    const result = await handler.execute({
+      manifests: [
+        { issue_ref: '#10', files_to_create: ['a.ts'] },
+        { issue_ref: '#3', files_to_create: ['b.ts'] },
+        { issue_ref: '#7', files_to_create: ['c.ts'] },
+      ],
+    });
+    const parsed = parseResult(result);
+    expect(parsed.flights[0].issues).toEqual(['#10', '#3', '#7']);
+  });
+
+  test('aggressive_strategy — currently equivalent to safe (v1)', async () => {
+    const result = await handler.execute({
+      manifests: [
+        { issue_ref: '#1', files_to_modify: ['a.ts'] },
+        { issue_ref: '#2', files_to_modify: ['a.ts'] },
+      ],
+      strategy: 'aggressive',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.strategy_used).toBe('aggressive');
+    expect(parsed.flights.length).toBe(2);
+  });
+
+  test('schema_validation — rejects invalid strategy', async () => {
+    const result = await handler.execute({
+      manifests: [],
+      strategy: 'yolo',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `flight_partition` — partitions issues into conflict-free flights using greedy graph coloring. Final story of Phase 1 Wave 4. Closes out the 34-tool migration scope.

## Changes

- `handlers/flight_partition.ts` — HandlerDef, schema: `manifests` array + optional `strategy` (safe/aggressive, default safe). Reuses lib/flight_overlap.
- `tests/flight_partition.test.ts` — all independent, all conflict, mixed partitioning, empty input, order preservation, aggressive strategy, schema validation.

## Linked Issues

Closes #38

## Test Plan

- [x] `./scripts/ci/validate.sh` green (435 tests + smoke)

This is the final story of Phase 1. After merge, tag v1.1.0 and ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)