### PR TITLE
feat(sdlc-mcp): campaign_stage_start handler

### DIFF
--- a/handlers/campaign_stage_start.ts
+++ b/handlers/campaign_stage_start.ts
@@ -1,0 +1,75 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const STAGES = ['concept', 'prd', 'backlog', 'implementation', 'dod'] as const;
+
+const inputSchema = z.object({
+  stage: z.enum(STAGES),
+  root: z.string().min(1).optional(),
+});
+
+function resolveRoot(explicit?: string): string {
+  if (explicit && explicit.length > 0) return explicit;
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function quoteArg(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+const campaignStageStartHandler: HandlerDef = {
+  name: 'campaign_stage_start',
+  description: 'Transition a campaign to start a new stage via campaign-status CLI',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    const root = resolveRoot(args.root);
+
+    try {
+      const output = execSync(`campaign-status stage-start ${quoteArg(args.stage)}`, {
+        encoding: 'utf8',
+        cwd: root,
+      });
+      // CLI says "Stage '<stage>' is now active." → derive new_state from CLI semantics.
+      const trimmed = output.trim();
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              stage: args.stage,
+              new_state: 'active',
+              cli_output: trimmed,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: false,
+              error: `campaign-status stage-start ${args.stage} failed: ${msg}`,
+            }),
+          },
+        ],
+      };
+    }
+  },
+};
+
+export default campaignStageStartHandler;

--- a/tests/campaign_stage_start.test.ts
+++ b/tests/campaign_stage_start.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+interface ExecCall {
+  cmd: string;
+  opts: { cwd?: string; encoding?: string } | undefined;
+}
+
+let execCalls: ExecCall[] = [];
+let execMockFn: (cmd: string, opts?: { cwd?: string }) => string = () => '';
+const mockExecSync = mock((cmd: string, opts?: { cwd?: string; encoding?: string }) => {
+  execCalls.push({ cmd, opts });
+  return execMockFn(cmd, opts);
+});
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/campaign_stage_start.ts');
+
+function resetMocks() {
+  execCalls = [];
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('campaign_stage_start handler', () => {
+  beforeEach(() => resetMocks());
+  afterEach(() => resetMocks());
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('campaign_stage_start');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('starts concept stage successfully', async () => {
+    execMockFn = () => "Stage 'concept' is now active.\n";
+    const result = await handler.execute({ stage: 'concept', root: '/tmp/repo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.stage).toBe('concept');
+    expect(parsed.new_state).toBe('active');
+    expect(parsed.cli_output).toContain('concept');
+  });
+
+  test('starts prd stage (not /devspec — internal id is prd per rename carveout)', async () => {
+    execMockFn = () => "Stage 'prd' is now active.\n";
+    const result = await handler.execute({ stage: 'prd', root: '/tmp/repo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.stage).toBe('prd');
+  });
+
+  test('starts each valid stage', async () => {
+    execMockFn = () => "Stage 'x' is now active.\n";
+    for (const stage of ['concept', 'prd', 'backlog', 'implementation', 'dod']) {
+      const result = await handler.execute({ stage, root: '/tmp/repo' });
+      const parsed = parseResult(result);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.stage).toBe(stage);
+    }
+  });
+
+  test('passes stage as positional arg to CLI', async () => {
+    execMockFn = () => "Stage 'concept' is now active.\n";
+    await handler.execute({ stage: 'concept', root: '/tmp/myrepo' });
+    const call = execCalls[0];
+    expect(call.cmd).toBe(`campaign-status stage-start 'concept'`);
+    expect(call.opts?.cwd).toBe('/tmp/myrepo');
+  });
+
+  test('rejects invalid stage name', async () => {
+    const result = await handler.execute({ stage: 'foo', root: '/tmp/repo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('errors when CLI fails (out-of-order transition)', async () => {
+    execMockFn = () => {
+      throw new Error('cannot start prd until concept is complete');
+    };
+    const result = await handler.execute({ stage: 'prd', root: '/tmp/repo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('campaign-status stage-start prd failed');
+  });
+
+  test('errors when .sdlc missing (CLI throws)', async () => {
+    execMockFn = () => {
+      throw new Error('Error: not a campaign-status project (.sdlc/ missing)');
+    };
+    const result = await handler.execute({ stage: 'concept', root: '/tmp/repo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('uses CLAUDE_PROJECT_DIR when root not provided', async () => {
+    const oldEnv = process.env.CLAUDE_PROJECT_DIR;
+    process.env.CLAUDE_PROJECT_DIR = '/tmp/from-env';
+    execMockFn = () => "Stage 'concept' is now active.\n";
+    try {
+      await handler.execute({ stage: 'concept' });
+      expect(execCalls[0].opts?.cwd).toBe('/tmp/from-env');
+    } finally {
+      if (oldEnv === undefined) {
+        delete process.env.CLAUDE_PROJECT_DIR;
+      } else {
+        process.env.CLAUDE_PROJECT_DIR = oldEnv;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements the `campaign_stage_start` MCP tool handler — Start a new stage. Shells out to `campaign-status` Python CLI with Zod input validation, structured JSON output, `CLAUDE_PROJECT_DIR` fallback, POSIX single-quote shell escaping.

## Changes

- `handlers/campaign_stage_start.ts` — new handler following the established `execSync` shell-out convention from `devspec_locate.ts` and `ddd_verify_committed.ts`
- `tests/campaign_stage_start.test.ts` — unit tests covering happy path, Zod schema validation, CLI error surface, and `CLAUDE_PROJECT_DIR` env fallback

## Linked Issues

Closes #116

## Test Plan

- `./scripts/ci/validate.sh` — clean
- Bun test suite: all tests pass (842+ across 61 files)
- Runtime smoke test: `tools/list` returns the new handler in the array
- Code reviewer ran across all 7 wave-pa-1c handlers as a batch; one finding on `campaign_show.ts` colon-in-deferral-item parsing was fixed before this commit.

Part of Family 3 Phase 1 (Pipeline Authoring) wave-pa-1c — tracked under epic Wave-Engineering/claudecode-workflow#331.
