### PR TITLE
feat(sdlc-mcp): pr_diff handler

### DIFF
--- a/handlers/pr_diff.ts
+++ b/handlers/pr_diff.ts
@@ -1,0 +1,160 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  number: z.number().int().positive(),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+const MAX_LINES = 10000;
+const HEAD_KEEP = 5000;
+const TAIL_KEEP = 5000;
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function exec(cmd: string): string {
+  return execSync(cmd, {
+    cwd: projectDir(),
+    encoding: 'utf8',
+    maxBuffer: 256 * 1024 * 1024, // 256 MiB — diffs can be large
+  });
+}
+
+function detectPlatform(): 'github' | 'gitlab' {
+  try {
+    const url = execSync('git remote get-url origin', {
+      cwd: projectDir(),
+      encoding: 'utf8',
+    }).trim();
+    return url.includes('gitlab') ? 'gitlab' : 'github';
+  } catch {
+    return 'github';
+  }
+}
+
+function getGithubDiff(num: number): string {
+  return exec(`gh pr diff ${num}`);
+}
+
+function getGithubUrl(num: number): string {
+  const raw = exec(`gh pr view ${num} --json url`);
+  const parsed = JSON.parse(raw) as { url: string };
+  return parsed.url;
+}
+
+function getGitlabDiff(num: number): string {
+  return exec(`glab mr diff ${num}`);
+}
+
+function getGitlabUrl(num: number): string {
+  const raw = exec(`glab mr view ${num} --output json`);
+  const parsed = JSON.parse(raw) as { web_url: string };
+  return parsed.web_url;
+}
+
+function countLines(diff: string): number {
+  if (diff.length === 0) return 0;
+  let count = 0;
+  for (let i = 0; i < diff.length; i++) {
+    if (diff.charCodeAt(i) === 10) count++;
+  }
+  // If the diff doesn't end with a newline, the last line still counts.
+  if (diff.charCodeAt(diff.length - 1) !== 10) count++;
+  return count;
+}
+
+function countFiles(diff: string): number {
+  if (diff.length === 0) return 0;
+  const matches = diff.match(/^diff --git /gm);
+  return matches ? matches.length : 0;
+}
+
+interface TruncateResult {
+  diff: string;
+  truncated: boolean;
+}
+
+function maybeTruncate(diff: string, lineCount: number): TruncateResult {
+  if (lineCount <= MAX_LINES) {
+    return { diff, truncated: false };
+  }
+
+  // Split on newlines while preserving them.
+  const lines = diff.split('\n');
+  // If diff ends with '\n', split produces a trailing empty string; drop it
+  // so the keep-count math lines up with countLines() above.
+  const hadTrailingNewline = lines.length > 0 && lines[lines.length - 1] === '';
+  if (hadTrailingNewline) lines.pop();
+
+  const totalLines = lines.length;
+  const head = lines.slice(0, HEAD_KEEP);
+  const tail = lines.slice(totalLines - TAIL_KEEP);
+  const omitted = totalLines - HEAD_KEEP - TAIL_KEEP;
+
+  const joined =
+    head.join('\n') +
+    `\n... [${omitted} lines omitted] ...\n` +
+    tail.join('\n') +
+    (hadTrailingNewline ? '\n' : '');
+
+  return { diff: joined, truncated: true };
+}
+
+const prDiffHandler: HandlerDef = {
+  name: 'pr_diff',
+  description:
+    'Fetch the unified diff for a PR/MR as a single string, with line/file counts and a safety-valve truncation above 10000 lines.',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: Input;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const platform = detectPlatform();
+      const rawDiff =
+        platform === 'github' ? getGithubDiff(args.number) : getGitlabDiff(args.number);
+      const url =
+        platform === 'github' ? getGithubUrl(args.number) : getGitlabUrl(args.number);
+
+      const rawLineCount = countLines(rawDiff);
+      const fileCount = countFiles(rawDiff);
+      const { diff, truncated } = maybeTruncate(rawDiff, rawLineCount);
+      const lineCount = truncated ? countLines(diff) : rawLineCount;
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              number: args.number,
+              diff,
+              line_count: lineCount,
+              file_count: fileCount,
+              url,
+              truncated,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default prDiffHandler;

--- a/tests/pr_diff.test.ts
+++ b/tests/pr_diff.test.ts
@@ -1,0 +1,241 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+// --- Mock child_process.execSync at module level ---
+// We intercept execSync via a registry so individual tests can override calls.
+
+let execRegistry: Array<{ match: string; value: string }> = [];
+let execError: Error | null = null;
+
+function mockExec(cmd: string): string {
+  if (execError) throw execError;
+  for (const { match, value } of execRegistry) {
+    if (cmd.includes(match)) return value;
+  }
+  throw new Error(`Unexpected exec call: ${cmd}`);
+}
+
+mock.module('child_process', () => ({
+  execSync: (cmd: string, _opts?: unknown) => mockExec(cmd),
+}));
+
+// Import AFTER the mock is registered
+const { default: prDiffHandler } = await import('../handlers/pr_diff.ts');
+
+function parseResult(content: Array<{ type: string; text: string }>) {
+  return JSON.parse(content[0].text) as Record<string, unknown>;
+}
+
+function register(match: string, value: string) {
+  execRegistry.push({ match, value });
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execError = null;
+});
+
+const SMALL_DIFF = `diff --git a/foo.txt b/foo.txt
+index 1234567..89abcde 100644
+--- a/foo.txt
++++ b/foo.txt
+@@ -1,3 +1,3 @@
+ line one
+-old line
++new line
+ line three
+`;
+
+const TWO_FILE_DIFF = `diff --git a/foo.txt b/foo.txt
+index 1234567..89abcde 100644
+--- a/foo.txt
++++ b/foo.txt
+@@ -1,1 +1,1 @@
+-old
++new
+diff --git a/bar.txt b/bar.txt
+index abcdef0..fedcba9 100644
+--- a/bar.txt
++++ b/bar.txt
+@@ -1,1 +1,1 @@
+-foo
++bar
+`;
+
+function buildHugeDiff(lineCount: number): string {
+  const parts: string[] = ['diff --git a/big.txt b/big.txt'];
+  parts.push('index 1234567..89abcde 100644');
+  parts.push('--- a/big.txt');
+  parts.push('+++ b/big.txt');
+  parts.push(`@@ -1,${lineCount - 4} +1,${lineCount - 4} @@`);
+  for (let i = 0; i < lineCount - 5; i++) {
+    parts.push(`+line ${i}`);
+  }
+  return parts.join('\n') + '\n';
+}
+
+describe('pr_diff handler', () => {
+  // --- input validation ---
+  test('invalid_input — missing number returns error', async () => {
+    const result = await prDiffHandler.execute({});
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+    expect(typeof data.error).toBe('string');
+  });
+
+  test('invalid_input — non-positive number returns error', async () => {
+    const result = await prDiffHandler.execute({ number: 0 });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+  });
+
+  // --- normal diff, github ---
+  test('normal_github — returns full diff with counts', async () => {
+    register('git remote get-url origin', 'https://github.com/org/repo.git');
+    register('gh pr diff 42', TWO_FILE_DIFF);
+    register(
+      'gh pr view 42',
+      JSON.stringify({ url: 'https://github.com/org/repo/pull/42' })
+    );
+
+    const result = await prDiffHandler.execute({ number: 42 });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(true);
+    expect(data.number).toBe(42);
+    expect(data.diff).toBe(TWO_FILE_DIFF);
+    expect(data.file_count).toBe(2);
+    expect(data.line_count).toBe(14);
+    expect(data.url).toBe('https://github.com/org/repo/pull/42');
+    expect(data.truncated).toBe(false);
+  });
+
+  // --- small single-file diff, github ---
+  test('small_github — single file counts correctly', async () => {
+    register('git remote get-url origin', 'https://github.com/org/repo.git');
+    register('gh pr diff 7', SMALL_DIFF);
+    register(
+      'gh pr view 7',
+      JSON.stringify({ url: 'https://github.com/org/repo/pull/7' })
+    );
+
+    const result = await prDiffHandler.execute({ number: 7 });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(true);
+    expect(data.file_count).toBe(1);
+    expect(data.line_count).toBe(9);
+    expect(data.truncated).toBe(false);
+  });
+
+  // --- empty diff (no-op PR) ---
+  test('empty_diff — returns zero counts', async () => {
+    register('git remote get-url origin', 'https://github.com/org/repo.git');
+    register('gh pr diff 99', '');
+    register(
+      'gh pr view 99',
+      JSON.stringify({ url: 'https://github.com/org/repo/pull/99' })
+    );
+
+    const result = await prDiffHandler.execute({ number: 99 });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(true);
+    expect(data.diff).toBe('');
+    expect(data.line_count).toBe(0);
+    expect(data.file_count).toBe(0);
+    expect(data.truncated).toBe(false);
+  });
+
+  // --- huge diff triggers truncation ---
+  test('huge_diff — triggers safety-valve truncation above 10000 lines', async () => {
+    const huge = buildHugeDiff(20000);
+    register('git remote get-url origin', 'https://github.com/org/repo.git');
+    register('gh pr diff 500', huge);
+    register(
+      'gh pr view 500',
+      JSON.stringify({ url: 'https://github.com/org/repo/pull/500' })
+    );
+
+    const result = await prDiffHandler.execute({ number: 500 });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(true);
+    expect(data.truncated).toBe(true);
+
+    const diff = data.diff as string;
+    // Must contain the omission marker
+    expect(diff).toContain('lines omitted');
+    // Must preserve the head
+    expect(diff.startsWith('diff --git a/big.txt b/big.txt')).toBe(true);
+    // Truncated diff must be dramatically smaller than the original
+    expect(diff.split('\n').length).toBeLessThan(huge.split('\n').length);
+    // Should keep roughly 10000 content lines + 1 marker line
+    const truncatedLineCount = data.line_count as number;
+    expect(truncatedLineCount).toBeGreaterThan(10000);
+    expect(truncatedLineCount).toBeLessThan(10010);
+  });
+
+  // --- right at threshold, no truncation ---
+  test('at_threshold — exactly 10000 lines is NOT truncated', async () => {
+    const atLimit = buildHugeDiff(10000);
+    register('git remote get-url origin', 'https://github.com/org/repo.git');
+    register('gh pr diff 123', atLimit);
+    register(
+      'gh pr view 123',
+      JSON.stringify({ url: 'https://github.com/org/repo/pull/123' })
+    );
+
+    const result = await prDiffHandler.execute({ number: 123 });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(true);
+    expect(data.truncated).toBe(false);
+    expect(data.diff).toBe(atLimit);
+  });
+
+  // --- gitlab platform ---
+  test('gitlab_platform — uses glab commands when origin is gitlab', async () => {
+    register('git remote get-url origin', 'https://gitlab.com/org/repo.git');
+    register('glab mr diff 11', TWO_FILE_DIFF);
+    register(
+      'glab mr view 11',
+      JSON.stringify({ web_url: 'https://gitlab.com/org/repo/-/merge_requests/11' })
+    );
+
+    const result = await prDiffHandler.execute({ number: 11 });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(true);
+    expect(data.number).toBe(11);
+    expect(data.diff).toBe(TWO_FILE_DIFF);
+    expect(data.file_count).toBe(2);
+    expect(data.url).toBe('https://gitlab.com/org/repo/-/merge_requests/11');
+    expect(data.truncated).toBe(false);
+  });
+
+  // --- gitlab empty diff ---
+  test('gitlab_empty — empty MR diff on gitlab returns zero counts', async () => {
+    register('git remote get-url origin', 'https://gitlab.com/org/repo.git');
+    register('glab mr diff 22', '');
+    register(
+      'glab mr view 22',
+      JSON.stringify({ web_url: 'https://gitlab.com/org/repo/-/merge_requests/22' })
+    );
+
+    const result = await prDiffHandler.execute({ number: 22 });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(true);
+    expect(data.line_count).toBe(0);
+    expect(data.file_count).toBe(0);
+  });
+
+  // --- cli failure is surfaced as ok:false ---
+  test('cli_failure — underlying command error is surfaced', async () => {
+    execError = new Error('gh: authentication required');
+    const result = await prDiffHandler.execute({ number: 1 });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+    expect((data.error as string)).toContain('authentication');
+  });
+});


### PR DESCRIPTION
## Summary

Add `pr_diff` MCP tool that fetches the unified diff for a PR/MR with line and file counts. Includes a safety-valve truncation above 10000 lines (head 5000 + tail 5000 with omitted-count marker) to protect against pathological diffs. 256MiB execSync buffer for normal large diffs.

## Changes

- Add the new handler file (auto-discovered by codegen registry)
- Add unit tests covering both GitHub and GitLab paths plus error cases

## Linked Issues

Closes #80

## Test Plan

- [x] `./scripts/ci/validate.sh` passes (codegen, tsc, shellcheck, all tests, runtime smoke)
- [x] New handler appears in `tools/list` via the registry codegen
- [x] Both GitHub and GitLab code paths covered by unit tests
- [x] Error paths return `{ok: false, error}` envelope consistently with the codebase

Generated with [Claude Code](https://claude.com/claude-code)
