### PR TITLE
feat(sdlc-mcp): pr_list handler

### DIFF
--- a/handlers/pr_list.ts
+++ b/handlers/pr_list.ts
@@ -1,0 +1,137 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  head: z.string().optional(),
+  base: z.string().optional(),
+  state: z.enum(['open', 'closed', 'merged', 'all']).optional().default('open'),
+  author: z.string().optional(),
+  limit: z.number().int().positive().optional().default(20),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+interface NormalizedPr {
+  number: number;
+  title: string;
+  state: string;
+  head: string;
+  base: string;
+  url: string;
+}
+
+function exec(cmd: string): string {
+  return execSync(cmd, { encoding: 'utf8' }).trim();
+}
+
+function detectPlatform(): 'github' | 'gitlab' {
+  try {
+    const url = exec('git remote get-url origin');
+    return url.includes('github') ? 'github' : 'gitlab';
+  } catch {
+    return 'github';
+  }
+}
+
+function quoteArg(s: string): string {
+  // Single-quote the arg and escape any embedded single quotes.
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+interface GithubPr {
+  number: number;
+  title: string;
+  state: string;
+  headRefName: string;
+  baseRefName: string;
+  url: string;
+}
+
+function listGithubPrs(args: Input): NormalizedPr[] {
+  const flags: string[] = [];
+  if (args.head !== undefined) flags.push(`--head ${quoteArg(args.head)}`);
+  if (args.base !== undefined) flags.push(`--base ${quoteArg(args.base)}`);
+  flags.push(`--state ${quoteArg(args.state)}`);
+  if (args.author !== undefined) flags.push(`--author ${quoteArg(args.author)}`);
+  flags.push(`--limit ${args.limit}`);
+  flags.push('--json number,title,state,headRefName,baseRefName,url');
+
+  const cmd = `gh pr list ${flags.join(' ')}`;
+  const raw = exec(cmd);
+  const parsed = JSON.parse(raw) as GithubPr[];
+  return parsed.map((pr) => ({
+    number: pr.number,
+    title: pr.title,
+    state: pr.state,
+    head: pr.headRefName,
+    base: pr.baseRefName,
+    url: pr.url,
+  }));
+}
+
+interface GitlabMr {
+  iid: number;
+  title: string;
+  state: string;
+  source_branch: string;
+  target_branch: string;
+  web_url: string;
+}
+
+function listGitlabMrs(args: Input): NormalizedPr[] {
+  const flags: string[] = [];
+  if (args.head !== undefined) flags.push(`--source-branch ${quoteArg(args.head)}`);
+  if (args.base !== undefined) flags.push(`--target-branch ${quoteArg(args.base)}`);
+  flags.push(`--state ${quoteArg(args.state)}`);
+  if (args.author !== undefined) flags.push(`--author ${quoteArg(args.author)}`);
+  flags.push(`--per-page ${args.limit}`);
+  flags.push('--output json');
+
+  const cmd = `glab mr list ${flags.join(' ')}`;
+  const raw = exec(cmd);
+  const parsed = JSON.parse(raw) as GitlabMr[];
+  return parsed.map((mr) => ({
+    number: mr.iid,
+    title: mr.title,
+    state: mr.state,
+    head: mr.source_branch,
+    base: mr.target_branch,
+    url: mr.web_url,
+  }));
+}
+
+const prListHandler: HandlerDef = {
+  name: 'pr_list',
+  description:
+    'List PRs (GitHub) or MRs (GitLab) filtered by head branch, base branch, state, and author. Used to check whether a PR already exists for the current branch before creating a new one.',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: Input;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const platform = detectPlatform();
+      const prs = platform === 'github' ? listGithubPrs(args) : listGitlabMrs(args);
+      return {
+        content: [
+          { type: 'text' as const, text: JSON.stringify({ ok: true, prs }) },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default prListHandler;

--- a/tests/pr_list.test.ts
+++ b/tests/pr_list.test.ts
@@ -1,0 +1,286 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+// --- Mock child_process.execSync at module level ---
+// We intercept execSync via a registry so individual tests can override calls.
+
+let execRegistry: Record<string, string> = {};
+let execCalls: string[] = [];
+let execError: Error | null = null;
+
+function mockExec(cmd: string): string {
+  execCalls.push(cmd);
+  if (execError) throw execError;
+  // Match by prefix/substring
+  for (const [key, value] of Object.entries(execRegistry)) {
+    if (cmd.includes(key)) return value;
+  }
+  throw new Error(`Unexpected exec call: ${cmd}`);
+}
+
+mock.module('child_process', () => ({
+  execSync: (cmd: string, _opts?: unknown) => mockExec(cmd),
+}));
+
+// Import AFTER the mock is registered
+const { default: prListHandler } = await import('../handlers/pr_list.ts');
+
+function parseResult(content: Array<{ type: string; text: string }>) {
+  return JSON.parse(content[0].text) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  execRegistry = {};
+  execCalls = [];
+  execError = null;
+});
+
+describe('pr_list handler', () => {
+  // --- github: head filter ---
+  test('github head_filter — passes --head flag to gh pr list', async () => {
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    execRegistry['gh pr list'] = JSON.stringify([
+      {
+        number: 7,
+        title: 'Some PR',
+        state: 'OPEN',
+        headRefName: 'feature/42-thing',
+        baseRefName: 'main',
+        url: 'https://github.com/org/repo/pull/7',
+      },
+    ]);
+
+    const result = await prListHandler.execute({ head: 'feature/42-thing' });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(true);
+    const prs = data.prs as Array<Record<string, unknown>>;
+    expect(prs).toHaveLength(1);
+    expect(prs[0].number).toBe(7);
+    expect(prs[0].head).toBe('feature/42-thing');
+    expect(prs[0].base).toBe('main');
+    expect(prs[0].url).toBe('https://github.com/org/repo/pull/7');
+
+    const ghCall = execCalls.find((c) => c.startsWith('gh pr list')) ?? '';
+    expect(ghCall).toContain("--head 'feature/42-thing'");
+  });
+
+  // --- github: state filter ---
+  test('github state_filter — passes --state flag and default is open', async () => {
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    execRegistry['gh pr list'] = JSON.stringify([]);
+
+    // explicit state
+    await prListHandler.execute({ state: 'closed' });
+    let ghCall = execCalls.find((c) => c.startsWith('gh pr list')) ?? '';
+    expect(ghCall).toContain("--state 'closed'");
+
+    // default state
+    execCalls = [];
+    await prListHandler.execute({});
+    ghCall = execCalls.find((c) => c.startsWith('gh pr list')) ?? '';
+    expect(ghCall).toContain("--state 'open'");
+  });
+
+  // --- github: author filter ---
+  test('github author_filter — passes --author flag when provided', async () => {
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    execRegistry['gh pr list'] = JSON.stringify([]);
+
+    await prListHandler.execute({ author: '@me' });
+    const ghCall = execCalls.find((c) => c.startsWith('gh pr list')) ?? '';
+    expect(ghCall).toContain("--author '@me'");
+  });
+
+  // --- github: author omitted ---
+  test('github author_omitted — no --author flag when not provided', async () => {
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    execRegistry['gh pr list'] = JSON.stringify([]);
+
+    await prListHandler.execute({});
+    const ghCall = execCalls.find((c) => c.startsWith('gh pr list')) ?? '';
+    expect(ghCall).not.toContain('--author');
+  });
+
+  // --- github: default limit ---
+  test('github default_limit — uses --limit 20 by default', async () => {
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    execRegistry['gh pr list'] = JSON.stringify([]);
+
+    await prListHandler.execute({});
+    const ghCall = execCalls.find((c) => c.startsWith('gh pr list')) ?? '';
+    expect(ghCall).toContain('--limit 20');
+  });
+
+  // --- github: custom limit ---
+  test('github custom_limit — passes provided --limit', async () => {
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    execRegistry['gh pr list'] = JSON.stringify([]);
+
+    await prListHandler.execute({ limit: 5 });
+    const ghCall = execCalls.find((c) => c.startsWith('gh pr list')) ?? '';
+    expect(ghCall).toContain('--limit 5');
+  });
+
+  // --- github: base filter ---
+  test('github base_filter — passes --base flag when provided', async () => {
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    execRegistry['gh pr list'] = JSON.stringify([]);
+
+    await prListHandler.execute({ base: 'main' });
+    const ghCall = execCalls.find((c) => c.startsWith('gh pr list')) ?? '';
+    expect(ghCall).toContain("--base 'main'");
+  });
+
+  // --- github: empty result ---
+  test('github empty_result — returns {prs: []} not an error', async () => {
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    execRegistry['gh pr list'] = JSON.stringify([]);
+
+    const result = await prListHandler.execute({ head: 'feature/99-none' });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(true);
+    expect(data.prs).toEqual([]);
+  });
+
+  // --- github: normalizes field names ---
+  test('github normalize — maps headRefName/baseRefName to head/base', async () => {
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    execRegistry['gh pr list'] = JSON.stringify([
+      {
+        number: 12,
+        title: 'Refactor',
+        state: 'OPEN',
+        headRefName: 'feature/12-refactor',
+        baseRefName: 'develop',
+        url: 'https://github.com/org/repo/pull/12',
+      },
+    ]);
+
+    const result = await prListHandler.execute({});
+    const data = parseResult(result.content);
+    const prs = data.prs as Array<Record<string, unknown>>;
+
+    expect(prs[0]).toEqual({
+      number: 12,
+      title: 'Refactor',
+      state: 'OPEN',
+      head: 'feature/12-refactor',
+      base: 'develop',
+      url: 'https://github.com/org/repo/pull/12',
+    });
+  });
+
+  // --- gitlab: head filter ---
+  test('gitlab head_filter — uses --source-branch on glab mr list', async () => {
+    execRegistry['git remote get-url origin'] = 'https://gitlab.com/org/repo.git';
+    execRegistry['glab mr list'] = JSON.stringify([
+      {
+        iid: 5,
+        title: 'Some MR',
+        state: 'opened',
+        source_branch: 'feature/5-thing',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/5',
+      },
+    ]);
+
+    const result = await prListHandler.execute({ head: 'feature/5-thing' });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(true);
+    const prs = data.prs as Array<Record<string, unknown>>;
+    expect(prs).toHaveLength(1);
+    expect(prs[0].number).toBe(5);
+    expect(prs[0].head).toBe('feature/5-thing');
+    expect(prs[0].base).toBe('main');
+    expect(prs[0].url).toBe('https://gitlab.com/org/repo/-/merge_requests/5');
+
+    const glabCall = execCalls.find((c) => c.startsWith('glab mr list')) ?? '';
+    expect(glabCall).toContain("--source-branch 'feature/5-thing'");
+  });
+
+  // --- gitlab: state filter ---
+  test('gitlab state_filter — passes --state flag and default is open', async () => {
+    execRegistry['git remote get-url origin'] = 'https://gitlab.com/org/repo.git';
+    execRegistry['glab mr list'] = JSON.stringify([]);
+
+    await prListHandler.execute({ state: 'merged' });
+    let glabCall = execCalls.find((c) => c.startsWith('glab mr list')) ?? '';
+    expect(glabCall).toContain("--state 'merged'");
+
+    execCalls = [];
+    await prListHandler.execute({});
+    glabCall = execCalls.find((c) => c.startsWith('glab mr list')) ?? '';
+    expect(glabCall).toContain("--state 'open'");
+  });
+
+  // --- gitlab: author filter ---
+  test('gitlab author_filter — passes --author flag when provided', async () => {
+    execRegistry['git remote get-url origin'] = 'https://gitlab.com/org/repo.git';
+    execRegistry['glab mr list'] = JSON.stringify([]);
+
+    await prListHandler.execute({ author: 'alice' });
+    const glabCall = execCalls.find((c) => c.startsWith('glab mr list')) ?? '';
+    expect(glabCall).toContain("--author 'alice'");
+  });
+
+  // --- gitlab: empty result ---
+  test('gitlab empty_result — returns {prs: []} not an error', async () => {
+    execRegistry['git remote get-url origin'] = 'https://gitlab.com/org/repo.git';
+    execRegistry['glab mr list'] = JSON.stringify([]);
+
+    const result = await prListHandler.execute({ head: 'feature/99-none' });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(true);
+    expect(data.prs).toEqual([]);
+  });
+
+  // --- gitlab: default limit via --per-page ---
+  test('gitlab default_limit — uses --per-page 20 by default', async () => {
+    execRegistry['git remote get-url origin'] = 'https://gitlab.com/org/repo.git';
+    execRegistry['glab mr list'] = JSON.stringify([]);
+
+    await prListHandler.execute({});
+    const glabCall = execCalls.find((c) => c.startsWith('glab mr list')) ?? '';
+    expect(glabCall).toContain('--per-page 20');
+  });
+
+  // --- gitlab: normalizes field names ---
+  test('gitlab normalize — maps source_branch/target_branch to head/base and iid to number', async () => {
+    execRegistry['git remote get-url origin'] = 'https://gitlab.com/org/repo.git';
+    execRegistry['glab mr list'] = JSON.stringify([
+      {
+        iid: 21,
+        title: 'Docs update',
+        state: 'opened',
+        source_branch: 'docs/21-update',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/21',
+      },
+    ]);
+
+    const result = await prListHandler.execute({});
+    const data = parseResult(result.content);
+    const prs = data.prs as Array<Record<string, unknown>>;
+
+    expect(prs[0]).toEqual({
+      number: 21,
+      title: 'Docs update',
+      state: 'opened',
+      head: 'docs/21-update',
+      base: 'main',
+      url: 'https://gitlab.com/org/repo/-/merge_requests/21',
+    });
+  });
+
+  // --- invalid state rejected by zod ---
+  test('invalid_state — returns ok:false when state is not in enum', async () => {
+    const result = await prListHandler.execute({ state: 'bogus' });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(false);
+    expect(typeof data.error).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary

Add `pr_list` MCP tool that lists PRs/MRs filtered by head branch, base branch, state, author, and limit. Used by /scp to check if a PR already exists for the current branch before creating a new one. Returns normalized {prs: [...]} shape across platforms.

## Changes

- Add the new handler file (auto-discovered by codegen registry)
- Add unit tests covering both GitHub and GitLab paths plus error cases

## Linked Issues

Closes #83

## Test Plan

- [x] `./scripts/ci/validate.sh` passes (codegen, tsc, shellcheck, all tests, runtime smoke)
- [x] New handler appears in `tools/list` via the registry codegen
- [x] Both GitHub and GitLab code paths covered by unit tests
- [x] Error paths return `{ok: false, error}` envelope consistently with the codebase

Generated with [Claude Code](https://claude.com/claude-code)
