### PR TITLE
feat(sdlc-mcp): ddd_verify_committed handler

### DIFF
--- a/handlers/ddd_verify_committed.ts
+++ b/handlers/ddd_verify_committed.ts
@@ -1,0 +1,98 @@
+import { execSync } from 'child_process';
+import { dirname } from 'path';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  path: z.string().min(1, 'path must be a non-empty string'),
+});
+
+function quoteArg(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+const dddVerifyCommittedHandler: HandlerDef = {
+  name: 'ddd_verify_committed',
+  description: 'Verify a file has no uncommitted git changes (gate for /ddd accept)',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    // Verify the file exists (`test -e` for either file or symlink).
+    try {
+      execSync(`test -e ${quoteArg(args.path)}`, { encoding: 'utf8' });
+    } catch {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({ ok: false, error: `file not found: ${args.path}` }),
+          },
+        ],
+      };
+    }
+
+    // Run git status --porcelain with cwd set to the file's containing directory,
+    // so git can resolve the containing repo correctly.
+    const fileDir = dirname(args.path) || '.';
+    try {
+      const output = execSync(
+        `git status --porcelain -- ${quoteArg(args.path)}`,
+        { encoding: 'utf8', cwd: fileDir }
+      );
+
+      // Preserve leading whitespace — the XY status prefix (e.g. ' M', '??') is meaningful.
+      // Only strip a trailing newline.
+      const stripped = output.replace(/\n+$/, '');
+      if (stripped.length === 0) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({ ok: true, path: args.path, committed: true }),
+            },
+          ],
+        };
+      }
+
+      // Uncommitted changes — return the first status line (still includes XY prefix).
+      const firstLine = stripped.split('\n')[0];
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              path: args.path,
+              committed: false,
+              status: firstLine,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: false,
+              error: `git status failed (not a git repo?): ${msg}`,
+            }),
+          },
+        ],
+      };
+    }
+  },
+};
+
+export default dddVerifyCommittedHandler;

--- a/tests/ddd_verify_committed.test.ts
+++ b/tests/ddd_verify_committed.test.ts
@@ -1,0 +1,125 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+interface ExecCall {
+  cmd: string;
+  opts: { cwd?: string; encoding?: string } | undefined;
+}
+
+let execCalls: ExecCall[] = [];
+let execMockFn: (cmd: string, opts?: { cwd?: string }) => string = () => '';
+const mockExecSync = mock((cmd: string, opts?: { cwd?: string; encoding?: string }) => {
+  execCalls.push({ cmd, opts });
+  return execMockFn(cmd, opts);
+});
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/ddd_verify_committed.ts');
+
+function resetMocks() {
+  execCalls = [];
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+/**
+ * Build a mock that handles:
+ *   - `test -e <path>` for file existence
+ *   - `git status --porcelain -- <path>` returning the configured status output
+ */
+function buildExec(opts: { fileExists: boolean; gitStatus: string; gitThrows?: boolean }) {
+  return (cmd: string) => {
+    if (cmd.startsWith('test -e')) {
+      if (!opts.fileExists) throw new Error('file missing');
+      return '';
+    }
+    if (cmd.startsWith('git status')) {
+      if (opts.gitThrows) throw new Error('fatal: not a git repository');
+      return opts.gitStatus;
+    }
+    return '';
+  };
+}
+
+describe('ddd_verify_committed handler', () => {
+  beforeEach(() => resetMocks());
+  afterEach(() => resetMocks());
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('ddd_verify_committed');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('returns committed:true when file is clean', async () => {
+    execMockFn = buildExec({ fileExists: true, gitStatus: '' });
+    const result = await handler.execute({ path: '/tmp/repo/docs/DOMAIN-MODEL.md' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.committed).toBe(true);
+    expect(parsed.path).toBe('/tmp/repo/docs/DOMAIN-MODEL.md');
+    expect(parsed.status).toBeUndefined();
+  });
+
+  test('returns committed:false with status for modified file', async () => {
+    execMockFn = buildExec({
+      fileExists: true,
+      gitStatus: ' M docs/DOMAIN-MODEL.md\n',
+    });
+    const result = await handler.execute({ path: '/tmp/repo/docs/DOMAIN-MODEL.md' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.committed).toBe(false);
+    expect(parsed.status).toBe(' M docs/DOMAIN-MODEL.md');
+  });
+
+  test('returns committed:false for untracked file', async () => {
+    execMockFn = buildExec({
+      fileExists: true,
+      gitStatus: '?? docs/DOMAIN-MODEL.md\n',
+    });
+    const result = await handler.execute({ path: '/tmp/repo/docs/DOMAIN-MODEL.md' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.committed).toBe(false);
+    expect(parsed.status).toBe('?? docs/DOMAIN-MODEL.md');
+  });
+
+  test('returns error when file does not exist', async () => {
+    execMockFn = buildExec({ fileExists: false, gitStatus: '' });
+    const result = await handler.execute({ path: '/tmp/nonexistent.md' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('file not found');
+  });
+
+  test('returns error when git status fails (not a git repo)', async () => {
+    execMockFn = buildExec({ fileExists: true, gitStatus: '', gitThrows: true });
+    const result = await handler.execute({ path: '/tmp/not-a-repo/file.md' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('git status failed');
+  });
+
+  test('git status invoked with cwd set to containing directory', async () => {
+    execMockFn = buildExec({ fileExists: true, gitStatus: '' });
+    await handler.execute({ path: '/tmp/repo/subdir/FILE.md' });
+    const gitCall = execCalls.find(c => c.cmd.startsWith('git status'));
+    expect(gitCall).toBeDefined();
+    expect(gitCall?.opts?.cwd).toBe('/tmp/repo/subdir');
+  });
+
+  test('schema rejects missing path', async () => {
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema rejects empty path', async () => {
+    const result = await handler.execute({ path: '' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Verify a file has no uncommitted git changes (gate for /ddd accept). Part of Family 3 (Pipeline Authoring sdlc-mcp migration).

## Changes

- `handlers/ddd_verify_committed.ts` — new handler file
- `tests/ddd_verify_committed.test.ts` — new test file (flat `tests/` layout)
- Handler auto-registers via the codegen handler registry

## Test Results

- `./scripts/ci/validate.sh` — codegen, tsc lint, shellcheck, full test suite, runtime smoke all pass
- `bun test tests/ddd_verify_committed.test.ts` — all tests pass in isolation
- Handler appears in `tools/list` via the runtime smoke test (56 handlers total)

## Linked Issues

Closes #113

Related: parent epic Wave-Engineering/claudecode-workflow#331

🤖 Generated with [Claude Code](https://claude.com/claude-code)