### PR TITLE
feat(sdlc-mcp): campaign_stage_review handler

### DIFF
--- a/handlers/campaign_stage_review.ts
+++ b/handlers/campaign_stage_review.ts
@@ -1,0 +1,73 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+// Only review-gated stages support stage-review.
+const REVIEW_STAGES = ['concept', 'prd', 'dod'] as const;
+
+const inputSchema = z.object({
+  stage: z.enum(REVIEW_STAGES),
+  root: z.string().min(1).optional(),
+});
+
+function resolveRoot(explicit?: string): string {
+  if (explicit && explicit.length > 0) return explicit;
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function quoteArg(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+const campaignStageReviewHandler: HandlerDef = {
+  name: 'campaign_stage_review',
+  description: 'Mark a review-gated stage (concept|prd|dod) as in-review via campaign-status CLI',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    const root = resolveRoot(args.root);
+
+    try {
+      const output = execSync(`campaign-status stage-review ${quoteArg(args.stage)}`, {
+        encoding: 'utf8',
+        cwd: root,
+      });
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              stage: args.stage,
+              cli_output: output.trim(),
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: false,
+              error: `campaign-status stage-review ${args.stage} failed: ${msg}`,
+            }),
+          },
+        ],
+      };
+    }
+  },
+};
+
+export default campaignStageReviewHandler;

--- a/tests/campaign_stage_review.test.ts
+++ b/tests/campaign_stage_review.test.ts
@@ -1,0 +1,112 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+interface ExecCall {
+  cmd: string;
+  opts: { cwd?: string; encoding?: string } | undefined;
+}
+
+let execCalls: ExecCall[] = [];
+let execMockFn: (cmd: string, opts?: { cwd?: string }) => string = () => '';
+const mockExecSync = mock((cmd: string, opts?: { cwd?: string; encoding?: string }) => {
+  execCalls.push({ cmd, opts });
+  return execMockFn(cmd, opts);
+});
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/campaign_stage_review.ts');
+
+function resetMocks() {
+  execCalls = [];
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('campaign_stage_review handler', () => {
+  beforeEach(() => resetMocks());
+  afterEach(() => resetMocks());
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('campaign_stage_review');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('marks concept for review', async () => {
+    execMockFn = () => "Stage 'concept' is now in review.\n";
+    const result = await handler.execute({ stage: 'concept', root: '/tmp/repo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.stage).toBe('concept');
+  });
+
+  test('marks prd for review', async () => {
+    execMockFn = () => "Stage 'prd' is now in review.\n";
+    const result = await handler.execute({ stage: 'prd', root: '/tmp/repo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.stage).toBe('prd');
+  });
+
+  test('marks dod for review', async () => {
+    execMockFn = () => "Stage 'dod' is now in review.\n";
+    const result = await handler.execute({ stage: 'dod', root: '/tmp/repo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.stage).toBe('dod');
+  });
+
+  test('rejects backlog (not review-gated)', async () => {
+    const result = await handler.execute({ stage: 'backlog', root: '/tmp/repo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('rejects implementation (not review-gated)', async () => {
+    const result = await handler.execute({ stage: 'implementation', root: '/tmp/repo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('rejects unknown stage', async () => {
+    const result = await handler.execute({ stage: 'foo', root: '/tmp/repo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('passes stage to CLI with correct cwd', async () => {
+    execMockFn = () => "Stage 'concept' is now in review.\n";
+    await handler.execute({ stage: 'concept', root: '/tmp/myrepo' });
+    const call = execCalls[0];
+    expect(call.cmd).toBe(`campaign-status stage-review 'concept'`);
+    expect(call.opts?.cwd).toBe('/tmp/myrepo');
+  });
+
+  test('errors when CLI fails (stage not active)', async () => {
+    execMockFn = () => {
+      throw new Error('Error: stage prd is not currently active');
+    };
+    const result = await handler.execute({ stage: 'prd', root: '/tmp/repo' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('campaign-status stage-review prd failed');
+  });
+
+  test('uses CLAUDE_PROJECT_DIR when root not provided', async () => {
+    const oldEnv = process.env.CLAUDE_PROJECT_DIR;
+    process.env.CLAUDE_PROJECT_DIR = '/tmp/from-env';
+    execMockFn = () => "Stage 'concept' is now in review.\n";
+    try {
+      await handler.execute({ stage: 'concept' });
+      expect(execCalls[0].opts?.cwd).toBe('/tmp/from-env');
+    } finally {
+      if (oldEnv === undefined) {
+        delete process.env.CLAUDE_PROJECT_DIR;
+      } else {
+        process.env.CLAUDE_PROJECT_DIR = oldEnv;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements the `campaign_stage_review` MCP tool handler — Mark a review-gated stage as in-review. Shells out to `campaign-status` Python CLI with Zod input validation, structured JSON output, `CLAUDE_PROJECT_DIR` fallback, POSIX single-quote shell escaping.

## Changes

- `handlers/campaign_stage_review.ts` — new handler following the established `execSync` shell-out convention from `devspec_locate.ts` and `ddd_verify_committed.ts`
- `tests/campaign_stage_review.test.ts` — unit tests covering happy path, Zod schema validation, CLI error surface, and `CLAUDE_PROJECT_DIR` env fallback

## Linked Issues

Closes #117

## Test Plan

- `./scripts/ci/validate.sh` — clean
- Bun test suite: all tests pass (842+ across 61 files)
- Runtime smoke test: `tools/list` returns the new handler in the array
- Code reviewer ran across all 7 wave-pa-1c handlers as a batch; one finding on `campaign_show.ts` colon-in-deferral-item parsing was fixed before this commit.

Part of Family 3 Phase 1 (Pipeline Authoring) wave-pa-1c — tracked under epic Wave-Engineering/claudecode-workflow#331.
