### PR TITLE
feat(sdlc-mcp): pr_wait_ci handler — server-side check polling

### DIFF
--- a/handlers/pr_wait_ci.ts
+++ b/handlers/pr_wait_ci.ts
@@ -1,0 +1,316 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z
+  .object({
+    number: z.number().int().positive(),
+    poll_interval_sec: z.number().int().optional().default(30),
+    timeout_sec: z.number().int().positive().optional().default(1800),
+  })
+  .strict();
+
+type Input = z.infer<typeof inputSchema>;
+
+export type CheckBucket = 'pass' | 'fail' | 'pending' | 'skipping' | 'cancel';
+
+export interface ChecksSnapshot {
+  total: number;
+  passed: number;
+  failed: number;
+  pending: number;
+  summary: string;
+  url: string;
+}
+
+type FinalState = 'passed' | 'failed' | 'timed_out';
+
+const POLL_FLOOR_SEC = 5;
+
+function exec(cmd: string): string {
+  return execSync(cmd, { encoding: 'utf8' }).trim();
+}
+
+function detectPlatform(): 'github' | 'gitlab' {
+  try {
+    const url = exec('git remote get-url origin');
+    return url.includes('gitlab') ? 'gitlab' : 'github';
+  } catch {
+    return 'github';
+  }
+}
+
+interface GithubCheck {
+  name?: string;
+  bucket?: string;
+  state?: string;
+}
+
+function snapshotGithub(number: number): ChecksSnapshot {
+  const raw = exec(`gh pr checks ${number} --json name,bucket,state`);
+  const checks = JSON.parse(raw) as GithubCheck[];
+
+  let passed = 0;
+  let failed = 0;
+  let pending = 0;
+  for (const c of checks) {
+    const b = (c.bucket ?? '').toLowerCase();
+    if (b === 'pass') passed++;
+    else if (b === 'fail' || b === 'cancel') failed++;
+    else if (b === 'pending') pending++;
+    // 'skipping' is not counted against any bucket
+  }
+
+  const urlRaw = (() => {
+    try {
+      return exec(`gh pr view ${number} --json url`);
+    } catch {
+      return '{"url":""}';
+    }
+  })();
+  const url = (JSON.parse(urlRaw) as { url?: string }).url ?? '';
+
+  const total = checks.length;
+  return {
+    total,
+    passed,
+    failed,
+    pending,
+    summary: `${passed}/${total} passed, ${failed} failed, ${pending} pending`,
+    url,
+  };
+}
+
+interface GitlabPipeline {
+  status?: string;
+}
+
+interface GitlabMr {
+  web_url?: string;
+  head_pipeline?: GitlabPipeline;
+  pipeline?: GitlabPipeline;
+}
+
+function snapshotGitlab(number: number): ChecksSnapshot {
+  const raw = exec(`glab mr view ${number} --output json`);
+  const mr = JSON.parse(raw) as GitlabMr;
+  const status = (
+    mr.head_pipeline?.status ??
+    mr.pipeline?.status ??
+    'unknown'
+  ).toLowerCase();
+  const url = mr.web_url ?? '';
+
+  // GitLab reports a single pipeline status; treat it as a single aggregated
+  // "check" for accounting purposes so the counts schema stays consistent.
+  let passed = 0;
+  let failed = 0;
+  let pending = 0;
+  if (status === 'success') passed = 1;
+  else if (
+    status === 'failed' ||
+    status === 'canceled' ||
+    status === 'cancelled'
+  )
+    failed = 1;
+  else if (
+    status === 'running' ||
+    status === 'pending' ||
+    status === 'created' ||
+    status === 'preparing' ||
+    status === 'waiting_for_resource' ||
+    status === 'scheduled' ||
+    status === 'manual'
+  )
+    pending = 1;
+
+  return {
+    total: passed + failed + pending,
+    passed,
+    failed,
+    pending,
+    summary: `pipeline ${status}`,
+    url,
+  };
+}
+
+function snapshotChecks(number: number): ChecksSnapshot {
+  const platform = detectPlatform();
+  return platform === 'gitlab' ? snapshotGitlab(number) : snapshotGithub(number);
+}
+
+function decide(snap: ChecksSnapshot): FinalState | null {
+  if (snap.failed > 0) return 'failed';
+  if (snap.total > 0 && snap.pending === 0 && snap.passed >= 1) return 'passed';
+  return null;
+}
+
+function logCycle(number: number, elapsedSec: number, snap: ChecksSnapshot) {
+  // stderr only — never stdout (would corrupt MCP protocol).
+  process.stderr.write(
+    `[pr_wait_ci] #${number} t=${elapsedSec}s pending=${snap.pending}/${snap.total}\n`,
+  );
+}
+
+// Injection seam for tests — swap sleep + snapshot without touching real time/net.
+interface Deps {
+  snapshotFn: (number: number) => ChecksSnapshot;
+  sleepFn: (ms: number) => Promise<void>;
+  nowFn: () => number;
+}
+
+const defaultDeps: Deps = {
+  snapshotFn: snapshotChecks,
+  sleepFn: (ms: number) => new Promise((r) => setTimeout(r, ms)),
+  nowFn: () => Date.now(),
+};
+
+export async function runPollLoop(
+  args: Input,
+  deps: Deps = defaultDeps,
+): Promise<{
+  ok: true;
+  number: number;
+  final_state: FinalState;
+  checks: { total: number; passed: number; failed: number; pending: number; summary: string };
+  waited_sec: number;
+  url: string;
+}> {
+  const intervalMs = args.poll_interval_sec * 1000;
+  const timeoutMs = args.timeout_sec * 1000;
+  const start = deps.nowFn();
+
+  let lastSnap: ChecksSnapshot = {
+    total: 0,
+    passed: 0,
+    failed: 0,
+    pending: 0,
+    summary: 'no checks observed',
+    url: '',
+  };
+
+  // Loop: snapshot → decide → (sleep | return). Timeout is checked after each
+  // snapshot AND before each sleep so we can't over-shoot by a full interval.
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    lastSnap = deps.snapshotFn(args.number);
+    const elapsedSec = Math.floor((deps.nowFn() - start) / 1000);
+    logCycle(args.number, elapsedSec, lastSnap);
+
+    const decision = decide(lastSnap);
+    if (decision) {
+      return {
+        ok: true,
+        number: args.number,
+        final_state: decision,
+        checks: {
+          total: lastSnap.total,
+          passed: lastSnap.passed,
+          failed: lastSnap.failed,
+          pending: lastSnap.pending,
+          summary: lastSnap.summary,
+        },
+        waited_sec: elapsedSec,
+        url: lastSnap.url,
+      };
+    }
+
+    if (deps.nowFn() - start >= timeoutMs) {
+      return {
+        ok: true,
+        number: args.number,
+        final_state: 'timed_out',
+        checks: {
+          total: lastSnap.total,
+          passed: lastSnap.passed,
+          failed: lastSnap.failed,
+          pending: lastSnap.pending,
+          summary: lastSnap.summary,
+        },
+        waited_sec: Math.floor((deps.nowFn() - start) / 1000),
+        url: lastSnap.url,
+      };
+    }
+
+    await deps.sleepFn(intervalMs);
+
+    // Re-check timeout after sleep in case we slept past the deadline.
+    if (deps.nowFn() - start >= timeoutMs) {
+      lastSnap = deps.snapshotFn(args.number);
+      const finalElapsed = Math.floor((deps.nowFn() - start) / 1000);
+      logCycle(args.number, finalElapsed, lastSnap);
+      const postDecision = decide(lastSnap);
+      return {
+        ok: true,
+        number: args.number,
+        final_state: postDecision ?? 'timed_out',
+        checks: {
+          total: lastSnap.total,
+          passed: lastSnap.passed,
+          failed: lastSnap.failed,
+          pending: lastSnap.pending,
+          summary: lastSnap.summary,
+        },
+        waited_sec: finalElapsed,
+        url: lastSnap.url,
+      };
+    }
+  }
+}
+
+// Exposed for tests that want to drive the loop with injected deps.
+export async function __runWithDeps(rawArgs: unknown, deps: Deps) {
+  const args = inputSchema.parse(rawArgs) as Input;
+  if (args.poll_interval_sec < POLL_FLOOR_SEC) {
+    throw new Error(
+      `poll_interval_sec must be >= ${POLL_FLOOR_SEC} (got ${args.poll_interval_sec})`,
+    );
+  }
+  return runPollLoop(args, deps);
+}
+
+const prWaitCiHandler: HandlerDef = {
+  name: 'pr_wait_ci',
+  description:
+    "Block until a PR/MR's check runs complete. Server-side polling with configurable interval (default 30s, min 5s) and timeout (default 1800s). Returns passed | failed | timed_out.",
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: Input;
+    try {
+      args = inputSchema.parse(rawArgs) as Input;
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    if (args.poll_interval_sec < POLL_FLOOR_SEC) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: false,
+              error: `poll_interval_sec must be >= ${POLL_FLOOR_SEC} (got ${args.poll_interval_sec})`,
+            }),
+          },
+        ],
+      };
+    }
+
+    try {
+      const result = await runPollLoop(args);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default prWaitCiHandler;

--- a/tests/pr_wait_ci.test.ts
+++ b/tests/pr_wait_ci.test.ts
@@ -1,0 +1,266 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+// --- Mock child_process for the real-deps path (execute) ---------------------
+
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string, _opts?: unknown) => execMockFn(cmd));
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+// Import AFTER the module mock is registered.
+import type { ChecksSnapshot } from '../handlers/pr_wait_ci.ts';
+const mod = await import('../handlers/pr_wait_ci.ts');
+const handler = mod.default;
+const runWithDeps = mod.__runWithDeps;
+
+beforeEach(() => {
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+});
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text) as Record<string, unknown>;
+}
+
+// Virtual clock + scripted snapshot sequence for deterministic loop tests.
+function makeDeps(sequence: ChecksSnapshot[], intervalSec: number) {
+  let now = 0;
+  let idx = 0;
+  const snapshotCalls: number[] = [];
+  const sleepCalls: number[] = [];
+
+  const deps = {
+    snapshotFn: (_n: number) => {
+      snapshotCalls.push(now);
+      // Last element sticks if we run past the script end.
+      const snap = sequence[Math.min(idx, sequence.length - 1)];
+      idx++;
+      return snap;
+    },
+    sleepFn: async (ms: number) => {
+      sleepCalls.push(ms);
+      now += ms;
+    },
+    nowFn: () => now,
+  };
+
+  return { deps, snapshotCalls, sleepCalls, getNow: () => now, intervalSec };
+}
+
+function snap(
+  partial: Partial<ChecksSnapshot> & { total: number },
+): ChecksSnapshot {
+  return {
+    passed: 0,
+    failed: 0,
+    pending: 0,
+    summary: 'test',
+    url: 'https://example/pr/1',
+    ...partial,
+  };
+}
+
+describe('pr_wait_ci handler', () => {
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('pr_wait_ci');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('passed — all checks succeed after two polls', async () => {
+    const { deps, snapshotCalls, sleepCalls } = makeDeps(
+      [
+        snap({ total: 3, passed: 1, pending: 2 }),
+        snap({ total: 3, passed: 2, pending: 1 }),
+        snap({ total: 3, passed: 3, pending: 0, summary: '3/3 passed' }),
+      ],
+      5,
+    );
+
+    const result = await runWithDeps(
+      { number: 42, poll_interval_sec: 5, timeout_sec: 600 },
+      deps,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.final_state).toBe('passed');
+    expect(result.number).toBe(42);
+    expect(result.checks.total).toBe(3);
+    expect(result.checks.passed).toBe(3);
+    expect(result.checks.pending).toBe(0);
+    expect(snapshotCalls.length).toBe(3);
+    expect(sleepCalls.length).toBe(2); // slept twice between the 3 snapshots
+    expect(sleepCalls.every((ms) => ms === 5000)).toBe(true);
+  });
+
+  test('failed — any failing check terminates immediately', async () => {
+    const { deps, snapshotCalls } = makeDeps(
+      [
+        snap({ total: 5, passed: 1, pending: 4 }),
+        // Second poll: one check went red while others still pending.
+        // Must NOT wait for others to finish.
+        snap({ total: 5, passed: 1, failed: 1, pending: 3 }),
+        // This should never be consumed.
+        snap({ total: 5, passed: 5, pending: 0 }),
+      ],
+      5,
+    );
+
+    const result = await runWithDeps(
+      { number: 7, poll_interval_sec: 5, timeout_sec: 600 },
+      deps,
+    );
+
+    expect(result.final_state).toBe('failed');
+    expect(result.checks.failed).toBe(1);
+    expect(result.checks.pending).toBe(3); // proves we didn't wait
+    expect(snapshotCalls.length).toBe(2);
+  });
+
+  test('timed_out — loop exits when elapsed > timeout', async () => {
+    // Every snapshot stays pending forever.
+    const stuck = snap({ total: 2, passed: 0, pending: 2 });
+    const { deps, snapshotCalls } = makeDeps([stuck], 5);
+
+    const result = await runWithDeps(
+      { number: 99, poll_interval_sec: 5, timeout_sec: 15 },
+      deps,
+    );
+
+    expect(result.final_state).toBe('timed_out');
+    expect(result.checks.pending).toBe(2);
+    expect(result.waited_sec).toBeGreaterThanOrEqual(15);
+    // With a 15s budget and 5s interval, we expect ~3-4 snapshots.
+    expect(snapshotCalls.length).toBeGreaterThanOrEqual(3);
+    expect(snapshotCalls.length).toBeLessThanOrEqual(5);
+  });
+
+  test('poll_interval_sec hard floor — rejects values below 5', async () => {
+    const result = await handler.execute({
+      number: 1,
+      poll_interval_sec: 2,
+      timeout_sec: 60,
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+    expect((data.error as string)).toContain('>= 5');
+  });
+
+  test('poll_interval_sec at floor (5s) is accepted', async () => {
+    const { deps } = makeDeps(
+      [snap({ total: 1, passed: 1, pending: 0 })],
+      5,
+    );
+
+    const result = await runWithDeps(
+      { number: 1, poll_interval_sec: 5, timeout_sec: 60 },
+      deps,
+    );
+    expect(result.final_state).toBe('passed');
+  });
+
+  test('defaults — poll_interval_sec=30 and timeout_sec=1800 when omitted', async () => {
+    // Just validate the schema passes and uses defaults via runWithDeps.
+    const { deps, sleepCalls } = makeDeps(
+      [
+        snap({ total: 1, passed: 0, pending: 1 }),
+        snap({ total: 1, passed: 1, pending: 0 }),
+      ],
+      30,
+    );
+
+    const result = await runWithDeps({ number: 1 }, deps);
+    expect(result.final_state).toBe('passed');
+    expect(sleepCalls[0]).toBe(30_000);
+  });
+
+  test('schema_validation — rejects unknown fields', async () => {
+    const result = await handler.execute({ number: 1, foo: 'bar' });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+  });
+
+  test('schema_validation — requires number', async () => {
+    const result = await handler.execute({});
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+  });
+
+  test('execute — end-to-end with mocked execSync (github pass path)', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote'))
+        return 'https://github.com/org/repo.git\n';
+      if (cmd.startsWith('gh pr checks'))
+        return JSON.stringify([
+          { name: 'build', bucket: 'pass', state: 'SUCCESS' },
+          { name: 'test', bucket: 'pass', state: 'SUCCESS' },
+        ]);
+      if (cmd.startsWith('gh pr view'))
+        return JSON.stringify({ url: 'https://github.com/org/repo/pull/5' });
+      throw new Error(`unexpected exec: ${cmd}`);
+    };
+
+    // Use a very small timeout; the very first snapshot should return passed.
+    const result = await handler.execute({
+      number: 5,
+      poll_interval_sec: 5,
+      timeout_sec: 10,
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(data.final_state).toBe('passed');
+    expect(data.url).toBe('https://github.com/org/repo/pull/5');
+    const checks = data.checks as Record<string, number | string>;
+    expect(checks.passed).toBe(2);
+    expect(checks.failed).toBe(0);
+  });
+
+  test('execute — end-to-end with mocked execSync (github fail path)', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote'))
+        return 'https://github.com/org/repo.git\n';
+      if (cmd.startsWith('gh pr checks'))
+        return JSON.stringify([
+          { name: 'build', bucket: 'pass' },
+          { name: 'lint', bucket: 'fail' },
+          { name: 'test', bucket: 'pending' },
+        ]);
+      if (cmd.startsWith('gh pr view'))
+        return JSON.stringify({ url: 'https://github.com/org/repo/pull/9' });
+      throw new Error(`unexpected exec: ${cmd}`);
+    };
+
+    const result = await handler.execute({
+      number: 9,
+      poll_interval_sec: 5,
+      timeout_sec: 10,
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(data.final_state).toBe('failed');
+    const checks = data.checks as Record<string, number>;
+    expect(checks.failed).toBe(1);
+    expect(checks.pending).toBe(1); // proves early termination preserved state
+  });
+
+  test('execute — gitlab mr with successful pipeline', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote'))
+        return 'https://gitlab.com/org/repo.git\n';
+      if (cmd.startsWith('glab mr view'))
+        return JSON.stringify({
+          web_url: 'https://gitlab.com/org/repo/-/merge_requests/3',
+          head_pipeline: { status: 'success' },
+        });
+      throw new Error(`unexpected exec: ${cmd}`);
+    };
+
+    const result = await handler.execute({
+      number: 3,
+      poll_interval_sec: 5,
+      timeout_sec: 10,
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(data.final_state).toBe('passed');
+    expect(data.url).toBe('https://gitlab.com/org/repo/-/merge_requests/3');
+  });
+});


### PR DESCRIPTION
## Summary

Add `pr_wait_ci` MCP tool that blocks until a PR's own check runs complete. Server-side polling at default 30s interval (configurable, hard floor 5s), default timeout 30 minutes. Returns final state passed/failed/timed_out plus checks summary. Replaces agent-side busy-wait loops.

## Changes

- Add the new handler file (auto-discovered by codegen registry)
- Add unit tests covering both GitHub and GitLab paths plus error cases

## Linked Issues

Closes #78

## Test Plan

- [x] `./scripts/ci/validate.sh` passes (codegen, tsc, shellcheck, all tests, runtime smoke)
- [x] New handler appears in `tools/list` via the registry codegen
- [x] Both GitHub and GitLab code paths covered by unit tests
- [x] Error paths return `{ok: false, error}` envelope consistently with the codebase

Generated with [Claude Code](https://claude.com/claude-code)
