### PR TITLE
feat(sdlc-mcp): devspec_verify_approved handler

### DIFF
--- a/handlers/devspec_verify_approved.ts
+++ b/handlers/devspec_verify_approved.ts
@@ -1,0 +1,197 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  path: z.string().min(1, 'path must be a non-empty string'),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+interface ApprovalMetadata {
+  approved: boolean;
+  approved_by?: string;
+  approved_at?: string;
+  finalization_score?: string;
+}
+
+/**
+ * Read a file via shell-out (cat) to stay consistent with the
+ * child_process.execSync convention used throughout this codebase.
+ * Throws an informative error if the file cannot be read.
+ */
+function readFileViaShell(path: string): string {
+  try {
+    // -- guards against paths that look like flags.
+    return execSync(`cat -- ${shellQuote(path)}`, { encoding: 'utf8' });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`file not found or unreadable: ${path} (${msg})`);
+  }
+}
+
+/**
+ * Minimal single-quote shell quoting.
+ */
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Locate the DEV-SPEC-APPROVAL comment block in a markdown body.
+ *
+ * Looks for an HTML comment whose first line (after `<!--`) is
+ * `DEV-SPEC-APPROVAL`. Captures the body of that comment up to the
+ * closing `-->`. Returns null when the opening marker is not found.
+ * Throws when the marker is found but the comment is unterminated.
+ */
+function extractApprovalBlock(markdown: string): string | null {
+  // Match: <!-- (optional whitespace/newline) DEV-SPEC-APPROVAL ... -->
+  // We scan manually so we can produce a targeted error for unterminated blocks.
+  const startRe = /<!--\s*DEV-SPEC-APPROVAL\b/;
+  const startMatch = startRe.exec(markdown);
+  if (!startMatch) return null;
+
+  const startIdx = startMatch.index + startMatch[0].length;
+  const endIdx = markdown.indexOf('-->', startIdx);
+  if (endIdx === -1) {
+    throw new Error(
+      'malformed DEV-SPEC-APPROVAL block: unterminated comment (no closing `-->`)'
+    );
+  }
+  return markdown.slice(startIdx, endIdx);
+}
+
+/**
+ * Parse `key: value` pairs from a DEV-SPEC-APPROVAL block body.
+ *
+ * Each non-empty line is expected to match `key: value`. Unknown keys
+ * are tolerated and ignored. Lines that cannot be parsed surface as
+ * an informative error.
+ */
+function parseApprovalBlock(body: string): ApprovalMetadata {
+  const lines = body
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => l.length > 0);
+
+  if (lines.length === 0) {
+    throw new Error(
+      'malformed DEV-SPEC-APPROVAL block: block is empty (no `approved:` field)'
+    );
+  }
+
+  const fields: Record<string, string> = {};
+  for (const line of lines) {
+    const m = /^([A-Za-z0-9_]+)\s*:\s*(.*)$/.exec(line);
+    if (!m) {
+      throw new Error(
+        `malformed DEV-SPEC-APPROVAL block: could not parse line "${line}" (expected "key: value")`
+      );
+    }
+    fields[m[1]] = m[2].trim();
+  }
+
+  if (!('approved' in fields)) {
+    throw new Error(
+      'malformed DEV-SPEC-APPROVAL block: missing required `approved` field'
+    );
+  }
+
+  const approvedRaw = fields.approved.toLowerCase();
+  if (approvedRaw !== 'true' && approvedRaw !== 'false') {
+    throw new Error(
+      `malformed DEV-SPEC-APPROVAL block: \`approved\` must be "true" or "false", got "${fields.approved}"`
+    );
+  }
+
+  const result: ApprovalMetadata = {
+    approved: approvedRaw === 'true',
+  };
+  if (fields.approved_by) result.approved_by = fields.approved_by;
+  if (fields.approved_at) result.approved_at = fields.approved_at;
+  if (fields.finalization_score) result.finalization_score = fields.finalization_score;
+  return result;
+}
+
+const devspecVerifyApprovedHandler: HandlerDef = {
+  name: 'devspec_verify_approved',
+  description:
+    'Check whether a Dev Spec file has been approved via its DEV-SPEC-APPROVAL metadata comment block.',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: Input;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    let body: string;
+    try {
+      body = readFileViaShell(args.path);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    let block: string | null;
+    try {
+      block = extractApprovalBlock(body);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    if (block === null) {
+      // No block at all — this is a valid "not approved" result, not an error.
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({ ok: true, path: args.path, approved: false }),
+          },
+        ],
+      };
+    }
+
+    let meta: ApprovalMetadata;
+    try {
+      meta = parseApprovalBlock(block);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    const payload: {
+      ok: true;
+      path: string;
+      approved: boolean;
+      approved_by?: string;
+      approved_at?: string;
+      finalization_score?: string;
+    } = {
+      ok: true,
+      path: args.path,
+      approved: meta.approved,
+    };
+    if (meta.approved_by) payload.approved_by = meta.approved_by;
+    if (meta.approved_at) payload.approved_at = meta.approved_at;
+    if (meta.finalization_score) payload.finalization_score = meta.finalization_score;
+
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(payload) }],
+    };
+  },
+};
+
+export default devspecVerifyApprovedHandler;

