### PR TITLE
feat(sdlc-mcp): ddd_summary handler

### DIFF
--- a/handlers/ddd_summary.ts
+++ b/handlers/ddd_summary.ts
@@ -1,0 +1,292 @@
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  path: z.string().min(1, 'path must be a non-empty string'),
+});
+
+interface SectionRange {
+  /** 1-indexed line number of the heading itself */
+  headingLine: number;
+  /** 0-indexed start of body lines (inclusive) */
+  start: number;
+  /** 0-indexed end of body lines (exclusive) */
+  end: number;
+}
+
+/**
+ * Read a Domain Model markdown file from disk.
+ *
+ * Per `lesson_mcp_gotchas.md` and `devspec_summary.ts` precedent, this
+ * handler uses `Bun.file()` for local file reads (not `fs`, not shell-out).
+ */
+async function readDomainModelFile(path: string): Promise<string> {
+  const file = Bun.file(path);
+  if (!(await file.exists())) {
+    throw new Error(`file not found: ${path}`);
+  }
+  return await file.text();
+}
+
+/**
+ * Find a numbered top-level section (`## N. ...`) and return the line range
+ * of its body — from the line after the heading up to (but not including)
+ * the next `## ` heading at the same level (or EOF).
+ *
+ * Returns null if the section heading is not present.
+ */
+function findTopLevelSection(lines: string[], n: number): SectionRange | null {
+  const headingRe = new RegExp(`^##\\s+${n}\\.\\s+\\S`);
+  let headingIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (headingRe.test(lines[i])) {
+      headingIdx = i;
+      break;
+    }
+  }
+  if (headingIdx === -1) return null;
+
+  let endIdx = lines.length;
+  for (let i = headingIdx + 1; i < lines.length; i++) {
+    // Stop at the next top-level `## ` heading (regardless of number).
+    if (/^##\s+\S/.test(lines[i]) && !/^###/.test(lines[i])) {
+      endIdx = i;
+      break;
+    }
+  }
+
+  return { headingLine: headingIdx + 1, start: headingIdx + 1, end: endIdx };
+}
+
+/**
+ * Count unique `E-NN` identifiers inside Section 3 (Domain Events).
+ *
+ * The template organises events under `### Phase: ...` subsections, each
+ * with a markdown table whose first column contains `E-01`, `E-02`, etc.
+ * We scan the entire section body and collect unique IDs of the shape
+ * `E-<digits>` so that repeats across phases (or the summary row) are not
+ * double-counted.
+ */
+function countEvents(lines: string[]): number {
+  const section = findTopLevelSection(lines, 3);
+  if (!section) return 0;
+
+  const ids = new Set<string>();
+  const idRe = /\bE-(\d+)\b/g;
+  for (let i = section.start; i < section.end; i++) {
+    const line = lines[i];
+    let m: RegExpExecArray | null;
+    idRe.lastIndex = 0;
+    while ((m = idRe.exec(line)) !== null) {
+      ids.add(`E-${m[1]}`);
+    }
+  }
+  return ids.size;
+}
+
+/**
+ * Count unique `C-NN` identifiers inside Section 4 (Commands).
+ *
+ * Section 4 has a single `## 4. Commands` heading and a markdown table with
+ * `C-01`, `C-02`, ... rows. We collect unique IDs to tolerate back-references
+ * in Key Insights bullets.
+ */
+function countCommands(lines: string[]): number {
+  const section = findTopLevelSection(lines, 4);
+  if (!section) return 0;
+
+  const ids = new Set<string>();
+  const idRe = /\bC-(\d+)\b/g;
+  for (let i = section.start; i < section.end; i++) {
+    const line = lines[i];
+    let m: RegExpExecArray | null;
+    idRe.lastIndex = 0;
+    while ((m = idRe.exec(line)) !== null) {
+      ids.add(`C-${m[1]}`);
+    }
+  }
+  return ids.size;
+}
+
+/**
+ * Count rows in Section 5 (Actors) responsibility matrix.
+ *
+ * Section 5 contains a `### Responsibility Matrix` subsection with a
+ * markdown table whose columns are `Actor | Commands | Responsibility`.
+ * We count data rows — lines starting with `|`, excluding the header and
+ * separator, and skipping rows whose cells are all template placeholders
+ * (empty or wrapped in `[[...]]`). Only the FIRST table in the section is
+ * counted (the Actor Pattern Summary table that follows has different
+ * semantics and should not inflate the actor count).
+ */
+function countActors(lines: string[]): number {
+  const section = findTopLevelSection(lines, 5);
+  if (!section) return 0;
+
+  const sectionLines = lines.slice(section.start, section.end);
+
+  // Find the first markdown table header (a row starting with `|`).
+  let headerIdx = -1;
+  for (let i = 0; i < sectionLines.length; i++) {
+    const trimmed = sectionLines[i].trim();
+    if (trimmed.startsWith('|') && trimmed.endsWith('|')) {
+      headerIdx = i;
+      break;
+    }
+  }
+  if (headerIdx === -1) return 0;
+
+  // Skip the separator row `|---|---|`.
+  let startRow = headerIdx + 1;
+  if (
+    startRow < sectionLines.length &&
+    /^\|[\s\-:|]+\|$/.test(sectionLines[startRow].trim())
+  ) {
+    startRow += 1;
+  }
+
+  let count = 0;
+  for (let i = startRow; i < sectionLines.length; i++) {
+    const trimmed = sectionLines[i].trim();
+    if (!trimmed.startsWith('|')) {
+      // Table ended.
+      break;
+    }
+    const cells = trimmed.split('|').slice(1, -1).map(c => c.trim());
+    if (cells.length === 0) continue;
+
+    // Skip rows whose cells are all empty or pure `[[...]]` placeholders.
+    const meaningful = cells.some(c => c.length > 0 && !/^\[\[.*\]\]$/.test(c));
+    if (!meaningful) continue;
+
+    count += 1;
+  }
+
+  return count;
+}
+
+/**
+ * Count unique `P-NN` identifiers inside Section 6 (Policies).
+ *
+ * Section 6 contains multiple subsections (6.1 Cascade, 6.2 Quality, 6.3
+ * Notification, 6.4 Loop) each with its own table. We scan the entire
+ * section body and collect unique IDs of the shape `P-<digits>` so that
+ * Key Insights back-references don't double-count.
+ */
+function countPolicies(lines: string[]): number {
+  const section = findTopLevelSection(lines, 6);
+  if (!section) return 0;
+
+  const ids = new Set<string>();
+  const idRe = /\bP-(\d+)\b/g;
+  for (let i = section.start; i < section.end; i++) {
+    const line = lines[i];
+    let m: RegExpExecArray | null;
+    idRe.lastIndex = 0;
+    while ((m = idRe.exec(line)) !== null) {
+      ids.add(`P-${m[1]}`);
+    }
+  }
+  return ids.size;
+}
+
+/**
+ * Count aggregate subsections inside Section 7 (Aggregates).
+ *
+ * The template puts each aggregate under `#### <Name>` (h4) within `### 7.1
+ * Core Aggregates`. We count every h4 heading inside Section 7 — Section
+ * 7.2 and 7.3 are h3 subsections and are not counted. The "(Root
+ * Aggregate)" suffix on the first h4 is tolerated.
+ */
+function countAggregates(lines: string[]): number {
+  const section = findTopLevelSection(lines, 7);
+  if (!section) return 0;
+
+  let count = 0;
+  for (let i = section.start; i < section.end; i++) {
+    // h4 heading: `#### Something` but not `##### Something`.
+    if (/^####\s+\S/.test(lines[i]) && !/^#####/.test(lines[i])) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/**
+ * Count unique `RM-NN` identifiers inside Section 8 (Read Models).
+ *
+ * Section 8 contains multiple subsections (8.1 For X, 8.2 For Y, ...) each
+ * with its own table of `RM-01`, `RM-02`, ... rows. We collect unique IDs
+ * so that Key Insights back-references don't double-count.
+ */
+function countReadModels(lines: string[]): number {
+  const section = findTopLevelSection(lines, 8);
+  if (!section) return 0;
+
+  const ids = new Set<string>();
+  const idRe = /\bRM-(\d+)\b/g;
+  for (let i = section.start; i < section.end; i++) {
+    const line = lines[i];
+    let m: RegExpExecArray | null;
+    idRe.lastIndex = 0;
+    while ((m = idRe.exec(line)) !== null) {
+      ids.add(`RM-${m[1]}`);
+    }
+  }
+  return ids.size;
+}
+
+const dddSummaryHandler: HandlerDef = {
+  name: 'ddd_summary',
+  description:
+    'Count structural elements of a Domain Model file (events, commands, actors, policies, aggregates, read models) for the /ddd accept handoff summary',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const body = await readDomainModelFile(args.path);
+      const lines = body.split('\n');
+
+      const events = countEvents(lines);
+      const commands = countCommands(lines);
+      const actors = countActors(lines);
+      const policies = countPolicies(lines);
+      const aggregates = countAggregates(lines);
+      const read_models = countReadModels(lines);
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              path: args.path,
+              events,
+              commands,
+              actors,
+              policies,
+              aggregates,
+              read_models,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default dddSummaryHandler;

--- a/tests/ddd_summary.test.ts
+++ b/tests/ddd_summary.test.ts
@@ -1,0 +1,454 @@
+import { describe, test, expect } from 'bun:test';
+
+const { default: handler } = await import('../handlers/ddd_summary.ts');
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+async function writeTempFile(content: string): Promise<string> {
+  const path = `/tmp/ddd-summary-${Date.now()}-${Math.floor(Math.random() * 1e9)}.md`;
+  await Bun.write(path, content);
+  return path;
+}
+
+// A complete Domain Model fixture with every section populated. Counts:
+//   events      = 5 (E-01..E-05 across two phases)
+//   commands    = 3 (C-01..C-03)
+//   actors      = 3 rows in the Responsibility Matrix
+//   policies    = 6 (P-01..P-06 spread across cascade/quality/notification/loop)
+//   aggregates  = 2 (#### Script, #### Project) under 7.1
+//   read_models = 4 (RM-01..RM-04 across two actor subsections)
+const COMPLETE_MODEL = `# Sample Project — Domain Model
+
+**Method:** Event Storming (Domain-Driven Design)
+**Status:** Draft
+
+---
+
+## 1. Decisions Made
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| D-01 | Use EventStorming | Shared understanding |
+
+---
+
+## 2. Domain Context
+
+### 2.1 Project Overview
+
+Modeling a content pipeline.
+
+### 2.2 Actors
+
+| Actor | Type | Description |
+|-------|------|-------------|
+| Director | Human | Creative lead |
+| Agent | Agent | Automation |
+
+### 2.3 Core Problem
+
+Too slow.
+
+---
+
+## 3. Domain Events
+
+### Phase: Ideation
+
+| # | Event | Notes |
+|---|-------|-------|
+| E-01 | Brief Submitted | Kickoff event |
+| E-02 | Brief Approved | After review |
+
+### Phase: Production
+
+| # | Event | Notes |
+|---|-------|-------|
+| E-03 | Script Drafted | First draft |
+| E-04 | Script Reviewed | Feedback gathered |
+| E-05 | Script Approved | Ready for production |
+
+**Total events:** 5
+
+---
+
+## 4. Commands
+
+| # | Command | Serial Chain | Decision |
+|---|---------|--------------|----------|
+| C-01 | Submit Brief | E-01 | Human initiates |
+| C-02 | Approve Brief | E-02 | Director approves |
+| C-03 | Draft Script | E-03 -> E-04 -> E-05 | Agent chain |
+
+**Total commands:** 3
+
+### Key Insights
+
+- **Approval gates:** C-02
+- **Agent-autonomous chains:** C-03
+
+---
+
+## 5. Actors
+
+### Responsibility Matrix
+
+| Actor | Commands | Responsibility |
+|-------|----------|---------------|
+| **Director** | C-02 | Approves briefs |
+| **Producer** | C-01 | Submits briefs |
+| **Agent** | C-03 | Drafts scripts |
+
+### Actor Pattern Summary
+
+| Actor Type | Commands | Count |
+|-----------|----------|:-----:|
+| **Human only** | C-01, C-02 | 2 |
+| **Agent only** | C-03 | 1 |
+
+**The split:** Humans decide, agents execute.
+
+---
+
+## 6. Policies
+
+### 6.1 Cascade Policies (Dominos)
+
+| # | When | Then | Why Automatic |
+|---|------|------|---------------|
+| P-01 | E-02 | Trigger C-03 | Always chain |
+| P-02 | E-05 | Trigger downstream | Always chain |
+
+### 6.2 Quality Policies (Guardrails)
+
+| # | When | Then | Why |
+|---|------|------|-----|
+| P-03 | E-03 without citation | Reject | Must cite |
+
+### 6.3 Notification Policies (Alerts)
+
+| # | When | Then | Channel |
+|---|------|------|---------|
+| P-04 | E-02 | Notify Director | Discord |
+| P-05 | E-05 | Notify Producer | Discord |
+
+### 6.4 Loop Policies (Iteration)
+
+| # | When | Then | Exit Condition |
+|---|------|------|----------------|
+| P-06 | E-04 rejected | Redraft | Approved |
+
+**Total policies:** 6
+
+### Key Insights
+
+- **Critical cascades:** P-01 triggers the production chain.
+
+---
+
+## 7. Aggregates
+
+### 7.1 Core Aggregates
+
+#### Script (Root Aggregate)
+
+**What it holds:** Text and metadata.
+
+**State machine:**
+- **States:** draft | reviewed | approved
+- **Transitions:** E-03 (draft), E-04 (reviewed), E-05 (approved)
+
+**Invariants:**
+- Cannot approve without review
+
+---
+
+#### Project
+
+**What it holds:** High-level campaign data.
+
+**State machine:**
+- **States:** planning | active | closed
+
+### 7.2 Aggregate Relationships
+
+\`\`\`
+Project
+ └── Script (1:many)
+\`\`\`
+
+### 7.3 Aggregate Homes in Monorepo
+
+| Aggregate | Location | Notes |
+|-----------|----------|-------|
+| Script | repo/scripts | filesystem |
+
+---
+
+## 8. Read Models
+
+### 8.1 For Director
+
+| # | Read Model | Informs Decision | Shows |
+|---|-----------|-----------------|-------|
+| RM-01 | Brief Queue | C-02 approval | Pending briefs |
+| RM-02 | Script Review Board | C-02 approval | Scripts needing review |
+
+### 8.2 For Agent
+
+| # | Read Model | Informs Decision | Shows |
+|---|-----------|-----------------|-------|
+| RM-03 | Draft Queue | C-03 drafting | Scripts to draft |
+| RM-04 | Feedback Log | C-03 revision | Reviewer comments |
+
+**Total read models:** 4
+
+---
+
+## 9. Open Questions
+
+1. **How to version scripts?**
+
+---
+
+## 10. DDD -> Dev Spec Translation Map
+
+| DDD Artifact | Dev Spec Section | Translation | Status |
+|--------------|-------------|-------------|:------:|
+| Actors | 1.4 Target Users | Personas | Pending |
+`;
+
+describe('ddd_summary handler', () => {
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('ddd_summary');
+    expect(typeof handler.execute).toBe('function');
+    expect(typeof handler.description).toBe('string');
+  });
+
+  test('counts all structural elements in a complete domain model', async () => {
+    const path = await writeTempFile(COMPLETE_MODEL);
+    const result = await handler.execute({ path });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.path).toBe(path);
+    expect(parsed.events).toBe(5);
+    expect(parsed.commands).toBe(3);
+    expect(parsed.actors).toBe(3);
+    // P-01..P-06 across cascade, quality, notification, loop subsections.
+    expect(parsed.policies).toBe(6);
+    // Script + Project (h4 headings under 7.1).
+    expect(parsed.aggregates).toBe(2);
+    // RM-01..RM-04 across 8.1 and 8.2.
+    expect(parsed.read_models).toBe(4);
+  });
+
+  test('handles missing sections gracefully — counts are 0', async () => {
+    const md = `# Minimal model
+
+## 1. Decisions Made
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| D-01 | Foo | Bar |
+
+## 2. Domain Context
+
+Context only.
+
+## 9. Open Questions
+
+1. None.
+`;
+    const path = await writeTempFile(md);
+    const result = await handler.execute({ path });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.events).toBe(0);
+    expect(parsed.commands).toBe(0);
+    expect(parsed.actors).toBe(0);
+    expect(parsed.policies).toBe(0);
+    expect(parsed.aggregates).toBe(0);
+    expect(parsed.read_models).toBe(0);
+  });
+
+  test('counts policies across multiple subsections (cascade, quality, notification, loop)', async () => {
+    const md = `# Model
+
+## 6. Policies
+
+### 6.1 Cascade Policies
+
+| # | When | Then | Why |
+|---|------|------|-----|
+| P-01 | E-01 | Trigger C-02 | always |
+| P-02 | E-02 | Trigger C-03 | always |
+| P-03 | E-03 | Trigger C-04 | always |
+
+### 6.2 Quality Policies
+
+| # | When | Then | Why |
+|---|------|------|-----|
+| P-04 | Bad input | Reject | safety |
+| P-05 | Missing ref | Log | trace |
+
+### 6.3 Notification Policies
+
+| # | When | Then | Channel |
+|---|------|------|---------|
+| P-06 | E-05 | Notify | Discord |
+
+### 6.4 Loop Policies
+
+| # | When | Then | Exit |
+|---|------|------|------|
+| P-07 | E-06 | Continue | Approved |
+| P-08 | E-07 | Continue | Max attempts |
+
+### Key Insights
+
+- P-01, P-02 are critical cascades.
+`;
+    const path = await writeTempFile(md);
+    const result = await handler.execute({ path });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    // 8 unique P-IDs even though P-01/P-02 are mentioned again in Key Insights.
+    expect(parsed.policies).toBe(8);
+  });
+
+  test('counts aggregates as h4 headings under Section 7', async () => {
+    const md = `# Model
+
+## 7. Aggregates
+
+### 7.1 Core Aggregates
+
+#### Alpha (Root Aggregate)
+
+Details.
+
+#### Bravo
+
+Details.
+
+#### Charlie
+
+Details.
+
+#### Delta
+
+Details.
+
+### 7.2 Aggregate Relationships
+
+Diagram stuff — this h3 should NOT count.
+
+### 7.3 Aggregate Homes
+
+More h3 — should NOT count.
+
+## 8. Read Models
+
+None.
+`;
+    const path = await writeTempFile(md);
+    const result = await handler.execute({ path });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.aggregates).toBe(4);
+  });
+
+  test('counts actors from the Responsibility Matrix and ignores the Pattern Summary', async () => {
+    const md = `# Model
+
+## 5. Actors
+
+### Responsibility Matrix
+
+| Actor | Commands | Responsibility |
+|-------|----------|---------------|
+| **Alpha** | C-01 | Role A |
+| **Bravo** | C-02 | Role B |
+| **Charlie** | C-03 | Role C |
+| **Delta** | C-04 | Role D |
+| **Echo** | C-05 | Role E |
+
+### Actor Pattern Summary
+
+| Actor Type | Commands | Count |
+|-----------|----------|:-----:|
+| Human only | C-01, C-02 | 2 |
+| Agent only | C-03, C-04, C-05 | 3 |
+`;
+    const path = await writeTempFile(md);
+    const result = await handler.execute({ path });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    // Only the Responsibility Matrix (first table) counts: 5 rows.
+    expect(parsed.actors).toBe(5);
+  });
+
+  test('counts events uniquely across multiple phases', async () => {
+    const md = `# Model
+
+## 3. Domain Events
+
+### Phase: Alpha
+
+| # | Event | Notes |
+|---|-------|-------|
+| E-01 | Start | - |
+| E-02 | Middle | - |
+
+### Phase: Bravo
+
+| # | Event | Notes |
+|---|-------|-------|
+| E-03 | Continue | - |
+| E-04 | Almost | - |
+
+### Phase: Charlie
+
+| # | Event | Notes |
+|---|-------|-------|
+| E-05 | Done | references E-01 as trigger |
+
+**Total events:** 5
+`;
+    const path = await writeTempFile(md);
+    const result = await handler.execute({ path });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    // E-01 is mentioned twice but must only count once.
+    expect(parsed.events).toBe(5);
+  });
+
+  test('returns ok:false when file is missing', async () => {
+    const result = await handler.execute({
+      path: '/tmp/ddd-summary-nonexistent-xyz-99999.md',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('file not found');
+  });
+
+  test('schema validation rejects missing path', async () => {
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('schema validation rejects empty path', async () => {
+    const result = await handler.execute({ path: '' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Count events, commands, actors, policies, aggregates, and read models in a domain model. Part of Family 3 (Pipeline Authoring sdlc-mcp migration).

## Changes

- `handlers/ddd_summary.ts` — new handler file
- `tests/ddd_summary.test.ts` — new test file (flat `tests/` layout)
- Handler auto-registers via the codegen handler registry

## Test Results

- `./scripts/ci/validate.sh` — codegen, tsc lint, shellcheck, full test suite, runtime smoke all pass
- `bun test tests/ddd_summary.test.ts` — all tests pass in isolation
- Handler appears in `tools/list` via the runtime smoke test (56 handlers total)

## Linked Issues

Closes #114

Related: parent epic Wave-Engineering/claudecode-workflow#331

🤖 Generated with [Claude Code](https://claude.com/claude-code)