### PR TITLE
feat(sdlc-mcp): campaign_defer handler

### DIFF
--- a/handlers/campaign_defer.ts
+++ b/handlers/campaign_defer.ts
@@ -1,0 +1,71 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const inputSchema = z.object({
+  item: z.string().min(1, 'item is required'),
+  reason: z.string().min(1, 'reason is required'),
+  root: z.string().min(1).optional(),
+});
+
+function resolveRoot(explicit?: string): string {
+  if (explicit && explicit.length > 0) return explicit;
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function quoteArg(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+const campaignDeferHandler: HandlerDef = {
+  name: 'campaign_defer',
+  description: 'Defer a deliverable or work item with a rationale via campaign-status CLI',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    const root = resolveRoot(args.root);
+
+    try {
+      execSync(
+        `campaign-status defer ${quoteArg(args.item)} --reason ${quoteArg(args.reason)}`,
+        { encoding: 'utf8', cwd: root }
+      );
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              item: args.item,
+              reason: args.reason,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: false,
+              error: `campaign-status defer failed: ${msg}`,
+            }),
+          },
+        ],
+      };
+    }
+  },
+};
+
+export default campaignDeferHandler;

--- a/tests/campaign_defer.test.ts
+++ b/tests/campaign_defer.test.ts
@@ -1,0 +1,137 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+interface ExecCall {
+  cmd: string;
+  opts: { cwd?: string; encoding?: string } | undefined;
+}
+
+let execCalls: ExecCall[] = [];
+let execMockFn: (cmd: string, opts?: { cwd?: string }) => string = () => '';
+const mockExecSync = mock((cmd: string, opts?: { cwd?: string; encoding?: string }) => {
+  execCalls.push({ cmd, opts });
+  return execMockFn(cmd, opts);
+});
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/campaign_defer.ts');
+
+function resetMocks() {
+  execCalls = [];
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('campaign_defer handler', () => {
+  beforeEach(() => resetMocks());
+  afterEach(() => resetMocks());
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('campaign_defer');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('defers an item with reason', async () => {
+    execMockFn = () => 'Deferred: telemetry-rework\n';
+    const result = await handler.execute({
+      item: 'telemetry-rework',
+      reason: 'requires schema RFC',
+      root: '/tmp/repo',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.item).toBe('telemetry-rework');
+    expect(parsed.reason).toBe('requires schema RFC');
+  });
+
+  test('passes item and --reason to CLI', async () => {
+    execMockFn = () => 'Deferred: x\n';
+    await handler.execute({
+      item: 'my-item',
+      reason: 'because reasons',
+      root: '/tmp/myrepo',
+    });
+    const call = execCalls[0];
+    expect(call.cmd).toContain(`campaign-status defer 'my-item'`);
+    expect(call.cmd).toContain(`--reason 'because reasons'`);
+    expect(call.opts?.cwd).toBe('/tmp/myrepo');
+  });
+
+  test('rejects empty reason', async () => {
+    const result = await handler.execute({
+      item: 'foo',
+      reason: '',
+      root: '/tmp/repo',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('rejects empty item', async () => {
+    const result = await handler.execute({
+      item: '',
+      reason: 'because',
+      root: '/tmp/repo',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('rejects missing item', async () => {
+    const result = await handler.execute({ reason: 'because', root: '/tmp/repo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('rejects missing reason', async () => {
+    const result = await handler.execute({ item: 'foo', root: '/tmp/repo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('errors when CLI fails (.sdlc missing)', async () => {
+    execMockFn = () => {
+      throw new Error('Error: not a campaign-status project');
+    };
+    const result = await handler.execute({
+      item: 'x',
+      reason: 'y',
+      root: '/tmp/no-sdlc',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('campaign-status defer failed');
+  });
+
+  test('handles items and reasons containing single quotes safely', async () => {
+    execMockFn = () => 'Deferred: x\n';
+    await handler.execute({
+      item: "user's request",
+      reason: "it's complicated",
+      root: '/tmp/repo',
+    });
+    // Single-quote escape shape: 'user'\''s request'
+    const call = execCalls[0];
+    expect(call.cmd).toContain(`'user'\\''s request'`);
+    expect(call.cmd).toContain(`'it'\\''s complicated'`);
+  });
+
+  test('uses CLAUDE_PROJECT_DIR when root not provided', async () => {
+    const oldEnv = process.env.CLAUDE_PROJECT_DIR;
+    process.env.CLAUDE_PROJECT_DIR = '/tmp/from-env';
+    execMockFn = () => 'Deferred: x\n';
+    try {
+      await handler.execute({ item: 'foo', reason: 'bar' });
+      expect(execCalls[0].opts?.cwd).toBe('/tmp/from-env');
+    } finally {
+      if (oldEnv === undefined) {
+        delete process.env.CLAUDE_PROJECT_DIR;
+      } else {
+        process.env.CLAUDE_PROJECT_DIR = oldEnv;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements the `campaign_defer` MCP tool handler — Defer a deliverable or work item. Shells out to `campaign-status` Python CLI with Zod input validation, structured JSON output, `CLAUDE_PROJECT_DIR` fallback, POSIX single-quote shell escaping.

## Changes

- `handlers/campaign_defer.ts` — new handler following the established `execSync` shell-out convention from `devspec_locate.ts` and `ddd_verify_committed.ts`
- `tests/campaign_defer.test.ts` — unit tests covering happy path, Zod schema validation, CLI error surface, and `CLAUDE_PROJECT_DIR` env fallback

## Linked Issues

Closes #119

## Test Plan

- `./scripts/ci/validate.sh` — clean
- Bun test suite: all tests pass (842+ across 61 files)
- Runtime smoke test: `tools/list` returns the new handler in the array
- Code reviewer ran across all 7 wave-pa-1c handlers as a batch; one finding on `campaign_show.ts` colon-in-deferral-item parsing was fixed before this commit.

Part of Family 3 Phase 1 (Pipeline Authoring) wave-pa-1c — tracked under epic Wave-Engineering/claudecode-workflow#331.
