### PR TITLE
feat(sdlc-mcp): ci_run_status handler

### DIFF
--- a/handlers/ci_run_status.ts
+++ b/handlers/ci_run_status.ts
@@ -1,0 +1,315 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z
+  .object({
+    ref: z.string().min(1, 'ref must be a non-empty string'),
+    workflow_name: z.string().optional(),
+  })
+  .strict();
+
+type Input = z.infer<typeof inputSchema>;
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+function exec(cmd: string): string {
+  return execSync(cmd, { encoding: 'utf8' }).trim();
+}
+
+function detectPlatform(): 'github' | 'gitlab' {
+  try {
+    const url = exec('git remote get-url origin');
+    return url.includes('github') ? 'github' : 'gitlab';
+  } catch {
+    return 'github';
+  }
+}
+
+function isSha(ref: string): boolean {
+  return SHA_PATTERN.test(ref);
+}
+
+function shellQuote(value: string): string {
+  // Conservative: reject characters that could break shell quoting.
+  if (!/^[A-Za-z0-9._\/-]+$/.test(value)) {
+    throw new Error(`invalid characters in argument: ${value}`);
+  }
+  return `"${value}"`;
+}
+
+interface NormalizedRun {
+  run_id: number;
+  workflow_name: string;
+  status: 'queued' | 'in_progress' | 'completed';
+  conclusion:
+    | 'success'
+    | 'failure'
+    | 'cancelled'
+    | 'skipped'
+    | 'timed_out'
+    | null;
+  url: string;
+  ref: string;
+  sha: string;
+  created_at: string;
+  finished_at: string | null;
+}
+
+interface GhRun {
+  databaseId: number;
+  name: string;
+  status: string;
+  conclusion: string | null;
+  url: string;
+  headBranch: string;
+  headSha: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface GlRun {
+  id: number;
+  status: string;
+  web_url: string;
+  ref: string;
+  sha: string;
+  created_at: string;
+  updated_at: string;
+  finished_at?: string | null;
+  name?: string | null;
+  // glab sometimes exposes source/name in different forms across versions.
+  source?: string | null;
+}
+
+function normalizeGhStatus(status: string): 'queued' | 'in_progress' | 'completed' {
+  switch (status) {
+    case 'queued':
+    case 'waiting':
+    case 'pending':
+    case 'requested':
+      return 'queued';
+    case 'in_progress':
+    case 'running':
+      return 'in_progress';
+    case 'completed':
+    default:
+      return 'completed';
+  }
+}
+
+function normalizeGhConclusion(
+  value: string | null
+):
+  | 'success'
+  | 'failure'
+  | 'cancelled'
+  | 'skipped'
+  | 'timed_out'
+  | null {
+  if (!value) return null;
+  switch (value) {
+    case 'success':
+    case 'failure':
+    case 'cancelled':
+    case 'skipped':
+    case 'timed_out':
+      return value;
+    case 'neutral':
+    case 'action_required':
+    case 'stale':
+      return 'failure';
+    default:
+      return null;
+  }
+}
+
+function normalizeGlStatus(
+  status: string
+): 'queued' | 'in_progress' | 'completed' {
+  switch (status) {
+    case 'created':
+    case 'waiting_for_resource':
+    case 'preparing':
+    case 'pending':
+    case 'scheduled':
+    case 'manual':
+      return 'queued';
+    case 'running':
+      return 'in_progress';
+    case 'success':
+    case 'failed':
+    case 'canceled':
+    case 'cancelled':
+    case 'skipped':
+      return 'completed';
+    default:
+      return 'completed';
+  }
+}
+
+function normalizeGlConclusion(
+  status: string
+):
+  | 'success'
+  | 'failure'
+  | 'cancelled'
+  | 'skipped'
+  | 'timed_out'
+  | null {
+  switch (status) {
+    case 'success':
+      return 'success';
+    case 'failed':
+      return 'failure';
+    case 'canceled':
+    case 'cancelled':
+      return 'cancelled';
+    case 'skipped':
+      return 'skipped';
+    default:
+      return null;
+  }
+}
+
+function ghQueryRuns(
+  ref: string,
+  workflowName: string | undefined
+): GhRun[] {
+  const selector = isSha(ref)
+    ? `--commit ${shellQuote(ref)}`
+    : `--branch ${shellQuote(ref)}`;
+  const workflow = workflowName ? ` --workflow ${shellQuote(workflowName)}` : '';
+  const cmd = `gh run list ${selector}${workflow} --limit 1 --json databaseId,name,status,conclusion,url,headBranch,headSha,createdAt,updatedAt`;
+  const raw = exec(cmd);
+  if (!raw) return [];
+  return JSON.parse(raw) as GhRun[];
+}
+
+function glQueryRuns(
+  ref: string,
+  workflowName: string | undefined
+): GlRun[] {
+  // GitLab pipelines don't carry a workflow "name" the way GitHub does; we
+  // list without filter and then apply workflow_name client-side against the
+  // "name"/"source" fields for best-effort matching.
+  const selector = isSha(ref)
+    ? `--sha ${shellQuote(ref)}`
+    : `--branch ${shellQuote(ref)}`;
+  const pageSize = workflowName ? '20' : '1';
+  const cmd = `glab ci list ${selector} --per-page ${pageSize} --output json`;
+  const raw = exec(cmd);
+  if (!raw) return [];
+  const runs = JSON.parse(raw) as GlRun[];
+  if (!workflowName) return runs;
+  return runs.filter((r) => {
+    const name = r.name ?? r.source ?? '';
+    return name === workflowName;
+  });
+}
+
+function normalizeGh(run: GhRun): NormalizedRun {
+  const status = normalizeGhStatus(run.status);
+  const conclusion = normalizeGhConclusion(run.conclusion);
+  return {
+    run_id: run.databaseId,
+    workflow_name: run.name,
+    status,
+    conclusion,
+    url: run.url,
+    ref: run.headBranch,
+    sha: run.headSha,
+    created_at: run.createdAt,
+    finished_at: status === 'completed' ? run.updatedAt : null,
+  };
+}
+
+function normalizeGl(run: GlRun): NormalizedRun {
+  const status = normalizeGlStatus(run.status);
+  const conclusion = normalizeGlConclusion(run.status);
+  return {
+    run_id: run.id,
+    workflow_name: run.name ?? run.source ?? '',
+    status,
+    conclusion,
+    url: run.web_url,
+    ref: run.ref,
+    sha: run.sha,
+    created_at: run.created_at,
+    finished_at: run.finished_at ?? (status === 'completed' ? run.updated_at : null),
+  };
+}
+
+const ciRunStatusHandler: HandlerDef = {
+  name: 'ci_run_status',
+  description:
+    'Get the latest CI workflow/pipeline run status for a commit SHA or branch ref, optionally filtered by workflow name.',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: Input;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [
+          { type: 'text' as const, text: JSON.stringify({ ok: false, error }) },
+        ],
+      };
+    }
+
+    try {
+      const platform = detectPlatform();
+
+      let normalized: NormalizedRun | null = null;
+
+      if (platform === 'github') {
+        const runs = ghQueryRuns(args.ref, args.workflow_name);
+        if (runs.length > 0) {
+          normalized = normalizeGh(runs[0]);
+        }
+      } else {
+        const runs = glQueryRuns(args.ref, args.workflow_name);
+        if (runs.length > 0) {
+          normalized = normalizeGl(runs[0]);
+        }
+      }
+
+      if (!normalized) {
+        const filter = args.workflow_name
+          ? ` with workflow '${args.workflow_name}'`
+          : '';
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                ok: false,
+                code: 'no_runs_found',
+                error: `no CI runs found for ref '${args.ref}'${filter}`,
+              }),
+            },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({ ok: true, data: normalized }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [
+          { type: 'text' as const, text: JSON.stringify({ ok: false, error }) },
+        ],
+      };
+    }
+  },
+};
+
+export default ciRunStatusHandler;