--- a/tests/devspec_verify_approved.test.ts
+++ b/tests/devspec_verify_approved.test.ts
@@ -1,0 +1,259 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+// Mock child_process BEFORE importing the handler. The handler uses
+// execSync('cat ...') to read the Dev Spec file, keeping with the
+// codebase's child_process.execSync convention.
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string, _opts?: unknown) => execMockFn(cmd));
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/devspec_verify_approved.ts');
+
+function resetMocks() {
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+/**
+ * Build an execSync stub that returns the given file contents for any
+ * `cat ...` command, and throws for anything else. This matches how
+ * the handler shells out to read the Dev Spec file.
+ */
+function catReturning(contents: string) {
+  return (cmd: string) => {
+    if (cmd.startsWith('cat')) return contents;
+    return '';
+  };
+}
+
+function catThrowing(msg: string) {
+  return (cmd: string): string => {
+    if (cmd.startsWith('cat')) throw new Error(msg);
+    return '';
+  };
+}
+
+const APPROVED_SPEC = `# Example Dev Spec
+
+<!-- DEV-SPEC-APPROVAL
+approved: true
+approved_by: BJ
+approved_at: 2026-04-04T12:00:00Z
+finalization_score: 7/7
+-->
+
+## Section 1: Overview
+
+Body text here.
+`;
+
+const UNAPPROVED_SPEC_NO_BLOCK = `# Example Dev Spec
+
+## Section 1: Overview
+
+No approval block anywhere in this file.
+`;
+
+const UNAPPROVED_SPEC_FALSE = `# Example Dev Spec
+
+<!-- DEV-SPEC-APPROVAL
+approved: false
+approved_by: BJ
+approved_at: 2026-04-04T12:00:00Z
+finalization_score: 4/7
+-->
+
+## Section 1: Overview
+`;
+
+const APPROVED_SPEC_MINIMAL = `<!-- DEV-SPEC-APPROVAL
+approved: true
+-->
+
+# Minimal
+`;
+
+const MALFORMED_UNTERMINATED = `# Spec
+
+<!-- DEV-SPEC-APPROVAL
+approved: true
+approved_by: BJ
+
+## Section 1: Overview
+`;
+
+const MALFORMED_BAD_LINE = `# Spec
+
+<!-- DEV-SPEC-APPROVAL
+approved: true
+this line has no colon
+-->
+`;
+
+const MALFORMED_MISSING_APPROVED = `# Spec
+
+<!-- DEV-SPEC-APPROVAL
+approved_by: BJ
+approved_at: 2026-04-04T12:00:00Z
+-->
+`;
+
+const MALFORMED_APPROVED_NON_BOOL = `# Spec
+
+<!-- DEV-SPEC-APPROVAL
+approved: maybe
+-->
+`;
+
+const MALFORMED_EMPTY_BLOCK = `# Spec
+
+<!-- DEV-SPEC-APPROVAL
+
+-->
+`;
+
+describe('devspec_verify_approved handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('devspec_verify_approved');
+    expect(typeof handler.description).toBe('string');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('returns approved:true for a properly approved file', async () => {
+    execMockFn = catReturning(APPROVED_SPEC);
+    const result = await handler.execute({ path: 'docs/my-devspec.md' });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.path).toBe('docs/my-devspec.md');
+    expect(parsed.approved).toBe(true);
+    expect(parsed.approved_by).toBe('BJ');
+    expect(parsed.approved_at).toBe('2026-04-04T12:00:00Z');
+    expect(parsed.finalization_score).toBe('7/7');
+  });
+
+  test('returns approved:true with only required field (other metadata optional)', async () => {
+    execMockFn = catReturning(APPROVED_SPEC_MINIMAL);
+    const result = await handler.execute({ path: 'docs/minimal-devspec.md' });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.approved).toBe(true);
+    expect(parsed.approved_by).toBeUndefined();
+    expect(parsed.approved_at).toBeUndefined();
+    expect(parsed.finalization_score).toBeUndefined();
+  });
+
+  test('returns approved:false for an unapproved file (no block)', async () => {
+    execMockFn = catReturning(UNAPPROVED_SPEC_NO_BLOCK);
+    const result = await handler.execute({ path: 'docs/draft-devspec.md' });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.path).toBe('docs/draft-devspec.md');
+    expect(parsed.approved).toBe(false);
+    expect(parsed.approved_by).toBeUndefined();
+    expect(parsed.approved_at).toBeUndefined();
+    expect(parsed.finalization_score).toBeUndefined();
+  });
+
+  test('returns approved:false when block has approved:false (metadata still populated)', async () => {
+    execMockFn = catReturning(UNAPPROVED_SPEC_FALSE);
+    const result = await handler.execute({ path: 'docs/rejected-devspec.md' });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.approved).toBe(false);
+    expect(parsed.approved_by).toBe('BJ');
+    expect(parsed.approved_at).toBe('2026-04-04T12:00:00Z');
+    expect(parsed.finalization_score).toBe('4/7');
+  });
+
+  test('handles malformed block — unterminated comment', async () => {
+    execMockFn = catReturning(MALFORMED_UNTERMINATED);
+    const result = await handler.execute({ path: 'docs/bad-devspec.md' });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('malformed');
+    expect(parsed.error).toContain('unterminated');
+  });
+
+  test('handles malformed block — line without colon', async () => {
+    execMockFn = catReturning(MALFORMED_BAD_LINE);
+    const result = await handler.execute({ path: 'docs/bad-devspec.md' });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('malformed');
+    expect(parsed.error).toContain('this line has no colon');
+  });
+
+  test('handles malformed block — missing approved field', async () => {
+    execMockFn = catReturning(MALFORMED_MISSING_APPROVED);
+    const result = await handler.execute({ path: 'docs/bad-devspec.md' });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('missing required `approved`');
+  });
+
+  test('handles malformed block — approved is not a boolean', async () => {
+    execMockFn = catReturning(MALFORMED_APPROVED_NON_BOOL);
+    const result = await handler.execute({ path: 'docs/bad-devspec.md' });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('must be');
+    expect(parsed.error).toContain('maybe');
+  });
+
+  test('handles malformed block — empty block body', async () => {
+    execMockFn = catReturning(MALFORMED_EMPTY_BLOCK);
+    const result = await handler.execute({ path: 'docs/bad-devspec.md' });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('empty');
+  });
+
+  test('handles missing file with structured error', async () => {
+    execMockFn = catThrowing('cat: nonexistent: No such file or directory');
+    const result = await handler.execute({ path: '/tmp/nonexistent-devspec.md' });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('file not found or unreadable');
+    expect(parsed.error).toContain('/tmp/nonexistent-devspec.md');
+  });
+
+  test('schema validation — rejects missing path', async () => {
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema validation — rejects empty path', async () => {
+    const result = await handler.execute({ path: '' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('is case-insensitive for approved: true/TRUE', async () => {
+    execMockFn = catReturning(`<!-- DEV-SPEC-APPROVAL
+approved: TRUE
+-->
+`);
+    const result = await handler.execute({ path: 'docs/caps-devspec.md' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.approved).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Verify a Dev Spec has been approved via its metadata block. Part of Family 3 (Pipeline Authoring sdlc-mcp migration).

## Changes

- `handlers/devspec_verify_approved.ts` — new handler file
- `tests/devspec_verify_approved.test.ts` — new test file (flat `tests/` layout)
- Handler auto-registers via the codegen handler registry

## Test Results

All local validation green:

- `./scripts/ci/validate.sh` — codegen, tsc, shellcheck, full suite, runtime smoke all pass
- `bun test tests/devspec_verify_approved.test.ts` — all tests pass in isolation AND in the full mcp-server-sdlc suite
- No `mock.module('fs')` partial mocks (per `lesson_mcp_gotchas.md` memory)
- Handler appears in `tools/list` via the runtime smoke test

## Linked Issues

Closes #108

Related: parent epic Wave-Engineering/claudecode-workflow#331

🤖 Generated with [Claude Code](https://claude.com/claude-code)