### PR TITLE
feat(sdlc-mcp): devspec_approve handler

### DIFF
--- a/handlers/devspec_approve.ts
+++ b/handlers/devspec_approve.ts
@@ -1,0 +1,136 @@
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  path: z.string().min(1, 'path must be a non-empty string'),
+  approver: z.string().min(1, 'approver must be a non-empty string'),
+  finalization_score: z.string().optional().default('7/7'),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+const APPROVAL_BLOCK_REGEX = /<!--\s*DEV-SPEC-APPROVAL[\s\S]*?-->\s*\n?/;
+
+/**
+ * Build the DEV-SPEC-APPROVAL comment block with the given metadata.
+ */
+function buildApprovalBlock(approver: string, approvedAt: string, score: string): string {
+  return [
+    '<!-- DEV-SPEC-APPROVAL',
+    'approved: true',
+    `approved_by: ${approver}`,
+    `approved_at: ${approvedAt}`,
+    `finalization_score: ${score}`,
+    '-->',
+  ].join('\n');
+}
+
+/**
+ * Generate a current UTC ISO 8601 timestamp (seconds precision, Z suffix).
+ * Example: 2026-04-08T13:42:00Z
+ */
+function nowIso(): string {
+  const d = new Date();
+  return d.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+/**
+ * Return the end index (exclusive) of the YAML frontmatter block, or 0 if absent.
+ * Frontmatter is a `---` line at position 0 followed by content and a closing `---` line.
+ */
+function frontmatterEndIndex(body: string): number {
+  if (!body.startsWith('---\n') && !body.startsWith('---\r\n')) return 0;
+  // Find the closing '---' line after the opening one.
+  const openLen = body.startsWith('---\r\n') ? 5 : 4;
+  const rest = body.slice(openLen);
+  const closeMatch = /(^|\n)---(\r?\n|$)/.exec(rest);
+  if (!closeMatch) return 0;
+  const closeIdx = closeMatch.index + (closeMatch[1] === '\n' ? 1 : 0);
+  const closeEnd = closeIdx + 3 + (closeMatch[2].length); // include closing --- and its newline
+  return openLen + closeEnd;
+}
+
+/**
+ * Insert the approval block into the document. If an existing block exists it is
+ * replaced in place; otherwise the block is inserted after the frontmatter (if any)
+ * or at the top of the document (before Section 1 / first line).
+ */
+function insertOrReplaceBlock(body: string, block: string): string {
+  if (APPROVAL_BLOCK_REGEX.test(body)) {
+    // Replace existing block, preserving a single trailing newline after.
+    return body.replace(APPROVAL_BLOCK_REGEX, `${block}\n\n`);
+  }
+
+  const fmEnd = frontmatterEndIndex(body);
+  if (fmEnd > 0) {
+    const before = body.slice(0, fmEnd);
+    const after = body.slice(fmEnd);
+    // Ensure a blank line separates frontmatter from the block.
+    const sep = after.startsWith('\n') ? '' : '\n';
+    return `${before}${sep}${block}\n\n${after.replace(/^\n+/, '')}`;
+  }
+
+  // No frontmatter: insert at top of document, before any Section 1 heading.
+  const sep = body.startsWith('\n') ? '' : '';
+  return `${block}\n\n${sep}${body.replace(/^\n+/, '')}`;
+}
+
+const devspecApproveHandler: HandlerDef = {
+  name: 'devspec_approve',
+  description:
+    'Write a DEV-SPEC-APPROVAL metadata comment block into a Dev Spec file. Replaces any existing block.',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: Input;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const file = Bun.file(args.path);
+      if (!(await file.exists())) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({ ok: false, error: `file not found: ${args.path}` }),
+            },
+          ],
+        };
+      }
+
+      const original = await file.text();
+      const approvedAt = nowIso();
+      const block = buildApprovalBlock(args.approver, approvedAt, args.finalization_score);
+      const updated = insertOrReplaceBlock(original, block);
+      await Bun.write(args.path, updated);
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              path: args.path,
+              approved_at: approvedAt,
+              approved_by: args.approver,
+              finalization_score: args.finalization_score,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default devspecApproveHandler;