--- a/tests/ci_run_status.test.ts
+++ b/tests/ci_run_status.test.ts
@@ -1,0 +1,338 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+// --- Mock child_process.execSync at module level ---
+// Individual tests populate execRegistry with prefix→output pairs.
+
+let execRegistry: Record<string, string> = {};
+let execCalls: string[] = [];
+let execError: Error | null = null;
+
+function mockExec(cmd: string): string {
+  execCalls.push(cmd);
+  if (execError) throw execError;
+  for (const [key, value] of Object.entries(execRegistry)) {
+    if (cmd.includes(key)) return value;
+  }
+  throw new Error(`Unexpected exec call: ${cmd}`);
+}
+
+mock.module('child_process', () => ({
+  execSync: (cmd: string, _opts?: unknown) => mockExec(cmd),
+}));
+
+// Import AFTER mock registration.
+const { default: ciRunStatusHandler } = await import(
+  '../handlers/ci_run_status.ts'
+);
+
+function parseResult(content: Array<{ type: string; text: string }>) {
+  return JSON.parse(content[0].text) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  execRegistry = {};
+  execCalls = [];
+  execError = null;
+});
+
+describe('ci_run_status handler', () => {
+  // --- GitHub: branch ref ---
+  test('github_branch_ref — returns normalized run for branch lookup', async () => {
+    execRegistry['git remote get-url origin'] =
+      'https://github.com/org/repo.git';
+    execRegistry['gh run list --branch'] = JSON.stringify([
+      {
+        databaseId: 12345,
+        name: 'CI',
+        status: 'completed',
+        conclusion: 'success',
+        url: 'https://github.com/org/repo/actions/runs/12345',
+        headBranch: 'feature/42-thing',
+        headSha: 'abcdef0123456789abcdef0123456789abcdef01',
+        createdAt: '2025-01-01T00:00:00Z',
+        updatedAt: '2025-01-01T00:05:00Z',
+      },
+    ]);
+
+    const result = await ciRunStatusHandler.execute({
+      ref: 'feature/42-thing',
+    });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(true);
+    const run = data.data as Record<string, unknown>;
+    expect(run.run_id).toBe(12345);
+    expect(run.workflow_name).toBe('CI');
+    expect(run.status).toBe('completed');
+    expect(run.conclusion).toBe('success');
+    expect(run.url).toBe('https://github.com/org/repo/actions/runs/12345');
+    expect(run.ref).toBe('feature/42-thing');
+    expect(run.sha).toBe('abcdef0123456789abcdef0123456789abcdef01');
+    expect(run.created_at).toBe('2025-01-01T00:00:00Z');
+    expect(run.finished_at).toBe('2025-01-01T00:05:00Z');
+
+    // Verify selector was --branch, not --commit.
+    const runListCall = execCalls.find((c) => c.includes('gh run list')) ?? '';
+    expect(runListCall).toContain('--branch');
+    expect(runListCall).not.toContain('--commit');
+  });
+
+  // --- GitHub: SHA ref ---
+  test('github_sha_ref — 40-char hex ref uses --commit', async () => {
+    const sha = '0123456789abcdef0123456789abcdef01234567';
+    execRegistry['git remote get-url origin'] =
+      'https://github.com/org/repo.git';
+    execRegistry['gh run list --commit'] = JSON.stringify([
+      {
+        databaseId: 7777,
+        name: 'Build',
+        status: 'in_progress',
+        conclusion: null,
+        url: 'https://github.com/org/repo/actions/runs/7777',
+        headBranch: 'main',
+        headSha: sha,
+        createdAt: '2025-02-02T10:00:00Z',
+        updatedAt: '2025-02-02T10:03:00Z',
+      },
+    ]);
+
+    const result = await ciRunStatusHandler.execute({ ref: sha });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(true);
+    const run = data.data as Record<string, unknown>;
+    expect(run.run_id).toBe(7777);
+    expect(run.status).toBe('in_progress');
+    expect(run.conclusion).toBeNull();
+    // in_progress → finished_at null
+    expect(run.finished_at).toBeNull();
+
+    const runListCall = execCalls.find((c) => c.includes('gh run list')) ?? '';
+    expect(runListCall).toContain('--commit');
+    expect(runListCall).not.toContain('--branch');
+  });
+
+  // --- GitHub: workflow_name filter ---
+  test('github_workflow_filter — passes --workflow flag to gh', async () => {
+    execRegistry['git remote get-url origin'] =
+      'https://github.com/org/repo.git';
+    execRegistry['gh run list --branch'] = JSON.stringify([
+      {
+        databaseId: 999,
+        name: 'Deploy',
+        status: 'completed',
+        conclusion: 'success',
+        url: 'https://github.com/org/repo/actions/runs/999',
+        headBranch: 'main',
+        headSha: 'fedcba9876543210fedcba9876543210fedcba98',
+        createdAt: '2025-03-03T00:00:00Z',
+        updatedAt: '2025-03-03T00:02:00Z',
+      },
+    ]);
+
+    const result = await ciRunStatusHandler.execute({
+      ref: 'main',
+      workflow_name: 'Deploy',
+    });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(true);
+    expect((data.data as Record<string, unknown>).workflow_name).toBe('Deploy');
+
+    const runListCall = execCalls.find((c) => c.includes('gh run list')) ?? '';
+    expect(runListCall).toContain('--workflow');
+    expect(runListCall).toContain('Deploy');
+  });
+
+  // --- No runs found: structured error with code ---
+  test('no_runs_found — returns structured error when list is empty', async () => {
+    execRegistry['git remote get-url origin'] =
+      'https://github.com/org/repo.git';
+    execRegistry['gh run list --branch'] = JSON.stringify([]);
+
+    const result = await ciRunStatusHandler.execute({ ref: 'branch-no-runs' });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(false);
+    expect(data.code).toBe('no_runs_found');
+    expect((data.error as string)).toContain('no CI runs found');
+    expect((data.error as string)).toContain('branch-no-runs');
+  });
+
+  // --- No runs found with workflow filter mentions the filter ---
+  test('no_runs_found_with_filter — error message includes workflow filter', async () => {
+    execRegistry['git remote get-url origin'] =
+      'https://github.com/org/repo.git';
+    execRegistry['gh run list --branch'] = JSON.stringify([]);
+
+    const result = await ciRunStatusHandler.execute({
+      ref: 'main',
+      workflow_name: 'Nightly',
+    });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(false);
+    expect(data.code).toBe('no_runs_found');
+    expect((data.error as string)).toContain("Nightly");
+  });
+
+  // --- GitLab: branch ref ---
+  test('gitlab_branch_ref — uses glab with --branch and normalizes status', async () => {
+    execRegistry['git remote get-url origin'] =
+      'https://gitlab.com/org/repo.git';
+    execRegistry['glab ci list --branch'] = JSON.stringify([
+      {
+        id: 555,
+        status: 'success',
+        web_url: 'https://gitlab.com/org/repo/-/pipelines/555',
+        ref: 'feature/5-gl',
+        sha: 'aabbccddeeff0011223344556677889900aabbcc',
+        created_at: '2025-04-04T12:00:00Z',
+        updated_at: '2025-04-04T12:05:00Z',
+        finished_at: '2025-04-04T12:05:00Z',
+        name: 'pipeline',
+        source: 'push',
+      },
+    ]);
+
+    const result = await ciRunStatusHandler.execute({ ref: 'feature/5-gl' });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(true);
+    const run = data.data as Record<string, unknown>;
+    expect(run.run_id).toBe(555);
+    expect(run.status).toBe('completed');
+    expect(run.conclusion).toBe('success');
+    expect(run.url).toBe('https://gitlab.com/org/repo/-/pipelines/555');
+    expect(run.ref).toBe('feature/5-gl');
+
+    const listCall = execCalls.find((c) => c.includes('glab ci list')) ?? '';
+    expect(listCall).toContain('--branch');
+    expect(listCall).not.toContain('--sha');
+  });
+
+  // --- GitLab: SHA ref ---
+  test('gitlab_sha_ref — 40-char hex uses --sha on glab', async () => {
+    const sha = '11223344556677889900aabbccddeeff00112233';
+    execRegistry['git remote get-url origin'] =
+      'https://gitlab.com/org/repo.git';
+    execRegistry['glab ci list --sha'] = JSON.stringify([
+      {
+        id: 42,
+        status: 'failed',
+        web_url: 'https://gitlab.com/org/repo/-/pipelines/42',
+        ref: 'main',
+        sha,
+        created_at: '2025-05-05T00:00:00Z',
+        updated_at: '2025-05-05T00:10:00Z',
+        finished_at: '2025-05-05T00:10:00Z',
+        name: null,
+        source: 'merge_request_event',
+      },
+    ]);
+
+    const result = await ciRunStatusHandler.execute({ ref: sha });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(true);
+    const run = data.data as Record<string, unknown>;
+    expect(run.run_id).toBe(42);
+    expect(run.status).toBe('completed');
+    expect(run.conclusion).toBe('failure');
+    expect(run.sha).toBe(sha);
+
+    const listCall = execCalls.find((c) => c.includes('glab ci list')) ?? '';
+    expect(listCall).toContain('--sha');
+    expect(listCall).not.toContain('--branch');
+  });
+
+  // --- GitLab: workflow_name filters client-side ---
+  test('gitlab_workflow_filter — filters pipelines by name client-side', async () => {
+    execRegistry['git remote get-url origin'] =
+      'https://gitlab.com/org/repo.git';
+    execRegistry['glab ci list --branch'] = JSON.stringify([
+      {
+        id: 1,
+        status: 'success',
+        web_url: 'https://gitlab.com/org/repo/-/pipelines/1',
+        ref: 'main',
+        sha: 'aa11bb22cc33dd44ee55ff6677889900aabbccdd',
+        created_at: '2025-06-06T00:00:00Z',
+        updated_at: '2025-06-06T00:01:00Z',
+        finished_at: '2025-06-06T00:01:00Z',
+        name: 'other',
+        source: 'push',
+      },
+      {
+        id: 2,
+        status: 'success',
+        web_url: 'https://gitlab.com/org/repo/-/pipelines/2',
+        ref: 'main',
+        sha: 'bb22cc33dd44ee55ff66778899001122334455aa',
+        created_at: '2025-06-06T00:02:00Z',
+        updated_at: '2025-06-06T00:03:00Z',
+        finished_at: '2025-06-06T00:03:00Z',
+        name: 'nightly',
+        source: 'schedule',
+      },
+    ]);
+
+    const result = await ciRunStatusHandler.execute({
+      ref: 'main',
+      workflow_name: 'nightly',
+    });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(true);
+    const run = data.data as Record<string, unknown>;
+    expect(run.run_id).toBe(2);
+    expect(run.workflow_name).toBe('nightly');
+  });
+
+  // --- GitLab: no runs matching filter yields structured error ---
+  test('gitlab_no_runs — no matching pipeline returns no_runs_found error', async () => {
+    execRegistry['git remote get-url origin'] =
+      'https://gitlab.com/org/repo.git';
+    execRegistry['glab ci list --branch'] = JSON.stringify([
+      {
+        id: 10,
+        status: 'success',
+        web_url: 'https://gitlab.com/org/repo/-/pipelines/10',
+        ref: 'main',
+        sha: 'cc33dd44ee55ff66778899001122334455aabbcc',
+        created_at: '2025-07-07T00:00:00Z',
+        updated_at: '2025-07-07T00:01:00Z',
+        name: 'build',
+        source: 'push',
+      },
+    ]);
+
+    const result = await ciRunStatusHandler.execute({
+      ref: 'main',
+      workflow_name: 'release',
+    });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(false);
+    expect(data.code).toBe('no_runs_found');
+  });
+
+  // --- Input validation: missing ref ---
+  test('validation — missing ref returns error', async () => {
+    const result = await ciRunStatusHandler.execute({});
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+    expect(typeof data.error).toBe('string');
+  });
+
+  // --- Input validation: unsafe ref characters ---
+  test('validation — shell-unsafe ref characters surface as error', async () => {
+    execRegistry['git remote get-url origin'] =
+      'https://github.com/org/repo.git';
+
+    const result = await ciRunStatusHandler.execute({ ref: 'main; rm -rf /' });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+    expect(typeof data.error).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary

Add `ci_run_status` MCP tool returning the latest workflow/pipeline run status for a commit SHA or branch ref. Auto-detects ref type (40-char hex = SHA, otherwise branch). Optional workflow_name filter (native on GitHub, client-side on GitLab). Returns structured no_runs_found error when no runs match.

## Changes

- Add the new handler file (auto-discovered by codegen registry)
- Add unit tests covering both GitHub and GitLab paths plus error cases

## Linked Issues

Closes #84

## Test Plan

- [x] `./scripts/ci/validate.sh` passes (codegen, tsc, shellcheck, all tests, runtime smoke)
- [x] New handler appears in `tools/list` via the registry codegen
- [x] Both GitHub and GitLab code paths covered by unit tests
- [x] Error paths return `{ok: false, error}` envelope consistently with the codebase

Generated with [Claude Code](https://claude.com/claude-code)
