### PR TITLE
feat(sdlc-mcp): pr_comment handler

### DIFF
--- a/handlers/pr_comment.ts
+++ b/handlers/pr_comment.ts
@@ -1,0 +1,149 @@
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  number: z.number().int().positive('number must be a positive integer'),
+  body: z.string().min(1, 'body must be a non-empty string'),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+interface SpawnResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runCommand(cmd: string[], cwd: string): SpawnResult {
+  // Bun.spawnSync with an arg array preserves unicode, code fences, and
+  // multi-line markdown verbatim — no shell quoting required.
+  // Passing `env: process.env` explicitly ensures we honour any PATH
+  // mutations the caller has made since Bun startup.
+  const proc = Bun.spawnSync({
+    cmd,
+    cwd,
+    env: process.env as Record<string, string>,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  return {
+    exitCode: proc.exitCode ?? -1,
+    stdout: new TextDecoder().decode(proc.stdout),
+    stderr: new TextDecoder().decode(proc.stderr),
+  };
+}
+
+function detectPlatform(cwd: string): 'github' | 'gitlab' {
+  const proc = runCommand(['git', 'remote', 'get-url', 'origin'], cwd);
+  if (proc.exitCode !== 0) return 'github';
+  const url = proc.stdout.trim();
+  return url.includes('gitlab') ? 'gitlab' : 'github';
+}
+
+/**
+ * Parse a GitHub PR comment ID from the URL `gh pr comment` prints to stdout.
+ * Format: https://github.com/<owner>/<repo>/pull/<num>#issuecomment-<id>
+ */
+function parseGithubCommentId(stdout: string): number | null {
+  const match = /#issuecomment-(\d+)/.exec(stdout);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+/**
+ * Parse a GitLab MR note ID from the URL `glab mr note` prints to stdout.
+ * Format: https://gitlab.com/<group>/<repo>/-/merge_requests/<num>#note_<id>
+ */
+function parseGitlabNoteId(stdout: string): number | null {
+  const match = /#note_(\d+)/.exec(stdout);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+interface PostResult {
+  commentId: number;
+  url: string;
+}
+
+function postGithubComment(num: number, body: string, cwd: string): PostResult {
+  const proc = runCommand(
+    ['gh', 'pr', 'comment', String(num), '--body', body],
+    cwd,
+  );
+  if (proc.exitCode !== 0) {
+    throw new Error(`gh pr comment failed: ${proc.stderr.trim() || proc.stdout.trim()}`);
+  }
+  const url = proc.stdout.trim().split(/\s+/).pop() ?? proc.stdout.trim();
+  const commentId = parseGithubCommentId(proc.stdout);
+  if (commentId === null) {
+    throw new Error(`failed to parse comment ID from gh output: ${proc.stdout.trim()}`);
+  }
+  return { commentId, url };
+}
+
+function postGitlabComment(num: number, body: string, cwd: string): PostResult {
+  const proc = runCommand(
+    ['glab', 'mr', 'note', String(num), '--message', body],
+    cwd,
+  );
+  if (proc.exitCode !== 0) {
+    throw new Error(`glab mr note failed: ${proc.stderr.trim() || proc.stdout.trim()}`);
+  }
+  const url = proc.stdout.trim().split(/\s+/).pop() ?? proc.stdout.trim();
+  const commentId = parseGitlabNoteId(proc.stdout);
+  if (commentId === null) {
+    throw new Error(`failed to parse note ID from glab output: ${proc.stdout.trim()}`);
+  }
+  return { commentId, url };
+}
+
+const prCommentHandler: HandlerDef = {
+  name: 'pr_comment',
+  description:
+    'Post a top-level comment on a PR/MR. Plain markdown body. Returns the created comment/note ID.',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: Input;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const cwd = projectDir();
+      const platform = detectPlatform(cwd);
+
+      const { commentId, url } =
+        platform === 'github'
+          ? postGithubComment(args.number, args.body, cwd)
+          : postGitlabComment(args.number, args.body, cwd);
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              number: args.number,
+              comment_id: commentId,
+              url,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default prCommentHandler;

--- a/tests/pr_comment.test.ts
+++ b/tests/pr_comment.test.ts
@@ -1,0 +1,335 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+
+// This handler uses Bun.spawnSync directly (no child_process, no node:fs),
+// so tests run against real fixture shell scripts placed on a scoped PATH.
+// No module mocks.
+
+const { default: handler } = await import('../handlers/pr_comment.ts');
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text) as Record<string, unknown>;
+}
+
+const ORIGINAL_PATH = process.env.PATH;
+const ORIGINAL_PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR;
+
+let fixtureDir = '';
+
+function restoreEnv() {
+  process.env.PATH = ORIGINAL_PATH;
+  if (ORIGINAL_PROJECT_DIR === undefined) {
+    delete process.env.CLAUDE_PROJECT_DIR;
+  } else {
+    process.env.CLAUDE_PROJECT_DIR = ORIGINAL_PROJECT_DIR;
+  }
+}
+
+/**
+ * Build a fixture directory with:
+ *   - bin/gh, bin/glab, bin/git shell scripts (made executable)
+ *   - a dummy working tree
+ * Returns the absolute fixture path and updates PATH + CLAUDE_PROJECT_DIR.
+ *
+ * The shell scripts log their invocations to `bin/.calls` (one JSON line each)
+ * so tests can assert the exact body the handler passed via argv.
+ */
+async function makeFixture(bins: Record<string, string>): Promise<string> {
+  const dir = `/tmp/pr-comment-test-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+  await Bun.write(`${dir}/.keep`, '');
+  for (const [name, script] of Object.entries(bins)) {
+    const path = `${dir}/bin/${name}`;
+    await Bun.write(path, script);
+    Bun.spawnSync({ cmd: ['chmod', '+x', path] });
+  }
+  process.env.PATH = `${dir}/bin:${ORIGINAL_PATH}`;
+  process.env.CLAUDE_PROJECT_DIR = dir;
+  return dir;
+}
+
+/**
+ * A fake `git` that answers `git remote get-url origin` with the given URL
+ * and errors on anything else. Used to steer platform detection.
+ */
+function fakeGit(originUrl: string): string {
+  return `#!/bin/sh
+if [ "$1" = "remote" ] && [ "$2" = "get-url" ] && [ "$3" = "origin" ]; then
+  echo "${originUrl}"
+  exit 0
+fi
+echo "unexpected git call: $*" >&2
+exit 1
+`;
+}
+
+/**
+ * A fake `gh` that records its argv to $FIXTURE/bin/.calls and prints a
+ * canned URL so the handler can parse the comment ID. The PR number and
+ * comment ID come from env so each test can customize them.
+ */
+function fakeGh(prNum: number, commentId: number): string {
+  // Record args separated by \x1f (unit separator), calls separated by \x1e
+  // (record separator) — neither collides with markdown content.
+  return `#!/bin/sh
+{
+  printf '\\036'
+  first=1
+  for a in "$@"; do
+    if [ $first -eq 1 ]; then
+      first=0
+    else
+      printf '\\037'
+    fi
+    printf '%s' "$a"
+  done
+} >> "$(dirname "$0")/.calls"
+
+if [ "$1" = "pr" ] && [ "$2" = "comment" ]; then
+  echo "https://github.com/org/repo/pull/${prNum}#issuecomment-${commentId}"
+  exit 0
+fi
+echo "unexpected gh call" >&2
+exit 1
+`;
+}
+
+/**
+ * A fake `glab` that records its argv and prints a canned MR note URL.
+ */
+function fakeGlab(mrNum: number, noteId: number): string {
+  return `#!/bin/sh
+{
+  printf '\\036'
+  first=1
+  for a in "$@"; do
+    if [ $first -eq 1 ]; then
+      first=0
+    else
+      printf '\\037'
+    fi
+    printf '%s' "$a"
+  done
+} >> "$(dirname "$0")/.calls"
+
+if [ "$1" = "mr" ] && [ "$2" = "note" ]; then
+  echo "https://gitlab.com/org/repo/-/merge_requests/${mrNum}#note_${noteId}"
+  exit 0
+fi
+echo "unexpected glab call" >&2
+exit 1
+`;
+}
+
+async function readCalls(dir: string): Promise<string[][]> {
+  const file = Bun.file(`${dir}/bin/.calls`);
+  if (!(await file.exists())) return [];
+  const text = await file.text();
+  // Records separated by \x1e, fields within a record by \x1f.
+  return text
+    .split('\x1e')
+    .filter((rec) => rec.length > 0)
+    .map((rec) => rec.split('\x1f'));
+}
+
+describe('pr_comment handler', () => {
+  beforeEach(() => {
+    fixtureDir = '';
+  });
+  afterEach(() => {
+    fixtureDir = '';
+    restoreEnv();
+  });
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('pr_comment');
+    expect(typeof handler.execute).toBe('function');
+    expect(handler.description.length).toBeGreaterThan(0);
+  });
+
+  test('rejects missing number', async () => {
+    fixtureDir = await makeFixture({
+      git: fakeGit('https://github.com/org/repo.git'),
+      gh: fakeGh(1, 1),
+    });
+    const result = await handler.execute({ body: 'hi' });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+  });
+
+  test('rejects empty body', async () => {
+    fixtureDir = await makeFixture({
+      git: fakeGit('https://github.com/org/repo.git'),
+      gh: fakeGh(1, 1),
+    });
+    const result = await handler.execute({ number: 12, body: '' });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+    expect((data.error as string)).toContain('body');
+  });
+
+  test('github — plain text comment returns numeric comment_id and url', async () => {
+    fixtureDir = await makeFixture({
+      git: fakeGit('https://github.com/org/repo.git'),
+      gh: fakeGh(42, 1001),
+    });
+
+    const result = await handler.execute({ number: 42, body: 'looks good' });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.number).toBe(42);
+    expect(data.comment_id).toBe(1001);
+    expect(data.url).toBe('https://github.com/org/repo/pull/42#issuecomment-1001');
+
+    const calls = await readCalls(fixtureDir);
+    // One git call (platform detect) + one gh call (comment)
+    const ghCall = calls.find((c) => c[0] === 'pr' && c[1] === 'comment');
+    expect(ghCall).toBeDefined();
+    expect(ghCall).toEqual(['pr', 'comment', '42', '--body', 'looks good']);
+  });
+
+  test('github — markdown body (code fence, bold, link, list) round-trips verbatim', async () => {
+    fixtureDir = await makeFixture({
+      git: fakeGit('git@github.com:org/repo.git'),
+      gh: fakeGh(7, 2002),
+    });
+
+    const body = [
+      '**heads up** — see [issue](https://example.com/x)',
+      '',
+      '```ts',
+      'const x: number = 1;',
+      'console.log(`hello ${x}`);',
+      '```',
+      '',
+      '- item one',
+      '- item two',
+    ].join('\n');
+
+    const result = await handler.execute({ number: 7, body });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.comment_id).toBe(2002);
+
+    const calls = await readCalls(fixtureDir);
+    const ghCall = calls.find((c) => c[0] === 'pr' && c[1] === 'comment');
+    expect(ghCall).toBeDefined();
+    // The 5th arg is the full body — assert verbatim preservation.
+    expect(ghCall?.[4]).toBe(body);
+  });
+
+  test('github — unicode and emoji body preserved verbatim', async () => {
+    fixtureDir = await makeFixture({
+      git: fakeGit('https://github.com/org/repo.git'),
+      gh: fakeGh(3, 3003),
+    });
+
+    const body = 'LGTM — 🚀 中文 тест αβγ';
+
+    const result = await handler.execute({ number: 3, body });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.comment_id).toBe(3003);
+
+    const calls = await readCalls(fixtureDir);
+    const ghCall = calls.find((c) => c[0] === 'pr' && c[1] === 'comment');
+    expect(ghCall?.[4]).toBe(body);
+  });
+
+  test('gitlab — plain text comment returns numeric comment_id and url', async () => {
+    fixtureDir = await makeFixture({
+      git: fakeGit('https://gitlab.com/org/repo.git'),
+      glab: fakeGlab(55, 9090),
+    });
+
+    const result = await handler.execute({ number: 55, body: 'ship it' });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.number).toBe(55);
+    expect(data.comment_id).toBe(9090);
+    expect(data.url).toBe('https://gitlab.com/org/repo/-/merge_requests/55#note_9090');
+
+    const calls = await readCalls(fixtureDir);
+    const glabCall = calls.find((c) => c[0] === 'mr' && c[1] === 'note');
+    expect(glabCall).toEqual(['mr', 'note', '55', '--message', 'ship it']);
+  });
+
+  test('gitlab — markdown body with code fence preserved verbatim', async () => {
+    fixtureDir = await makeFixture({
+      git: fakeGit('git@gitlab.com:org/repo.git'),
+      glab: fakeGlab(88, 7070),
+    });
+
+    const body = [
+      '### Review findings',
+      '',
+      '```python',
+      'def hello():',
+      '    print("world")',
+      '```',
+    ].join('\n');
+
+    const result = await handler.execute({ number: 88, body });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.comment_id).toBe(7070);
+
+    const calls = await readCalls(fixtureDir);
+    const glabCall = calls.find((c) => c[0] === 'mr' && c[1] === 'note');
+    expect(glabCall?.[4]).toBe(body);
+  });
+
+  test('gitlab — unicode body preserved', async () => {
+    fixtureDir = await makeFixture({
+      git: fakeGit('https://gitlab.example.com/team/proj.git'),
+      glab: fakeGlab(11, 2222),
+    });
+
+    const body = '✅ passed: 42 ❌ failed: 0 — 完了';
+
+    const result = await handler.execute({ number: 11, body });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.comment_id).toBe(2222);
+
+    const calls = await readCalls(fixtureDir);
+    const glabCall = calls.find((c) => c[0] === 'mr' && c[1] === 'note');
+    expect(glabCall?.[4]).toBe(body);
+  });
+
+  test('github — gh failure is returned as structured error, not thrown', async () => {
+    fixtureDir = await makeFixture({
+      git: fakeGit('https://github.com/org/repo.git'),
+      gh: `#!/bin/sh
+echo "HTTP 404: Not Found" >&2
+exit 1
+`,
+    });
+
+    const result = await handler.execute({ number: 9999, body: 'nope' });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(false);
+    expect((data.error as string)).toContain('gh pr comment failed');
+  });
+
+  test('github — unparseable stdout (no issuecomment id) returns structured error', async () => {
+    fixtureDir = await makeFixture({
+      git: fakeGit('https://github.com/org/repo.git'),
+      gh: `#!/bin/sh
+echo "posted comment ok"
+exit 0
+`,
+    });
+
+    const result = await handler.execute({ number: 1, body: 'x' });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(false);
+    expect((data.error as string)).toContain('failed to parse comment ID');
+  });
+});


### PR DESCRIPTION
## Summary

Add `pr_comment` MCP tool that posts a top-level markdown comment on a PR/MR and returns the created comment's native ID. Uses Bun.spawnSync with explicit env passthrough for binary-safe body content (handles unicode, code fences, multi-line markdown without shell interpolation issues).

## Changes

- Add the new handler file (auto-discovered by codegen registry)
- Add unit tests covering both GitHub and GitLab paths plus error cases

## Linked Issues

Closes #81

## Test Plan

- [x] `./scripts/ci/validate.sh` passes (codegen, tsc, shellcheck, all tests, runtime smoke)
- [x] New handler appears in `tools/list` via the registry codegen
- [x] Both GitHub and GitLab code paths covered by unit tests
- [x] Error paths return `{ok: false, error}` envelope consistently with the codebase

Generated with [Claude Code](https://claude.com/claude-code)