--- a/tests/devspec_approve.test.ts
+++ b/tests/devspec_approve.test.ts
@@ -1,0 +1,206 @@
+import { describe, test, expect } from 'bun:test';
+
+const { default: handler } = await import('../handlers/devspec_approve.ts');
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+let counter = 0;
+async function writeTempFile(content: string): Promise<string> {
+  counter += 1;
+  const path = `/tmp/devspec-approve-${Date.now()}-${counter}-${Math.floor(Math.random() * 1e12)}.md`;
+  await Bun.write(path, content);
+  return path;
+}
+
+async function readFile(path: string): Promise<string> {
+  return await Bun.file(path).text();
+}
+
+const ISO_8601_UTC = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
+
+const FRESH_SPEC = `# Dev Spec: Example
+
+## 1. Overview
+
+Some overview content.
+
+## 2. Acceptance Criteria
+
+- [ ] Criterion A
+`;
+
+const SPEC_WITH_FRONTMATTER = `---
+title: Example
+owner: bj
+---
+
+# Dev Spec: Example
+
+## 1. Overview
+
+Content here.
+`;
+
+const SPEC_WITH_EXISTING_APPROVAL = `# Dev Spec: Example
+
+<!-- DEV-SPEC-APPROVAL
+approved: true
+approved_by: alice
+approved_at: 2025-01-01T00:00:00Z
+finalization_score: 5/7
+-->
+
+## 1. Overview
+
+Content.
+`;
+
+describe('devspec_approve handler', () => {
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('devspec_approve');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('inserts new approval block in a fresh file', async () => {
+    const path = await writeTempFile(FRESH_SPEC);
+    const result = await handler.execute({ path, approver: 'bj' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.path).toBe(path);
+    expect(parsed.approved_by).toBe('bj');
+    expect(parsed.finalization_score).toBe('7/7');
+
+    const updated = await readFile(path);
+    expect(updated).toContain('<!-- DEV-SPEC-APPROVAL');
+    expect(updated).toContain('approved: true');
+    expect(updated).toContain('approved_by: bj');
+    expect(updated).toContain('finalization_score: 7/7');
+    expect(updated).toContain('-->');
+    // Block is at the top, before Section 1
+    const blockIdx = updated.indexOf('<!-- DEV-SPEC-APPROVAL');
+    const section1Idx = updated.indexOf('## 1. Overview');
+    expect(blockIdx).toBeLessThan(section1Idx);
+    // Original body preserved
+    expect(updated).toContain('Some overview content.');
+  });
+
+  test('replaces existing approval block with updated values', async () => {
+    const path = await writeTempFile(SPEC_WITH_EXISTING_APPROVAL);
+    const result = await handler.execute({
+      path,
+      approver: 'bj',
+      finalization_score: '7/7',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+
+    const updated = await readFile(path);
+    // New values present
+    expect(updated).toContain('approved_by: bj');
+    expect(updated).toContain('finalization_score: 7/7');
+    // Old values gone
+    expect(updated).not.toContain('approved_by: alice');
+    expect(updated).not.toContain('finalization_score: 5/7');
+    expect(updated).not.toContain('2025-01-01T00:00:00Z');
+    // Exactly one approval block (no duplicates)
+    const matches = updated.match(/<!-- DEV-SPEC-APPROVAL/g);
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBe(1);
+    // Section 1 still present
+    expect(updated).toContain('## 1. Overview');
+  });
+
+  test('handles file with frontmatter correctly — block goes after frontmatter', async () => {
+    const path = await writeTempFile(SPEC_WITH_FRONTMATTER);
+    const result = await handler.execute({ path, approver: 'bj' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+
+    const updated = await readFile(path);
+    // Frontmatter preserved at the very top
+    expect(updated.startsWith('---\n')).toBe(true);
+    expect(updated).toContain('title: Example');
+    expect(updated).toContain('owner: bj');
+
+    // Block appears after closing frontmatter and before the H1
+    const frontmatterCloseIdx = updated.indexOf('\n---\n') + '\n---\n'.length;
+    const blockIdx = updated.indexOf('<!-- DEV-SPEC-APPROVAL');
+    const h1Idx = updated.indexOf('# Dev Spec: Example');
+    expect(blockIdx).toBeGreaterThanOrEqual(frontmatterCloseIdx);
+    expect(blockIdx).toBeLessThan(h1Idx);
+  });
+
+  test('generates valid ISO 8601 UTC timestamp', async () => {
+    const path = await writeTempFile(FRESH_SPEC);
+    const result = await handler.execute({ path, approver: 'bj' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.approved_at).toMatch(ISO_8601_UTC);
+
+    const updated = await readFile(path);
+    const tsMatch = updated.match(/approved_at: (\S+)/);
+    expect(tsMatch).not.toBeNull();
+    expect(tsMatch![1]).toMatch(ISO_8601_UTC);
+    // Handler return matches file content
+    expect(tsMatch![1]).toBe(parsed.approved_at);
+  });
+
+  test('returns the written metadata in the response', async () => {
+    const path = await writeTempFile(FRESH_SPEC);
+    const result = await handler.execute({
+      path,
+      approver: 'bj',
+      finalization_score: '6/7',
+    });
+    const parsed = parseResult(result);
+    expect(parsed).toEqual({
+      ok: true,
+      path,
+      approved_at: parsed.approved_at, // shape match; format validated separately
+      approved_by: 'bj',
+      finalization_score: '6/7',
+    });
+    expect(parsed.approved_at).toMatch(ISO_8601_UTC);
+  });
+
+  test('uses default finalization_score of 7/7 when not supplied', async () => {
+    const path = await writeTempFile(FRESH_SPEC);
+    const result = await handler.execute({ path, approver: 'bj' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.finalization_score).toBe('7/7');
+    const updated = await readFile(path);
+    expect(updated).toContain('finalization_score: 7/7');
+  });
+
+  test('missing file returns structured error', async () => {
+    const result = await handler.execute({
+      path: '/tmp/devspec-approve-nonexistent-xyz-12345.md',
+      approver: 'bj',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('file not found');
+  });
+
+  test('schema validation — rejects missing path', async () => {
+    const result = await handler.execute({ approver: 'bj' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema validation — rejects missing approver', async () => {
+    const path = await writeTempFile(FRESH_SPEC);
+    const result = await handler.execute({ path });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema validation — rejects empty path', async () => {
+    const result = await handler.execute({ path: '', approver: 'bj' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Write DEV-SPEC-APPROVAL metadata block to a Dev Spec file. Part of Family 3 (Pipeline Authoring sdlc-mcp migration).

## Changes

- `handlers/devspec_approve.ts` — new handler file
- `tests/devspec_approve.test.ts` — new test file (flat `tests/` layout)
- Handler auto-registers via the codegen handler registry

## Test Results

All local validation green:

- `./scripts/ci/validate.sh` — codegen, tsc, shellcheck, full suite, runtime smoke all pass
- `bun test tests/devspec_approve.test.ts` — all tests pass in isolation AND in the full mcp-server-sdlc suite
- No `mock.module('fs')` partial mocks (per `lesson_mcp_gotchas.md` memory)
- Handler appears in `tools/list` via the runtime smoke test

## Linked Issues

Closes #107

Related: parent epic Wave-Engineering/claudecode-workflow#331

🤖 Generated with [Claude Code](https://claude.com/claude-code)