### PR TITLE
feat(sdlc-mcp): ddd_locate_sketchbook handler

### DIFF
--- a/handlers/ddd_locate_sketchbook.ts
+++ b/handlers/ddd_locate_sketchbook.ts
@@ -1,0 +1,76 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  root: z.string().min(1).optional(),
+});
+
+function resolveRoot(explicit?: string): string {
+  if (explicit && explicit.length > 0) return explicit;
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function quoteArg(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+const dddLocateSketchbookHandler: HandlerDef = {
+  name: 'ddd_locate_sketchbook',
+  description: 'Find docs/SKETCHBOOK.md in a project root',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    const root = resolveRoot(args.root);
+
+    // Verify root directory exists.
+    try {
+      execSync(`test -d ${quoteArg(root)}`, { encoding: 'utf8' });
+    } catch {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: false,
+              error: `root directory does not exist: ${root}`,
+            }),
+          },
+        ],
+      };
+    }
+
+    const sketchbookPath = `${root}/docs/SKETCHBOOK.md`;
+    try {
+      execSync(`test -f ${quoteArg(sketchbookPath)}`, { encoding: 'utf8' });
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({ ok: true, path: sketchbookPath, exists: true }),
+          },
+        ],
+      };
+    } catch {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({ ok: true, exists: false }),
+          },
+        ],
+      };
+    }
+  },
+};
+
+export default dddLocateSketchbookHandler;

--- a/tests/ddd_locate_sketchbook.test.ts
+++ b/tests/ddd_locate_sketchbook.test.ts
@@ -1,0 +1,110 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+interface ExecCall {
+  cmd: string;
+  opts: { cwd?: string; encoding?: string } | undefined;
+}
+
+let execCalls: ExecCall[] = [];
+let execMockFn: (cmd: string, opts?: { cwd?: string }) => string = () => '';
+const mockExecSync = mock((cmd: string, opts?: { cwd?: string; encoding?: string }) => {
+  execCalls.push({ cmd, opts });
+  return execMockFn(cmd, opts);
+});
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/ddd_locate_sketchbook.ts');
+
+const ORIGINAL_ENV = process.env.CLAUDE_PROJECT_DIR;
+
+function resetMocks() {
+  execCalls = [];
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+function restoreEnv() {
+  if (ORIGINAL_ENV === undefined) {
+    delete process.env.CLAUDE_PROJECT_DIR;
+  } else {
+    process.env.CLAUDE_PROJECT_DIR = ORIGINAL_ENV;
+  }
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+function buildExec(opts: { rootExists: boolean; sketchbookExists: boolean }) {
+  return (cmd: string) => {
+    if (cmd.startsWith('test -d')) {
+      if (!opts.rootExists) throw new Error('root missing');
+      return '';
+    }
+    if (cmd.startsWith('test -f')) {
+      if (!opts.sketchbookExists) throw new Error('sketchbook missing');
+      return '';
+    }
+    return '';
+  };
+}
+
+describe('ddd_locate_sketchbook handler', () => {
+  beforeEach(() => {
+    resetMocks();
+    delete process.env.CLAUDE_PROJECT_DIR;
+  });
+  afterEach(() => {
+    resetMocks();
+    restoreEnv();
+  });
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('ddd_locate_sketchbook');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('finds existing sketchbook', async () => {
+    execMockFn = buildExec({ rootExists: true, sketchbookExists: true });
+    const result = await handler.execute({ root: '/tmp/proj' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.exists).toBe(true);
+    expect(parsed.path).toBe('/tmp/proj/docs/SKETCHBOOK.md');
+  });
+
+  test('returns exists:false when sketchbook missing (not an error)', async () => {
+    execMockFn = buildExec({ rootExists: true, sketchbookExists: false });
+    const result = await handler.execute({ root: '/tmp/proj' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.exists).toBe(false);
+    expect(parsed.path).toBeUndefined();
+  });
+
+  test('errors on nonexistent root', async () => {
+    execMockFn = buildExec({ rootExists: false, sketchbookExists: false });
+    const result = await handler.execute({ root: '/tmp/nonexistent' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('/tmp/nonexistent');
+  });
+
+  test('uses CLAUDE_PROJECT_DIR when root param omitted', async () => {
+    process.env.CLAUDE_PROJECT_DIR = '/tmp/env-root';
+    execMockFn = buildExec({ rootExists: true, sketchbookExists: true });
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.path).toBe('/tmp/env-root/docs/SKETCHBOOK.md');
+  });
+
+  test('explicit root param takes precedence over CLAUDE_PROJECT_DIR', async () => {
+    process.env.CLAUDE_PROJECT_DIR = '/tmp/env-root';
+    execMockFn = buildExec({ rootExists: true, sketchbookExists: true });
+    const result = await handler.execute({ root: '/tmp/explicit' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.path).toBe('/tmp/explicit/docs/SKETCHBOOK.md');
+  });
+});


### PR DESCRIPTION
## Summary

Find docs/SKETCHBOOK.md in a project root. Part of Family 3 (Pipeline Authoring sdlc-mcp migration).

## Changes

- `handlers/ddd_locate_sketchbook.ts` — new handler file
- `tests/ddd_locate_sketchbook.test.ts` — new test file (flat `tests/` layout)
- Handler auto-registers via the codegen handler registry

## Test Results

- `./scripts/ci/validate.sh` — codegen, tsc lint, shellcheck, full test suite, runtime smoke all pass
- `bun test tests/ddd_locate_sketchbook.test.ts` — all tests pass in isolation
- Handler appears in `tools/list` via the runtime smoke test (56 handlers total)

## Linked Issues

Closes #111

Related: parent epic Wave-Engineering/claudecode-workflow#331

🤖 Generated with [Claude Code](https://claude.com/claude-code)