### PR TITLE
feat(sdlc-mcp): ci_run_logs handler with truncation

### DIFF
--- a/handlers/ci_run_logs.ts
+++ b/handlers/ci_run_logs.ts
@@ -1,0 +1,200 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const HARD_MAX_LINES = 10000;
+const DEFAULT_MAX_LINES = 2000;
+
+const inputSchema = z.object({
+  run_id: z.number().int().nonnegative(),
+  job_id: z.number().int().nonnegative().optional(),
+  failed_only: z.boolean().optional().default(true),
+  max_lines: z.number().int().positive().optional().default(DEFAULT_MAX_LINES),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+interface FetchResult {
+  logs: string;
+  job_id: number | null;
+  url: string;
+}
+
+function exec(cmd: string): string {
+  return execSync(cmd, { encoding: 'utf8', maxBuffer: 1024 * 1024 * 64 });
+}
+
+function detectPlatform(): 'github' | 'gitlab' {
+  try {
+    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    return url.includes('gitlab') ? 'gitlab' : 'github';
+  } catch {
+    return 'github';
+  }
+}
+
+function parseRepoSlug(): string | null {
+  try {
+    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    const m = /[/:]([^/]+)\/([^/.]+?)(\.git)?$/.exec(url);
+    if (m) return `${m[1]}/${m[2]}`;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function fetchGithub(args: Input): FetchResult {
+  const parts = ['gh run view', String(args.run_id)];
+  if (args.job_id !== undefined) {
+    parts.push('--job', String(args.job_id));
+  }
+  parts.push(args.failed_only ? '--log-failed' : '--log');
+  const cmd = parts.join(' ');
+  const logs = exec(cmd);
+
+  const slug = parseRepoSlug();
+  const url = slug
+    ? `https://github.com/${slug}/actions/runs/${args.run_id}`
+    : `https://github.com/actions/runs/${args.run_id}`;
+
+  return {
+    logs,
+    job_id: args.job_id ?? null,
+    url,
+  };
+}
+
+interface GitlabJob {
+  id: number;
+  status: string;
+  web_url?: string;
+}
+
+function gitlabProjectPath(): string {
+  // URL-encoded project path for glab api
+  const slug = parseRepoSlug();
+  if (!slug) throw new Error('could not parse gitlab project path from origin url');
+  return encodeURIComponent(slug);
+}
+
+function fetchGitlab(args: Input): FetchResult {
+  let jobId = args.job_id;
+
+  if (jobId === undefined) {
+    // Fetch the first failed job from the pipeline
+    const projectPath = gitlabProjectPath();
+    const raw = exec(`glab api projects/${projectPath}/pipelines/${args.run_id}/jobs`);
+    const jobs = JSON.parse(raw) as GitlabJob[];
+    const failed = jobs.find(j => j.status === 'failed');
+    if (!failed) {
+      throw new Error(`no failed job found in pipeline ${args.run_id}`);
+    }
+    jobId = failed.id;
+  }
+
+  const logs = exec(`glab ci trace ${jobId}`);
+
+  const slug = parseRepoSlug();
+  const url = slug
+    ? `https://gitlab.com/${slug}/-/jobs/${jobId}`
+    : `https://gitlab.com/-/jobs/${jobId}`;
+
+  return {
+    logs,
+    job_id: jobId,
+    url,
+  };
+}
+
+interface TruncationResult {
+  logs: string;
+  line_count: number;
+  truncated: boolean;
+}
+
+export function truncateLogs(rawLogs: string, requestedMax: number): TruncationResult {
+  // Enforce hard cap regardless of caller override
+  const effectiveMax = Math.min(requestedMax, HARD_MAX_LINES);
+
+  // Split preserving content. Strip a single trailing empty line from a
+  // trailing newline so we don't count it as a "line".
+  let lines = rawLogs.split('\n');
+  if (lines.length > 0 && lines[lines.length - 1] === '') {
+    lines = lines.slice(0, -1);
+  }
+  const originalCount = lines.length;
+
+  if (originalCount <= effectiveMax) {
+    return {
+      logs: lines.join('\n'),
+      line_count: originalCount,
+      truncated: false,
+    };
+  }
+
+  const halfHead = Math.floor(effectiveMax / 2);
+  const halfTail = effectiveMax - halfHead;
+  const head = lines.slice(0, halfHead);
+  const tail = lines.slice(lines.length - halfTail);
+  const omitted = originalCount - head.length - tail.length;
+  const marker = `... [${omitted} lines omitted] ...`;
+
+  const out = [...head, marker, ...tail].join('\n');
+  // line_count reflects the original log size so callers can see how big the real log was
+  return {
+    logs: out,
+    line_count: originalCount,
+    truncated: true,
+  };
+}
+
+const ciRunLogsHandler: HandlerDef = {
+  name: 'ci_run_logs',
+  description:
+    'Fetch logs for a CI run (GitHub) or pipeline job (GitLab), truncated to keep response size sane. Used by /jfail.',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: Input;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const platform = detectPlatform();
+      const fetched =
+        platform === 'github' ? fetchGithub(args) : fetchGitlab(args);
+
+      const { logs, line_count, truncated } = truncateLogs(fetched.logs, args.max_lines);
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              run_id: args.run_id,
+              job_id: fetched.job_id,
+              logs,
+              line_count,
+              truncated,
+              url: fetched.url,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default ciRunLogsHandler;

--- a/tests/ci_run_logs.test.ts
+++ b/tests/ci_run_logs.test.ts
@@ -1,0 +1,285 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string, _opts?: unknown) => execMockFn(cmd));
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const handlerModule = await import('../handlers/ci_run_logs.ts');
+const handler = handlerModule.default;
+const { truncateLogs } = handlerModule;
+
+function resetMocks() {
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text) as Record<string, unknown>;
+}
+
+function makeLines(n: number, prefix = 'line'): string {
+  return Array.from({ length: n }, (_, i) => `${prefix}-${i + 1}`).join('\n');
+}
+
+describe('ci_run_logs handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('ci_run_logs');
+    expect(typeof handler.execute).toBe('function');
+    expect(handler.description).toBeTruthy();
+  });
+
+  test('invalid args — returns error result', async () => {
+    const result = await handler.execute({ run_id: 'not-a-number' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(typeof parsed.error).toBe('string');
+  });
+
+  // --- GitHub platform ---
+
+  test('github — failed-only logs, short content (no truncation)', async () => {
+    const logContent = makeLines(10);
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      if (cmd.includes('gh run view') && cmd.includes('--log-failed')) return logContent;
+      throw new Error(`unexpected cmd: ${cmd}`);
+    };
+
+    const result = await handler.execute({ run_id: 12345 });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.run_id).toBe(12345);
+    expect(parsed.job_id).toBeNull();
+    expect(parsed.truncated).toBe(false);
+    expect(parsed.line_count).toBe(10);
+    expect(parsed.logs).toBe(logContent);
+    expect((parsed.url as string)).toContain('org/repo');
+    expect((parsed.url as string)).toContain('12345');
+  });
+
+  test('github — uses --log (not --log-failed) when failed_only=false', async () => {
+    let sawFullLog = false;
+    let sawFailedOnly = false;
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      if (cmd.includes('gh run view')) {
+        if (cmd.includes('--log-failed')) sawFailedOnly = true;
+        if (cmd.includes('--log') && !cmd.includes('--log-failed')) sawFullLog = true;
+        return 'some logs\n';
+      }
+      throw new Error(`unexpected cmd: ${cmd}`);
+    };
+
+    const result = await handler.execute({ run_id: 1, failed_only: false });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(sawFullLog).toBe(true);
+    expect(sawFailedOnly).toBe(false);
+  });
+
+  test('github — specific job_id passes --job flag', async () => {
+    let jobFlagSeen = false;
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      if (cmd.includes('gh run view')) {
+        if (cmd.includes('--job 999')) jobFlagSeen = true;
+        return 'job logs\n';
+      }
+      throw new Error(`unexpected cmd: ${cmd}`);
+    };
+
+    const result = await handler.execute({ run_id: 42, job_id: 999 });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(jobFlagSeen).toBe(true);
+    expect(parsed.job_id).toBe(999);
+  });
+
+  test('github — long log triggers truncation at max_lines', async () => {
+    const longLog = makeLines(500);
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      if (cmd.includes('gh run view')) return longLog;
+      throw new Error(`unexpected cmd: ${cmd}`);
+    };
+
+    const result = await handler.execute({ run_id: 1, max_lines: 100 });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.truncated).toBe(true);
+    expect(parsed.line_count).toBe(500);
+    const logs = parsed.logs as string;
+    expect(logs).toContain('lines omitted');
+    // Head and tail should both be present
+    expect(logs).toContain('line-1');
+    expect(logs).toContain('line-500');
+    // A middle line should NOT be present
+    expect(logs).not.toContain('line-250');
+  });
+
+  test('github — hard cap at 10000 overrides caller max_lines', async () => {
+    const hugeLog = makeLines(50000);
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      if (cmd.includes('gh run view')) return hugeLog;
+      throw new Error(`unexpected cmd: ${cmd}`);
+    };
+
+    // Caller asks for 20000 but hard cap is 10000
+    const result = await handler.execute({ run_id: 1, max_lines: 20000 });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.truncated).toBe(true);
+    expect(parsed.line_count).toBe(50000);
+
+    // Output should be capped: ~10000 lines of content + 1 marker line
+    const logs = parsed.logs as string;
+    const outLineCount = logs.split('\n').length;
+    expect(outLineCount).toBeLessThanOrEqual(10001);
+    expect(outLineCount).toBeGreaterThan(9000);
+    expect(logs).toContain('lines omitted');
+  });
+
+  // --- GitLab platform ---
+
+  test('gitlab — with explicit job_id uses glab ci trace directly', async () => {
+    const logContent = makeLines(5, 'gl');
+    let tracedJob = 0;
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://gitlab.com/grp/proj.git\n';
+      if (cmd.startsWith('glab ci trace')) {
+        const m = /glab ci trace (\d+)/.exec(cmd);
+        if (m) tracedJob = parseInt(m[1], 10);
+        return logContent;
+      }
+      throw new Error(`unexpected cmd: ${cmd}`);
+    };
+
+    const result = await handler.execute({ run_id: 10, job_id: 77 });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(tracedJob).toBe(77);
+    expect(parsed.job_id).toBe(77);
+    expect(parsed.truncated).toBe(false);
+    expect(parsed.line_count).toBe(5);
+    expect((parsed.url as string)).toContain('grp/proj');
+    expect((parsed.url as string)).toContain('/jobs/77');
+  });
+
+  test('gitlab — without job_id fetches first failed job from pipeline', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://gitlab.com/grp/proj.git\n';
+      if (cmd.includes('glab api') && cmd.includes('/pipelines/55/jobs')) {
+        return JSON.stringify([
+          { id: 100, status: 'success' },
+          { id: 101, status: 'failed' },
+          { id: 102, status: 'failed' },
+        ]);
+      }
+      if (cmd.startsWith('glab ci trace 101')) {
+        return 'failed job log\n';
+      }
+      throw new Error(`unexpected cmd: ${cmd}`);
+    };
+
+    const result = await handler.execute({ run_id: 55 });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.job_id).toBe(101);
+    expect(parsed.truncated).toBe(false);
+    expect(parsed.logs).toBe('failed job log');
+  });
+
+  test('gitlab — no failed job in pipeline returns error', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://gitlab.com/grp/proj.git\n';
+      if (cmd.includes('glab api') && cmd.includes('/pipelines/99/jobs')) {
+        return JSON.stringify([{ id: 1, status: 'success' }]);
+      }
+      throw new Error(`unexpected cmd: ${cmd}`);
+    };
+
+    const result = await handler.execute({ run_id: 99 });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(false);
+    expect((parsed.error as string)).toContain('no failed job');
+  });
+
+  test('gitlab — long log triggers truncation', async () => {
+    const longLog = makeLines(1200);
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://gitlab.com/grp/proj.git\n';
+      if (cmd.startsWith('glab ci trace')) return longLog;
+      throw new Error(`unexpected cmd: ${cmd}`);
+    };
+
+    const result = await handler.execute({ run_id: 1, job_id: 5, max_lines: 200 });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.truncated).toBe(true);
+    expect(parsed.line_count).toBe(1200);
+    expect((parsed.logs as string)).toContain('lines omitted');
+  });
+});
+
+// --- truncateLogs unit tests (direct) ---
+
+describe('truncateLogs', () => {
+  test('short log — no truncation', () => {
+    const r = truncateLogs('a\nb\nc\n', 100);
+    expect(r.truncated).toBe(false);
+    expect(r.line_count).toBe(3);
+    expect(r.logs).toBe('a\nb\nc');
+  });
+
+  test('exact size match — no truncation', () => {
+    const r = truncateLogs('a\nb\nc', 3);
+    expect(r.truncated).toBe(false);
+    expect(r.line_count).toBe(3);
+  });
+
+  test('over max_lines — head+tail split with marker', () => {
+    const input = Array.from({ length: 20 }, (_, i) => `L${i}`).join('\n');
+    const r = truncateLogs(input, 6);
+    expect(r.truncated).toBe(true);
+    expect(r.line_count).toBe(20);
+    // 6/2 = 3 head + 3 tail + marker line
+    const outLines = r.logs.split('\n');
+    expect(outLines.length).toBe(7);
+    expect(outLines[0]).toBe('L0');
+    expect(outLines[1]).toBe('L1');
+    expect(outLines[2]).toBe('L2');
+    expect(outLines[3]).toContain('14 lines omitted');
+    expect(outLines[4]).toBe('L17');
+    expect(outLines[5]).toBe('L18');
+    expect(outLines[6]).toBe('L19');
+  });
+
+  test('hard cap — caller max_lines above 10000 capped to 10000', () => {
+    const input = Array.from({ length: 50000 }, (_, i) => `L${i}`).join('\n');
+    const r = truncateLogs(input, 20000);
+    expect(r.truncated).toBe(true);
+    expect(r.line_count).toBe(50000);
+    const outLines = r.logs.split('\n');
+    // 10000 lines kept + 1 marker
+    expect(outLines.length).toBe(10001);
+  });
+
+  test('empty input', () => {
+    const r = truncateLogs('', 100);
+    expect(r.truncated).toBe(false);
+    expect(r.line_count).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Add `ci_run_logs` MCP tool that fetches logs for a workflow run or specific job, with truncation (head + tail with omitted marker) above max_lines. Hard cap at 10000 lines regardless of caller override. GitHub supports failed_only via --log-failed; GitLab requires fetching pipeline jobs first to find a job_id.

## Changes

- Add the new handler file (auto-discovered by codegen registry)
- Add unit tests covering both GitHub and GitLab paths plus error cases

## Linked Issues

Closes #85

## Test Plan

- [x] `./scripts/ci/validate.sh` passes (codegen, tsc, shellcheck, all tests, runtime smoke)
- [x] New handler appears in `tools/list` via the registry codegen
- [x] Both GitHub and GitLab code paths covered by unit tests
- [x] Error paths return `{ok: false, error}` envelope consistently with the codebase

Generated with [Claude Code](https://claude.com/claude-code)
