### PR TITLE
feat(sdlc-mcp): pr_status handler

### DIFF
--- a/handlers/pr_status.ts
+++ b/handlers/pr_status.ts
@@ -1,0 +1,266 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  number: z.number().int().positive(),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+type State = 'open' | 'merged' | 'closed';
+type MergeState = 'clean' | 'unstable' | 'dirty' | 'blocked' | 'unknown';
+type ChecksSummary = 'all_passed' | 'has_failures' | 'pending' | 'none';
+
+interface ChecksAggregate {
+  total: number;
+  passed: number;
+  failed: number;
+  pending: number;
+  summary: ChecksSummary;
+}
+
+interface PrStatusResponse {
+  number: number;
+  state: State;
+  merge_state: MergeState;
+  mergeable: boolean;
+  checks: ChecksAggregate;
+  url: string;
+}
+
+function exec(cmd: string): string {
+  return execSync(cmd, { encoding: 'utf8' }).trim();
+}
+
+function detectPlatform(): 'github' | 'gitlab' {
+  try {
+    const url = exec('git remote get-url origin');
+    return url.includes('github') ? 'github' : 'gitlab';
+  } catch {
+    return 'github';
+  }
+}
+
+// --- GitHub normalization ---
+
+function normalizeGithubState(state: string): State {
+  const s = state.toUpperCase();
+  if (s === 'MERGED') return 'merged';
+  if (s === 'CLOSED') return 'closed';
+  return 'open';
+}
+
+function normalizeGithubMergeState(mergeStateStatus: string): MergeState {
+  const s = (mergeStateStatus || '').toUpperCase();
+  if (s === 'CLEAN') return 'clean';
+  if (s === 'UNSTABLE') return 'unstable';
+  if (s === 'DIRTY') return 'dirty';
+  if (s === 'BLOCKED') return 'blocked';
+  return 'unknown';
+}
+
+interface GithubCheck {
+  name?: string;
+  state?: string;
+  conclusion?: string | null;
+}
+
+function aggregateGithubChecks(checks: GithubCheck[]): ChecksAggregate {
+  let passed = 0;
+  let failed = 0;
+  let pending = 0;
+
+  for (const c of checks) {
+    const conclusion = (c.conclusion ?? '').toLowerCase();
+    const state = (c.state ?? '').toLowerCase();
+
+    if (conclusion === 'success' || state === 'success') {
+      passed += 1;
+    } else if (
+      conclusion === 'failure' ||
+      conclusion === 'cancelled' ||
+      conclusion === 'timed_out' ||
+      conclusion === 'action_required' ||
+      state === 'failure'
+    ) {
+      failed += 1;
+    } else {
+      // null conclusion, in_progress, queued, pending, etc.
+      pending += 1;
+    }
+  }
+
+  const total = checks.length;
+  let summary: ChecksSummary;
+  if (total === 0) {
+    summary = 'none';
+  } else if (failed > 0) {
+    summary = 'has_failures';
+  } else if (pending > 0) {
+    summary = 'pending';
+  } else {
+    summary = 'all_passed';
+  }
+
+  return { total, passed, failed, pending, summary };
+}
+
+function getGithubPrStatus(num: number): PrStatusResponse {
+  const rawPr = exec(
+    `gh pr view ${num} --json state,mergeStateStatus,mergeable,url`,
+  );
+  const pr = JSON.parse(rawPr) as {
+    state: string;
+    mergeStateStatus: string;
+    mergeable: string | boolean;
+    url: string;
+  };
+
+  const state = normalizeGithubState(pr.state);
+  const merge_state = normalizeGithubMergeState(pr.mergeStateStatus);
+  // GitHub `mergeable` comes back as "MERGEABLE" | "CONFLICTING" | "UNKNOWN" or bool.
+  const mergeableRaw =
+    typeof pr.mergeable === 'string' ? pr.mergeable.toUpperCase() : pr.mergeable;
+  const mergeable =
+    mergeableRaw === true || mergeableRaw === 'MERGEABLE' ? true : false;
+
+  let checks: ChecksAggregate = { total: 0, passed: 0, failed: 0, pending: 0, summary: 'none' };
+  try {
+    const rawChecks = exec(`gh pr checks ${num} --json name,state,conclusion`);
+    const parsed = JSON.parse(rawChecks) as GithubCheck[];
+    checks = aggregateGithubChecks(parsed);
+  } catch {
+    // No checks configured or command failed — leave as 'none'.
+  }
+
+  return {
+    number: num,
+    state,
+    merge_state,
+    mergeable,
+    checks,
+    url: pr.url,
+  };
+}
+
+// --- GitLab normalization ---
+
+function normalizeGitlabState(state: string): State {
+  const s = (state || '').toLowerCase();
+  if (s === 'merged') return 'merged';
+  if (s === 'closed') return 'closed';
+  return 'open';
+}
+
+function normalizeGitlabMergeState(
+  detailedMergeStatus: string | undefined,
+  mergeStatus: string | undefined,
+): MergeState {
+  const dm = (detailedMergeStatus || '').toLowerCase();
+  if (dm === 'mergeable') return 'clean';
+  if (dm === 'ci_still_running' || dm === 'checking') return 'unknown';
+  if (
+    dm === 'broken_status' ||
+    dm === 'conflict' ||
+    dm === 'ci_must_pass' ||
+    dm === 'discussions_not_resolved' ||
+    dm === 'draft_status' ||
+    dm === 'not_approved' ||
+    dm === 'blocked_status'
+  ) {
+    // conflicts are "dirty", other blockers are "blocked"
+    if (dm === 'conflict' || dm === 'broken_status') return 'dirty';
+    return 'blocked';
+  }
+  // Fall back to legacy `merge_status`: can_be_merged / cannot_be_merged / unchecked
+  const ms = (mergeStatus || '').toLowerCase();
+  if (ms === 'can_be_merged') return 'clean';
+  if (ms === 'cannot_be_merged') return 'dirty';
+  return 'unknown';
+}
+
+function aggregateGitlabPipeline(
+  pipelineStatus: string | undefined,
+): ChecksAggregate {
+  if (!pipelineStatus) {
+    return { total: 0, passed: 0, failed: 0, pending: 0, summary: 'none' };
+  }
+  const s = pipelineStatus.toLowerCase();
+  if (s === 'success') {
+    return { total: 1, passed: 1, failed: 0, pending: 0, summary: 'all_passed' };
+  }
+  if (s === 'failed' || s === 'canceled' || s === 'cancelled') {
+    return { total: 1, passed: 0, failed: 1, pending: 0, summary: 'has_failures' };
+  }
+  // running, pending, created, scheduled, preparing, waiting_for_resource, manual
+  return { total: 1, passed: 0, failed: 0, pending: 1, summary: 'pending' };
+}
+
+function getGitlabMrStatus(num: number): PrStatusResponse {
+  const raw = exec(`glab mr view ${num} --output json`);
+  const mr = JSON.parse(raw) as {
+    iid?: number;
+    state: string;
+    merge_status?: string;
+    detailed_merge_status?: string;
+    web_url: string;
+    pipeline?: { status?: string } | null;
+    head_pipeline?: { status?: string } | null;
+  };
+
+  const state = normalizeGitlabState(mr.state);
+  const merge_state = normalizeGitlabMergeState(mr.detailed_merge_status, mr.merge_status);
+  const mergeable = merge_state === 'clean';
+
+  const pipelineStatus = mr.pipeline?.status ?? mr.head_pipeline?.status;
+  const checks = aggregateGitlabPipeline(pipelineStatus);
+
+  return {
+    number: num,
+    state,
+    merge_state,
+    mergeable,
+    checks,
+    url: mr.web_url,
+  };
+}
+
+const prStatusHandler: HandlerDef = {
+  name: 'pr_status',
+  description:
+    'Get the current state of a PR/MR: open/merged/closed, merge state (clean/unstable/dirty/blocked/unknown), mergeable flag, and a summary of check runs. Used by /mmr to verify CI before merging.',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: Input;
+    try {
+      args = inputSchema.parse(rawArgs) as Input;
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const platform = detectPlatform();
+      const data =
+        platform === 'github'
+          ? getGithubPrStatus(args.number)
+          : getGitlabMrStatus(args.number);
+
+      return {
+        content: [
+          { type: 'text' as const, text: JSON.stringify({ ok: true, data }) },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default prStatusHandler;

--- a/tests/pr_status.test.ts
+++ b/tests/pr_status.test.ts
@@ -1,0 +1,382 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+// --- Mock child_process.execSync at module level ---
+// Registry-based mock so individual tests can register expected calls.
+
+let execRegistry: Array<{ match: string; value: string }> = [];
+let execError: Error | null = null;
+
+function mockExec(cmd: string): string {
+  if (execError) throw execError;
+  for (const { match, value } of execRegistry) {
+    if (cmd.includes(match)) return value;
+  }
+  throw new Error(`Unexpected exec call: ${cmd}`);
+}
+
+mock.module('child_process', () => ({
+  execSync: (cmd: string, _opts?: unknown) => mockExec(cmd),
+}));
+
+// Import AFTER the mock is registered
+const { default: prStatusHandler } = await import('../handlers/pr_status.ts');
+
+function parseResult(content: Array<{ type: string; text: string }>) {
+  return JSON.parse(content[0].text) as Record<string, unknown>;
+}
+
+function register(match: string, value: string) {
+  execRegistry.push({ match, value });
+}
+
+function registerGithubRemote() {
+  register('git remote get-url origin', 'https://github.com/Wave-Engineering/example.git');
+}
+
+function registerGitlabRemote() {
+  register('git remote get-url origin', 'https://gitlab.com/group/example.git');
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execError = null;
+});
+
+describe('pr_status handler', () => {
+  // --- input validation ---
+  test('invalid_input — missing number returns error', async () => {
+    const result = await prStatusHandler.execute({});
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+    expect(typeof data.error).toBe('string');
+  });
+
+  test('invalid_input — non-positive number returns error', async () => {
+    const result = await prStatusHandler.execute({ number: 0 });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+  });
+
+  test('invalid_input — non-integer number returns error', async () => {
+    const result = await prStatusHandler.execute({ number: 1.5 });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+  });
+
+  // --- GitHub paths ---
+
+  test('github_open_clean_all_checks_passed', async () => {
+    registerGithubRemote();
+    register(
+      'gh pr view 42 --json',
+      JSON.stringify({
+        state: 'OPEN',
+        mergeStateStatus: 'CLEAN',
+        mergeable: 'MERGEABLE',
+        url: 'https://github.com/Wave-Engineering/example/pull/42',
+      }),
+    );
+    register(
+      'gh pr checks 42',
+      JSON.stringify([
+        { name: 'validate', state: 'completed', conclusion: 'success' },
+        { name: 'lint', state: 'completed', conclusion: 'success' },
+      ]),
+    );
+
+    const result = await prStatusHandler.execute({ number: 42 });
+    const out = parseResult(result.content);
+    expect(out.ok).toBe(true);
+    const data = out.data as Record<string, unknown>;
+    expect(data.number).toBe(42);
+    expect(data.state).toBe('open');
+    expect(data.merge_state).toBe('clean');
+    expect(data.mergeable).toBe(true);
+    const checks = data.checks as Record<string, unknown>;
+    expect(checks.total).toBe(2);
+    expect(checks.passed).toBe(2);
+    expect(checks.failed).toBe(0);
+    expect(checks.pending).toBe(0);
+    expect(checks.summary).toBe('all_passed');
+    expect(data.url).toBe('https://github.com/Wave-Engineering/example/pull/42');
+  });
+
+  test('github_open_unstable_has_failures', async () => {
+    registerGithubRemote();
+    register(
+      'gh pr view 100 --json',
+      JSON.stringify({
+        state: 'OPEN',
+        mergeStateStatus: 'UNSTABLE',
+        mergeable: 'MERGEABLE',
+        url: 'https://github.com/Wave-Engineering/example/pull/100',
+      }),
+    );
+    register(
+      'gh pr checks 100',
+      JSON.stringify([
+        { name: 'validate', state: 'completed', conclusion: 'success' },
+        { name: 'flaky-test', state: 'completed', conclusion: 'failure' },
+      ]),
+    );
+
+    const result = await prStatusHandler.execute({ number: 100 });
+    const out = parseResult(result.content);
+    expect(out.ok).toBe(true);
+    const data = out.data as Record<string, unknown>;
+    expect(data.merge_state).toBe('unstable');
+    const checks = data.checks as Record<string, unknown>;
+    expect(checks.total).toBe(2);
+    expect(checks.passed).toBe(1);
+    expect(checks.failed).toBe(1);
+    expect(checks.summary).toBe('has_failures');
+  });
+
+  test('github_open_pending_checks', async () => {
+    registerGithubRemote();
+    register(
+      'gh pr view 7 --json',
+      JSON.stringify({
+        state: 'OPEN',
+        mergeStateStatus: 'BLOCKED',
+        mergeable: 'UNKNOWN',
+        url: 'https://github.com/Wave-Engineering/example/pull/7',
+      }),
+    );
+    register(
+      'gh pr checks 7',
+      JSON.stringify([
+        { name: 'validate', state: 'in_progress', conclusion: null },
+        { name: 'lint', state: 'completed', conclusion: 'success' },
+      ]),
+    );
+
+    const result = await prStatusHandler.execute({ number: 7 });
+    const out = parseResult(result.content);
+    const data = out.data as Record<string, unknown>;
+    expect(data.merge_state).toBe('blocked');
+    expect(data.mergeable).toBe(false);
+    const checks = data.checks as Record<string, unknown>;
+    expect(checks.passed).toBe(1);
+    expect(checks.pending).toBe(1);
+    expect(checks.summary).toBe('pending');
+  });
+
+  test('github_merged', async () => {
+    registerGithubRemote();
+    register(
+      'gh pr view 11 --json',
+      JSON.stringify({
+        state: 'MERGED',
+        mergeStateStatus: '',
+        mergeable: 'UNKNOWN',
+        url: 'https://github.com/Wave-Engineering/example/pull/11',
+      }),
+    );
+    register('gh pr checks 11', JSON.stringify([]));
+
+    const result = await prStatusHandler.execute({ number: 11 });
+    const out = parseResult(result.content);
+    const data = out.data as Record<string, unknown>;
+    expect(data.state).toBe('merged');
+    const checks = data.checks as Record<string, unknown>;
+    expect(checks.total).toBe(0);
+    expect(checks.summary).toBe('none');
+  });
+
+  test('github_closed', async () => {
+    registerGithubRemote();
+    register(
+      'gh pr view 22 --json',
+      JSON.stringify({
+        state: 'CLOSED',
+        mergeStateStatus: 'DIRTY',
+        mergeable: 'CONFLICTING',
+        url: 'https://github.com/Wave-Engineering/example/pull/22',
+      }),
+    );
+    register('gh pr checks 22', JSON.stringify([]));
+
+    const result = await prStatusHandler.execute({ number: 22 });
+    const out = parseResult(result.content);
+    const data = out.data as Record<string, unknown>;
+    expect(data.state).toBe('closed');
+    expect(data.merge_state).toBe('dirty');
+    expect(data.mergeable).toBe(false);
+  });
+
+  test('github_no_checks_command_failure_treated_as_none', async () => {
+    registerGithubRemote();
+    register(
+      'gh pr view 99 --json',
+      JSON.stringify({
+        state: 'OPEN',
+        mergeStateStatus: 'CLEAN',
+        mergeable: 'MERGEABLE',
+        url: 'https://github.com/Wave-Engineering/example/pull/99',
+      }),
+    );
+    // Intentionally do NOT register gh pr checks — the handler should catch and treat as 'none'
+
+    const result = await prStatusHandler.execute({ number: 99 });
+    const out = parseResult(result.content);
+    expect(out.ok).toBe(true);
+    const data = out.data as Record<string, unknown>;
+    expect(data.merge_state).toBe('clean');
+    const checks = data.checks as Record<string, unknown>;
+    expect(checks.total).toBe(0);
+    expect(checks.summary).toBe('none');
+  });
+
+  // --- GitLab paths ---
+
+  test('gitlab_open_clean_pipeline_success', async () => {
+    registerGitlabRemote();
+    register(
+      'glab mr view 5 --output json',
+      JSON.stringify({
+        iid: 5,
+        state: 'opened',
+        detailed_merge_status: 'mergeable',
+        merge_status: 'can_be_merged',
+        web_url: 'https://gitlab.com/group/example/-/merge_requests/5',
+        head_pipeline: { status: 'success' },
+      }),
+    );
+
+    const result = await prStatusHandler.execute({ number: 5 });
+    const out = parseResult(result.content);
+    expect(out.ok).toBe(true);
+    const data = out.data as Record<string, unknown>;
+    expect(data.state).toBe('open');
+    expect(data.merge_state).toBe('clean');
+    expect(data.mergeable).toBe(true);
+    const checks = data.checks as Record<string, unknown>;
+    expect(checks.total).toBe(1);
+    expect(checks.passed).toBe(1);
+    expect(checks.summary).toBe('all_passed');
+    expect(data.url).toBe('https://gitlab.com/group/example/-/merge_requests/5');
+  });
+
+  test('gitlab_open_failed_pipeline', async () => {
+    registerGitlabRemote();
+    register(
+      'glab mr view 6 --output json',
+      JSON.stringify({
+        iid: 6,
+        state: 'opened',
+        detailed_merge_status: 'ci_must_pass',
+        merge_status: 'cannot_be_merged',
+        web_url: 'https://gitlab.com/group/example/-/merge_requests/6',
+        head_pipeline: { status: 'failed' },
+      }),
+    );
+
+    const result = await prStatusHandler.execute({ number: 6 });
+    const out = parseResult(result.content);
+    const data = out.data as Record<string, unknown>;
+    expect(data.merge_state).toBe('blocked');
+    const checks = data.checks as Record<string, unknown>;
+    expect(checks.failed).toBe(1);
+    expect(checks.summary).toBe('has_failures');
+  });
+
+  test('gitlab_open_pending_pipeline', async () => {
+    registerGitlabRemote();
+    register(
+      'glab mr view 8 --output json',
+      JSON.stringify({
+        iid: 8,
+        state: 'opened',
+        detailed_merge_status: 'ci_still_running',
+        merge_status: 'unchecked',
+        web_url: 'https://gitlab.com/group/example/-/merge_requests/8',
+        pipeline: { status: 'running' },
+      }),
+    );
+
+    const result = await prStatusHandler.execute({ number: 8 });
+    const out = parseResult(result.content);
+    const data = out.data as Record<string, unknown>;
+    expect(data.merge_state).toBe('unknown');
+    const checks = data.checks as Record<string, unknown>;
+    expect(checks.pending).toBe(1);
+    expect(checks.summary).toBe('pending');
+  });
+
+  test('gitlab_merged', async () => {
+    registerGitlabRemote();
+    register(
+      'glab mr view 12 --output json',
+      JSON.stringify({
+        iid: 12,
+        state: 'merged',
+        detailed_merge_status: 'mergeable',
+        merge_status: 'can_be_merged',
+        web_url: 'https://gitlab.com/group/example/-/merge_requests/12',
+        head_pipeline: null,
+      }),
+    );
+
+    const result = await prStatusHandler.execute({ number: 12 });
+    const out = parseResult(result.content);
+    const data = out.data as Record<string, unknown>;
+    expect(data.state).toBe('merged');
+    const checks = data.checks as Record<string, unknown>;
+    expect(checks.total).toBe(0);
+    expect(checks.summary).toBe('none');
+  });
+
+  test('gitlab_closed', async () => {
+    registerGitlabRemote();
+    register(
+      'glab mr view 33 --output json',
+      JSON.stringify({
+        iid: 33,
+        state: 'closed',
+        detailed_merge_status: 'conflict',
+        merge_status: 'cannot_be_merged',
+        web_url: 'https://gitlab.com/group/example/-/merge_requests/33',
+      }),
+    );
+
+    const result = await prStatusHandler.execute({ number: 33 });
+    const out = parseResult(result.content);
+    const data = out.data as Record<string, unknown>;
+    expect(data.state).toBe('closed');
+    expect(data.merge_state).toBe('dirty');
+    expect(data.mergeable).toBe(false);
+  });
+
+  test('gitlab_legacy_merge_status_fallback', async () => {
+    registerGitlabRemote();
+    register(
+      'glab mr view 44 --output json',
+      JSON.stringify({
+        iid: 44,
+        state: 'opened',
+        // No detailed_merge_status — old GitLab API
+        merge_status: 'can_be_merged',
+        web_url: 'https://gitlab.com/group/example/-/merge_requests/44',
+      }),
+    );
+
+    const result = await prStatusHandler.execute({ number: 44 });
+    const out = parseResult(result.content);
+    const data = out.data as Record<string, unknown>;
+    expect(data.merge_state).toBe('clean');
+    expect(data.mergeable).toBe(true);
+  });
+
+  // --- Error path ---
+
+  test('exec_failure_surfaces_as_ok_false', async () => {
+    registerGithubRemote();
+    execError = new Error('command failed: gh: not found');
+
+    const result = await prStatusHandler.execute({ number: 1 });
+    const out = parseResult(result.content);
+    expect(out.ok).toBe(false);
+    expect(typeof out.error).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary

Add `pr_status` MCP tool returning the current state of a PR/MR (open/merged/closed), merge state (clean/unstable/dirty/blocked/unknown), mergeable flag, and a summary of check runs. Aggregates GitHub's per-check array and GitLab's pipeline status into a unified `checks` shape with summary classifier.

## Changes

- Add the new handler file (auto-discovered by codegen registry)
- Add unit tests covering both GitHub and GitLab paths plus error cases

## Linked Issues

Closes #77

## Test Plan

- [x] `./scripts/ci/validate.sh` passes (codegen, tsc, shellcheck, all tests, runtime smoke)
- [x] New handler appears in `tools/list` via the registry codegen
- [x] Both GitHub and GitLab code paths covered by unit tests
- [x] Error paths return `{ok: false, error}` envelope consistently with the codebase

Generated with [Claude Code](https://claude.com/claude-code)
