### PR TITLE
feat(sdlc-mcp): campaign_stage_complete handler

### DIFF
--- a/handlers/campaign_stage_complete.ts
+++ b/handlers/campaign_stage_complete.ts
@@ -1,0 +1,75 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const STAGES = ['concept', 'prd', 'backlog', 'implementation', 'dod'] as const;
+
+const inputSchema = z.object({
+  stage: z.enum(STAGES),
+  root: z.string().min(1).optional(),
+});
+
+function resolveRoot(explicit?: string): string {
+  if (explicit && explicit.length > 0) return explicit;
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function quoteArg(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+const campaignStageCompleteHandler: HandlerDef = {
+  name: 'campaign_stage_complete',
+  description: 'Mark a stage as complete via campaign-status CLI',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    const root = resolveRoot(args.root);
+
+    try {
+      const output = execSync(`campaign-status stage-complete ${quoteArg(args.stage)}`, {
+        encoding: 'utf8',
+        cwd: root,
+      });
+      // After completing dod, the campaign is fully complete.
+      const campaignComplete = args.stage === 'dod';
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              stage: args.stage,
+              campaign_complete: campaignComplete,
+              cli_output: output.trim(),
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: false,
+              error: `campaign-status stage-complete ${args.stage} failed: ${msg}`,
+            }),
+          },
+        ],
+      };
+    }
+  },
+};
+
+export default campaignStageCompleteHandler;

--- a/tests/campaign_stage_complete.test.ts
+++ b/tests/campaign_stage_complete.test.ts
@@ -1,0 +1,103 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+interface ExecCall {
+  cmd: string;
+  opts: { cwd?: string; encoding?: string } | undefined;
+}
+
+let execCalls: ExecCall[] = [];
+let execMockFn: (cmd: string, opts?: { cwd?: string }) => string = () => '';
+const mockExecSync = mock((cmd: string, opts?: { cwd?: string; encoding?: string }) => {
+  execCalls.push({ cmd, opts });
+  return execMockFn(cmd, opts);
+});
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/campaign_stage_complete.ts');
+
+function resetMocks() {
+  execCalls = [];
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('campaign_stage_complete handler', () => {
+  beforeEach(() => resetMocks());
+  afterEach(() => resetMocks());
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('campaign_stage_complete');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('completes concept stage with campaign_complete:false', async () => {
+    execMockFn = () => "Stage 'concept' is now complete.\n";
+    const result = await handler.execute({ stage: 'concept', root: '/tmp/repo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.stage).toBe('concept');
+    expect(parsed.campaign_complete).toBe(false);
+  });
+
+  test('completes dod stage with campaign_complete:true', async () => {
+    execMockFn = () => "Stage 'dod' is now complete.\n";
+    const result = await handler.execute({ stage: 'dod', root: '/tmp/repo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.campaign_complete).toBe(true);
+  });
+
+  test('completes each non-dod stage with campaign_complete:false', async () => {
+    execMockFn = () => "Stage 'x' is now complete.\n";
+    for (const stage of ['concept', 'prd', 'backlog', 'implementation']) {
+      const result = await handler.execute({ stage, root: '/tmp/repo' });
+      const parsed = parseResult(result);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.campaign_complete).toBe(false);
+    }
+  });
+
+  test('rejects unknown stage', async () => {
+    const result = await handler.execute({ stage: 'foo', root: '/tmp/repo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('passes stage to CLI with correct cwd', async () => {
+    execMockFn = () => "Stage 'prd' is now complete.\n";
+    await handler.execute({ stage: 'prd', root: '/tmp/myrepo' });
+    const call = execCalls[0];
+    expect(call.cmd).toBe(`campaign-status stage-complete 'prd'`);
+    expect(call.opts?.cwd).toBe('/tmp/myrepo');
+  });
+
+  test('errors when CLI fails (review-gated stage not reviewed)', async () => {
+    execMockFn = () => {
+      throw new Error('Error: stage prd must be reviewed before completion');
+    };
+    const result = await handler.execute({ stage: 'prd', root: '/tmp/repo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('campaign-status stage-complete prd failed');
+  });
+
+  test('uses CLAUDE_PROJECT_DIR when root not provided', async () => {
+    const oldEnv = process.env.CLAUDE_PROJECT_DIR;
+    process.env.CLAUDE_PROJECT_DIR = '/tmp/from-env';
+    execMockFn = () => "Stage 'concept' is now complete.\n";
+    try {
+      await handler.execute({ stage: 'concept' });
+      expect(execCalls[0].opts?.cwd).toBe('/tmp/from-env');
+    } finally {
+      if (oldEnv === undefined) {
+        delete process.env.CLAUDE_PROJECT_DIR;
+      } else {
+        process.env.CLAUDE_PROJECT_DIR = oldEnv;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements the `campaign_stage_complete` MCP tool handler — Mark a stage as complete. Shells out to `campaign-status` Python CLI with Zod input validation, structured JSON output, `CLAUDE_PROJECT_DIR` fallback, POSIX single-quote shell escaping.

## Changes

- `handlers/campaign_stage_complete.ts` — new handler following the established `execSync` shell-out convention from `devspec_locate.ts` and `ddd_verify_committed.ts`
- `tests/campaign_stage_complete.test.ts` — unit tests covering happy path, Zod schema validation, CLI error surface, and `CLAUDE_PROJECT_DIR` env fallback

## Linked Issues

Closes #118

## Test Plan

- `./scripts/ci/validate.sh` — clean
- Bun test suite: all tests pass (842+ across 61 files)
- Runtime smoke test: `tools/list` returns the new handler in the array
- Code reviewer ran across all 7 wave-pa-1c handlers as a batch; one finding on `campaign_show.ts` colon-in-deferral-item parsing was fixed before this commit.

Part of Family 3 Phase 1 (Pipeline Authoring) wave-pa-1c — tracked under epic Wave-Engineering/claudecode-workflow#331.
