### PR TITLE
feat(sdlc-mcp): devspec_locate handler

### DIFF
--- a/handlers/devspec_locate.ts
+++ b/handlers/devspec_locate.ts
@@ -1,0 +1,99 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  root: z.string().min(1).optional(),
+});
+
+function resolveRoot(explicit?: string): string {
+  if (explicit && explicit.length > 0) return explicit;
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function quoteArg(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+const devspecLocateHandler: HandlerDef = {
+  name: 'devspec_locate',
+  description: 'Find docs/*-devspec.md files in a project root',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    const root = resolveRoot(args.root);
+
+    try {
+      // Verify root directory exists. `test -d` exits non-zero if missing,
+      // which execSync throws on.
+      try {
+        execSync(`test -d ${quoteArg(root)}`, { encoding: 'utf8' });
+      } catch {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                ok: false,
+                error: `root directory does not exist: ${root}`,
+              }),
+            },
+          ],
+        };
+      }
+
+      // docs/ missing is not an error — return an empty list.
+      try {
+        execSync(`test -d ${quoteArg(`${root}/docs`)}`, { encoding: 'utf8' });
+      } catch {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({ ok: true, files: [], count: 0 }),
+            },
+          ],
+        };
+      }
+
+      // Glob via `find`. `-maxdepth 1` keeps it to direct children of docs/,
+      // matching the `docs/*-devspec.md` shell-glob semantics.
+      const cmd = `find docs -maxdepth 1 -type f -name '*-devspec.md'`;
+      const output = execSync(cmd, {
+        cwd: root,
+        encoding: 'utf8',
+      });
+
+      const files = output
+        .split('\n')
+        .map(s => s.trim())
+        .filter(s => s.length > 0)
+        .sort();
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({ ok: true, files, count: files.length }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default devspecLocateHandler;

--- a/tests/devspec_locate.test.ts
+++ b/tests/devspec_locate.test.ts
@@ -1,0 +1,194 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+interface ExecCall {
+  cmd: string;
+  opts: { cwd?: string; encoding?: string } | undefined;
+}
+
+let execCalls: ExecCall[] = [];
+let execMockFn: (cmd: string, opts?: { cwd?: string }) => string = () => '';
+const mockExecSync = mock((cmd: string, opts?: { cwd?: string; encoding?: string }) => {
+  execCalls.push({ cmd, opts });
+  return execMockFn(cmd, opts);
+});
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/devspec_locate.ts');
+
+const ORIGINAL_ENV = process.env.CLAUDE_PROJECT_DIR;
+
+function resetMocks() {
+  execCalls = [];
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+function restoreEnv() {
+  if (ORIGINAL_ENV === undefined) {
+    delete process.env.CLAUDE_PROJECT_DIR;
+  } else {
+    process.env.CLAUDE_PROJECT_DIR = ORIGINAL_ENV;
+  }
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+/**
+ * Build a fake execSync that recognizes the handler's three command shapes:
+ *   1. `test -d '<root>'`           — root existence
+ *   2. `test -d '<root>/docs'`      — docs existence
+ *   3. `find docs -maxdepth 1 ...`  — list devspec files
+ *
+ * Callers configure which directories "exist" and what the find output is.
+ */
+function buildExec(opts: {
+  rootExists: boolean;
+  docsExists: boolean;
+  findOutput: string;
+}) {
+  return (cmd: string) => {
+    if (cmd.startsWith('test -d')) {
+      // Second test -d targets path ending with /docs
+      if (/\/docs'?$/.test(cmd)) {
+        if (!opts.docsExists) throw new Error('docs missing');
+        return '';
+      }
+      if (!opts.rootExists) throw new Error('root missing');
+      return '';
+    }
+    if (cmd.startsWith('find docs')) {
+      return opts.findOutput;
+    }
+    return '';
+  };
+}
+
+describe('devspec_locate handler', () => {
+  beforeEach(() => {
+    resetMocks();
+    delete process.env.CLAUDE_PROJECT_DIR;
+  });
+  afterEach(() => {
+    resetMocks();
+    restoreEnv();
+  });
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('devspec_locate');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('finds single devspec file', async () => {
+    execMockFn = buildExec({
+      rootExists: true,
+      docsExists: true,
+      findOutput: 'docs/alpha-devspec.md\n',
+    });
+    const result = await handler.execute({ root: '/tmp/proj' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.files).toEqual(['docs/alpha-devspec.md']);
+    expect(parsed.count).toBe(1);
+  });
+
+  test('finds and sorts multiple devspec files', async () => {
+    execMockFn = buildExec({
+      rootExists: true,
+      docsExists: true,
+      // Deliberately unsorted to prove the handler sorts.
+      findOutput: 'docs/charlie-devspec.md\ndocs/alpha-devspec.md\ndocs/bravo-devspec.md\n',
+    });
+    const result = await handler.execute({ root: '/tmp/proj' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.files).toEqual([
+      'docs/alpha-devspec.md',
+      'docs/bravo-devspec.md',
+      'docs/charlie-devspec.md',
+    ]);
+    expect(parsed.count).toBe(3);
+  });
+
+  test('returns empty list when none exist', async () => {
+    execMockFn = buildExec({
+      rootExists: true,
+      docsExists: true,
+      findOutput: '',
+    });
+    const result = await handler.execute({ root: '/tmp/proj' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.files).toEqual([]);
+    expect(parsed.count).toBe(0);
+  });
+
+  test('handles missing docs/ directory — not an error', async () => {
+    execMockFn = buildExec({
+      rootExists: true,
+      docsExists: false,
+      findOutput: '',
+    });
+    const result = await handler.execute({ root: '/tmp/proj' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.files).toEqual([]);
+    expect(parsed.count).toBe(0);
+    // find should NOT have been called when docs/ is missing.
+    const findCalls = execCalls.filter(c => c.cmd.startsWith('find docs'));
+    expect(findCalls.length).toBe(0);
+  });
+
+  test('errors on nonexistent root', async () => {
+    execMockFn = buildExec({
+      rootExists: false,
+      docsExists: false,
+      findOutput: '',
+    });
+    const result = await handler.execute({ root: '/tmp/nonexistent' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('/tmp/nonexistent');
+  });
+
+  test('uses CLAUDE_PROJECT_DIR when root param omitted', async () => {
+    process.env.CLAUDE_PROJECT_DIR = '/tmp/env-root';
+    execMockFn = buildExec({
+      rootExists: true,
+      docsExists: true,
+      findOutput: 'docs/env-devspec.md\n',
+    });
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.files).toEqual(['docs/env-devspec.md']);
+    // find should have been invoked with cwd=/tmp/env-root
+    const findCall = execCalls.find(c => c.cmd.startsWith('find docs'));
+    expect(findCall?.opts?.cwd).toBe('/tmp/env-root');
+  });
+
+  test('explicit root param takes precedence over CLAUDE_PROJECT_DIR', async () => {
+    process.env.CLAUDE_PROJECT_DIR = '/tmp/env-root';
+    execMockFn = buildExec({
+      rootExists: true,
+      docsExists: true,
+      findOutput: 'docs/explicit-devspec.md\n',
+    });
+    await handler.execute({ root: '/tmp/explicit' });
+    const findCall = execCalls.find(c => c.cmd.startsWith('find docs'));
+    expect(findCall?.opts?.cwd).toBe('/tmp/explicit');
+  });
+
+  test('find is invoked with correct glob pattern', async () => {
+    execMockFn = buildExec({
+      rootExists: true,
+      docsExists: true,
+      findOutput: '',
+    });
+    await handler.execute({ root: '/tmp/proj' });
+    const findCall = execCalls.find(c => c.cmd.startsWith('find docs'));
+    expect(findCall?.cmd).toContain('-maxdepth 1');
+    expect(findCall?.cmd).toContain(`-name '*-devspec.md'`);
+  });
+});


### PR DESCRIPTION
## Summary

Find docs/*-devspec.md files in a project root. Part of Family 3 (Pipeline Authoring sdlc-mcp migration).

## Changes

- `handlers/devspec_locate.ts` — new handler file
- `tests/devspec_locate.test.ts` — new test file (flat `tests/` layout)
- Handler auto-registers via the codegen handler registry

## Test Results

All local validation green:

- `./scripts/ci/validate.sh` — codegen, tsc, shellcheck, full suite, runtime smoke all pass
- `bun test tests/devspec_locate.test.ts` — all tests pass in isolation AND in the full mcp-server-sdlc suite
- No `mock.module('fs')` partial mocks (per `lesson_mcp_gotchas.md` memory)
- Handler appears in `tools/list` via the runtime smoke test

## Linked Issues

Closes #105

Related: parent epic Wave-Engineering/claudecode-workflow#331

🤖 Generated with [Claude Code](https://claude.com/claude-code)