### PR TITLE
feat(sdlc-mcp): pr_merge handler with merge-queue fallback

### DIFF
--- a/handlers/pr_merge.ts
+++ b/handlers/pr_merge.ts
@@ -1,0 +1,307 @@
+import { execSync } from 'child_process';
+import { writeFileSync } from 'fs';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+// Codebase convention: child_process.execSync (29/36 handlers). Tests mock it
+// via `mock.module('child_process', ...)` — see tests/pr_merge.test.ts.
+//
+// Multi-line squash messages: we write them to a temp file and pass the path
+// via --body-file / --squash-message-file (no shell newline escaping needed).
+// Short single-line messages go inline via --body / --squash-message with the
+// arg value quoted.
+
+const inputSchema = z.object({
+  number: z.number().int().positive('number must be a positive integer'),
+  squash_message: z.string().optional(),
+  use_merge_queue: z.boolean().optional(),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+interface ExecError extends Error {
+  stdout?: Buffer | string;
+  stderr?: Buffer | string;
+  status?: number;
+}
+
+interface FailureInfo {
+  message: string;
+  stderr: string;
+}
+
+function bufToString(b: unknown): string {
+  if (b === undefined || b === null) return '';
+  if (typeof b === 'string') return b;
+  if (typeof (b as Buffer).toString === 'function') return (b as Buffer).toString();
+  return String(b);
+}
+
+/**
+ * Extract a failure message + stderr from a thrown exec error. Both real
+ * `execSync` errors (Buffer stderr) and test mocks (plain Error) are handled.
+ */
+function extractFailure(err: unknown): FailureInfo {
+  if (err instanceof Error) {
+    const e = err as ExecError;
+    const stderr = bufToString(e.stderr);
+    const stdout = bufToString(e.stdout);
+    const message = stderr.trim() || stdout.trim() || err.message;
+    // When tests mock by throwing new Error('...merge queue...'), stderr is
+    // empty but the merge-queue phrase lives in err.message. Fall back to
+    // err.message so the merge-queue detector can see it.
+    return { message, stderr: stderr || err.message };
+  }
+  const text = String(err);
+  return { message: text, stderr: text };
+}
+
+/**
+ * Heuristic for detecting GitHub merge-queue enforcement. Phrasings seen in
+ * the wild include:
+ *   - "merge strategy for main is set by the merge queue"
+ *   - "the merge queue is required"
+ *   - "changes must be made through a merge queue"
+ * We match case-insensitively on "merge queue" to tolerate phrasing drift.
+ */
+function stderrIndicatesMergeQueue(text: string): boolean {
+  return /merge\s*queue/i.test(text);
+}
+
+function exec(cmd: string): string {
+  return execSync(cmd, { encoding: 'utf8' });
+}
+
+function detectPlatform(): 'github' | 'gitlab' {
+  try {
+    const url = exec('git remote get-url origin').trim();
+    return url.includes('gitlab') ? 'gitlab' : 'github';
+  } catch {
+    return 'github';
+  }
+}
+
+/**
+ * Escape a value for safe inclusion inside a single-quoted shell argument.
+ * Used only for single-line squash messages; multi-line messages go via file.
+ */
+function shellEscape(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function writeTempMessageFile(message: string): string {
+  // /tmp is cleaned by the OS; we intentionally do not delete the file so
+  // we can stay within the fs-module surface already mocked by sibling tests
+  // (writeFileSync only).
+  const path = `/tmp/pr-merge-msg-${Date.now()}-${Math.floor(Math.random() * 1e6)}.txt`;
+  writeFileSync(path, message);
+  return path;
+}
+
+function buildGithubMergeCommand(
+  number: number,
+  auto: boolean,
+  squashMessage?: string,
+): string {
+  const parts = ['gh', 'pr', 'merge', String(number), '--squash', '--delete-branch'];
+  if (auto) parts.push('--auto');
+  if (squashMessage !== undefined && squashMessage.length > 0) {
+    if (squashMessage.includes('\n')) {
+      // Multi-line body: write to a temp file and pass via --body-file.
+      const tempFile = writeTempMessageFile(squashMessage);
+      parts.push('--body-file', shellEscape(tempFile));
+    } else {
+      parts.push('--body', shellEscape(squashMessage));
+    }
+  }
+  return parts.join(' ');
+}
+
+function buildGitlabMergeCommand(number: number, squashMessage?: string): string {
+  const parts = [
+    'glab',
+    'mr',
+    'merge',
+    String(number),
+    '--squash',
+    '--remove-source-branch',
+    '--yes',
+  ];
+  if (squashMessage !== undefined && squashMessage.length > 0) {
+    // glab exposes --squash-message (inline only). Single-quoted args
+    // preserve newlines in POSIX shells.
+    parts.push('--squash-message', shellEscape(squashMessage));
+  }
+  return parts.join(' ');
+}
+
+interface GithubPrViewResponse {
+  mergeCommit?: { oid?: string } | null;
+  url?: string;
+}
+
+function fetchGithubPrMergeInfo(number: number): { url: string; merge_commit_sha?: string } {
+  const raw = exec(`gh pr view ${number} --json mergeCommit,url`);
+  const parsed = JSON.parse(raw) as GithubPrViewResponse;
+  return {
+    url: parsed.url ?? '',
+    merge_commit_sha: parsed.mergeCommit?.oid,
+  };
+}
+
+function fetchGithubPrUrl(number: number): string {
+  const raw = exec(`gh pr view ${number} --json url`);
+  const parsed = JSON.parse(raw) as { url?: string };
+  return parsed.url ?? '';
+}
+
+interface GitlabMrViewResponse {
+  web_url?: string;
+  merge_commit_sha?: string;
+}
+
+function fetchGitlabMrMergeInfo(number: number): { url: string; merge_commit_sha?: string } {
+  const raw = exec(`glab mr view ${number} --output json`);
+  const parsed = JSON.parse(raw) as GitlabMrViewResponse;
+  return {
+    url: parsed.web_url ?? '',
+    merge_commit_sha: parsed.merge_commit_sha,
+  };
+}
+
+interface MergeSuccess {
+  ok: true;
+  number: number;
+  merged: boolean;
+  merge_method: 'direct_squash' | 'merge_queue';
+  url: string;
+  merge_commit_sha?: string;
+  queue_position?: number;
+}
+
+interface MergeFailure {
+  ok: false;
+  error: string;
+}
+
+function mergeGithub(args: Input): MergeSuccess | MergeFailure {
+  // Forced merge-queue path.
+  if (args.use_merge_queue === true) {
+    const cmd = buildGithubMergeCommand(args.number, true, args.squash_message);
+    try {
+      exec(cmd);
+    } catch (err) {
+      const fail = extractFailure(err);
+      return {
+        ok: false,
+        error: `gh pr merge --auto failed: ${fail.message}`,
+      };
+    }
+    const url = fetchGithubPrUrl(args.number);
+    return {
+      ok: true,
+      number: args.number,
+      merged: true,
+      merge_method: 'merge_queue',
+      url,
+    };
+  }
+
+  // Default: direct-squash first, fall back to --auto on merge-queue rejection.
+  const directCmd = buildGithubMergeCommand(args.number, false, args.squash_message);
+  try {
+    exec(directCmd);
+    const info = fetchGithubPrMergeInfo(args.number);
+    return {
+      ok: true,
+      number: args.number,
+      merged: true,
+      merge_method: 'direct_squash',
+      url: info.url,
+      merge_commit_sha: info.merge_commit_sha,
+    };
+  } catch (err) {
+    const fail = extractFailure(err);
+    if (!stderrIndicatesMergeQueue(fail.stderr) && !stderrIndicatesMergeQueue(fail.message)) {
+      return {
+        ok: false,
+        error: `gh pr merge failed: ${fail.message}`,
+      };
+    }
+  }
+
+  // Merge-queue fallback.
+  const autoCmd = buildGithubMergeCommand(args.number, true, args.squash_message);
+  try {
+    exec(autoCmd);
+  } catch (err) {
+    const fail = extractFailure(err);
+    return {
+      ok: false,
+      error: `gh pr merge --auto failed after merge-queue fallback: ${fail.message}`,
+    };
+  }
+  const url = fetchGithubPrUrl(args.number);
+  return {
+    ok: true,
+    number: args.number,
+    merged: true,
+    merge_method: 'merge_queue',
+    url,
+  };
+}
+
+function mergeGitlab(args: Input): MergeSuccess | MergeFailure {
+  // GitLab has no merge-queue concept; always direct.
+  const cmd = buildGitlabMergeCommand(args.number, args.squash_message);
+  try {
+    exec(cmd);
+  } catch (err) {
+    return {
+      ok: false,
+      error: `glab mr merge failed: ${extractFailure(err).message}`,
+    };
+  }
+  const info = fetchGitlabMrMergeInfo(args.number);
+  return {
+    ok: true,
+    number: args.number,
+    merged: true,
+    merge_method: 'direct_squash',
+    url: info.url,
+    merge_commit_sha: info.merge_commit_sha,
+  };
+}
+
+const prMergeHandler: HandlerDef = {
+  name: 'pr_merge',
+  description:
+    'Merge a PR/MR with squash + delete source branch. Auto-detects merge-queue enforcement on GitHub and falls back to --auto mode. Supports custom multi-line squash messages.',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: Input;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const platform = detectPlatform();
+      const result = platform === 'github' ? mergeGithub(args) : mergeGitlab(args);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default prMergeHandler;

--- a/tests/pr_merge.test.ts
+++ b/tests/pr_merge.test.ts
@@ -1,0 +1,334 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+// Intercept execSync via a registry keyed by command substring.
+// Each value may be a plain string (returned as stdout) or a function that
+// throws an Error (simulating a non-zero exit). Tests can attach `stderr` to
+// the thrown error to mimic real execSync behavior.
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+type Responder = string | (() => string);
+
+let execRegistry: Array<{ match: string; respond: Responder }> = [];
+let execCalls: string[] = [];
+
+function mockExec(cmd: string): string {
+  execCalls.push(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  throw new Error(`Unexpected exec call: ${cmd}`);
+}
+
+mock.module('child_process', () => ({
+  execSync: (cmd: string, _opts?: unknown) => mockExec(cmd),
+}));
+
+// Import AFTER the mock is registered.
+const { default: prMergeHandler } = await import('../handlers/pr_merge.ts');
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text) as Record<string, unknown>;
+}
+
+function onExec(match: string, respond: Responder) {
+  execRegistry.push({ match, respond });
+}
+
+function mergeQueueError(): ThrowableError {
+  const err = new Error(
+    'failed to run git: merge strategy for main is set by the merge queue',
+  ) as ThrowableError;
+  err.stderr =
+    'failed to run git: merge strategy for main is set by the merge queue\n';
+  return err;
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+afterEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('pr_merge handler', () => {
+  test('handler exports valid HandlerDef shape', () => {
+    expect(prMergeHandler.name).toBe('pr_merge');
+    expect(typeof prMergeHandler.execute).toBe('function');
+  });
+
+  // --- schema validation ---
+  test('invalid input — missing number returns schema error', async () => {
+    const result = await prMergeHandler.execute({});
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+    expect((data.error as string).length).toBeGreaterThan(0);
+  });
+
+  test('invalid input — negative number rejected', async () => {
+    const result = await prMergeHandler.execute({ number: -1 });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+  });
+
+  // --- github direct success ---
+  test('github direct squash — success path returns direct_squash + merge_commit_sha', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    onExec('gh pr merge 42 --squash --delete-branch', '');
+    onExec(
+      'gh pr view 42 --json mergeCommit,url',
+      JSON.stringify({
+        mergeCommit: { oid: 'abc123def456' },
+        url: 'https://github.com/org/repo/pull/42',
+      }),
+    );
+
+    const result = await prMergeHandler.execute({ number: 42 });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.number).toBe(42);
+    expect(data.merged).toBe(true);
+    expect(data.merge_method).toBe('direct_squash');
+    expect(data.url).toBe('https://github.com/org/repo/pull/42');
+    expect(data.merge_commit_sha).toBe('abc123def456');
+  });
+
+  // --- gitlab direct success ---
+  test('gitlab direct squash — success path returns direct_squash + merge_commit_sha', async () => {
+    onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git\n');
+    onExec('glab mr merge 17 --squash --remove-source-branch --yes', '');
+    onExec(
+      'glab mr view 17 --output json',
+      JSON.stringify({
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/17',
+        merge_commit_sha: 'deadbeef1234',
+      }),
+    );
+
+    const result = await prMergeHandler.execute({ number: 17 });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.number).toBe(17);
+    expect(data.merged).toBe(true);
+    expect(data.merge_method).toBe('direct_squash');
+    expect(data.url).toBe('https://gitlab.com/org/repo/-/merge_requests/17');
+    expect(data.merge_commit_sha).toBe('deadbeef1234');
+  });
+
+  // --- merge-queue fallback ---
+  test('github merge-queue fallback — direct fails with queue stderr, --auto succeeds', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+
+    let directCalled = false;
+    let autoCalled = false;
+    onExec('gh pr merge 55 --squash --delete-branch', () => {
+      if (!directCalled) {
+        directCalled = true;
+        throw mergeQueueError();
+      }
+      autoCalled = true;
+      return '';
+    });
+    onExec(
+      'gh pr view 55 --json url',
+      JSON.stringify({ url: 'https://github.com/org/repo/pull/55' }),
+    );
+
+    const result = await prMergeHandler.execute({ number: 55 });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.merge_method).toBe('merge_queue');
+    expect(data.merged).toBe(true);
+    expect(data.url).toBe('https://github.com/org/repo/pull/55');
+    expect(data.merge_commit_sha).toBeUndefined();
+    expect(directCalled).toBe(true);
+    expect(autoCalled).toBe(true);
+    // Confirm the second invocation carried --auto.
+    const autoCall = execCalls.find(
+      c => c.includes('gh pr merge 55') && c.includes('--auto'),
+    );
+    expect(autoCall).toBeDefined();
+  });
+
+  // --- forced merge-queue ---
+  test('github forced merge-queue — use_merge_queue=true skips direct path', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    onExec('gh pr merge 99 --squash --delete-branch --auto', '');
+    onExec(
+      'gh pr view 99 --json url',
+      JSON.stringify({ url: 'https://github.com/org/repo/pull/99' }),
+    );
+
+    const result = await prMergeHandler.execute({ number: 99, use_merge_queue: true });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.merge_method).toBe('merge_queue');
+    // Non-auto path must NOT have been invoked.
+    const directOnly = execCalls.find(
+      c =>
+        c.startsWith('gh pr merge 99 --squash --delete-branch') && !c.includes('--auto'),
+    );
+    expect(directOnly).toBeUndefined();
+  });
+
+  // --- failed merge (conflicts) ---
+  test('github failed merge — conflict error (no merge-queue phrase) surfaces as failure', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    onExec('gh pr merge 8 --squash --delete-branch', () => {
+      const err = new Error(
+        'Pull request is not mergeable: the base branch requires all conflicts to be resolved',
+      ) as ThrowableError;
+      err.stderr = 'Pull request is not mergeable: conflicts detected\n';
+      throw err;
+    });
+
+    const result = await prMergeHandler.execute({ number: 8 });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(false);
+    expect((data.error as string)).toContain('gh pr merge failed');
+    expect((data.error as string).toLowerCase()).toContain('mergeable');
+  });
+
+  // --- invalid PR number ---
+  test('github invalid PR — not-found error surfaces as failure', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    onExec('gh pr merge 99999 --squash --delete-branch', () => {
+      const err = new Error('could not find pull request') as ThrowableError;
+      err.stderr = 'GraphQL: Could not resolve to a PullRequest with the number of 99999.\n';
+      throw err;
+    });
+
+    const result = await prMergeHandler.execute({ number: 99999 });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(false);
+    expect((data.error as string)).toContain('gh pr merge failed');
+  });
+
+  // --- multi-line squash message (tempfile path) ---
+  test('github multi-line squash message — written to temp file and passed via --body-file', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    onExec('gh pr merge 21 --squash --delete-branch', '');
+    onExec(
+      'gh pr view 21 --json mergeCommit,url',
+      JSON.stringify({
+        mergeCommit: { oid: 'aaaaaaaa' },
+        url: 'https://github.com/org/repo/pull/21',
+      }),
+    );
+
+    const body = 'feat: do the thing\n\nLong body\nwith multiple lines\n\nCloses #21\n';
+    const result = await prMergeHandler.execute({
+      number: 21,
+      squash_message: body,
+    });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.merge_method).toBe('direct_squash');
+
+    // Confirm --body-file was used (not --body with escaped newlines).
+    const mergeCall = execCalls.find(c => c.startsWith('gh pr merge 21'));
+    expect(mergeCall).toBeDefined();
+    expect(mergeCall!).toContain('--body-file');
+    expect(mergeCall!).not.toMatch(/--body\s+'feat:/);
+  });
+
+  test('github single-line squash message — passed inline via --body', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    onExec('gh pr merge 33 --squash --delete-branch', '');
+    onExec(
+      'gh pr view 33 --json mergeCommit,url',
+      JSON.stringify({
+        mergeCommit: { oid: 'cafebabe' },
+        url: 'https://github.com/org/repo/pull/33',
+      }),
+    );
+
+    const result = await prMergeHandler.execute({
+      number: 33,
+      squash_message: 'chore: small tweak',
+    });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    const mergeCall = execCalls.find(c => c.startsWith('gh pr merge 33'));
+    expect(mergeCall).toBeDefined();
+    expect(mergeCall!).toContain("--body 'chore: small tweak'");
+    expect(mergeCall!).not.toContain('--body-file');
+  });
+
+  test('gitlab squash message — passed via --squash-message', async () => {
+    onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git\n');
+    onExec('glab mr merge 14 --squash --remove-source-branch --yes', '');
+    onExec(
+      'glab mr view 14 --output json',
+      JSON.stringify({
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/14',
+        merge_commit_sha: 'f00dbabe',
+      }),
+    );
+
+    const result = await prMergeHandler.execute({
+      number: 14,
+      squash_message: 'fix: patch',
+    });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    const mergeCall = execCalls.find(c => c.startsWith('glab mr merge 14'));
+    expect(mergeCall).toBeDefined();
+    expect(mergeCall!).toContain("--squash-message 'fix: patch'");
+  });
+
+  // --- merge-queue fallback failure ---
+  test('github merge-queue fallback — if --auto also fails, reports fallback failure', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+
+    let call = 0;
+    onExec('gh pr merge 77 --squash --delete-branch', () => {
+      call += 1;
+      if (call === 1) throw mergeQueueError();
+      // Second call (--auto) also fails.
+      const err = new Error('auto merge not permitted') as ThrowableError;
+      err.stderr = 'auto-merge is disabled on this repository\n';
+      throw err;
+    });
+
+    const result = await prMergeHandler.execute({ number: 77 });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(false);
+    expect((data.error as string)).toContain('merge-queue fallback');
+  });
+
+  // --- gitlab failure ---
+  test('gitlab failed merge — error surfaces as failure', async () => {
+    onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git\n');
+    onExec('glab mr merge 9 --squash --remove-source-branch --yes', () => {
+      const err = new Error('merge request cannot be merged') as ThrowableError;
+      err.stderr = 'merge request has conflicts\n';
+      throw err;
+    });
+
+    const result = await prMergeHandler.execute({ number: 9 });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(false);
+    expect((data.error as string)).toContain('glab mr merge failed');
+  });
+});


### PR DESCRIPTION
## Summary

Add `pr_merge` MCP tool that squash-merges a PR/MR with branch deletion. Auto-detects merge-queue-enforced GitHub repos by parsing stderr from the direct attempt and falling back to `--auto` mode. Returns merge_method indicator (direct_squash vs merge_queue) and merge commit SHA on direct merges. Supports multi-line squash messages via temp file.

## Changes

- Add the new handler file (auto-discovered by codegen registry)
- Add unit tests covering both GitHub and GitLab paths plus error cases

## Linked Issues

Closes #79

## Test Plan

- [x] `./scripts/ci/validate.sh` passes (codegen, tsc, shellcheck, all tests, runtime smoke)
- [x] New handler appears in `tools/list` via the registry codegen
- [x] Both GitHub and GitLab code paths covered by unit tests
- [x] Error paths return `{ok: false, error}` envelope consistently with the codebase

Generated with [Claude Code](https://claude.com/claude-code)
