### PR TITLE
fix(pr_create): make idempotent — return existing PR/MR on duplicate

### DIFF
--- a/handlers/pr_create.ts
+++ b/handlers/pr_create.ts
@@ -67,6 +67,31 @@ interface NormalizedPr {
   state: 'open';
   head: string;
   base: string;
+  created: boolean;
+}
+
+function lookupGithubPr(head: string, cwd: string): NormalizedPr | null {
+  const list = run(
+    ['gh', 'pr', 'list', '--head', head, '--state', 'open', '--json', 'number,url,state,headRefName,baseRefName', '--limit', '1'],
+    cwd,
+  );
+  if (list.exitCode !== 0) return null;
+  const prs = JSON.parse(list.stdout) as Array<{
+    number: number;
+    url: string;
+    state: string;
+    headRefName: string;
+    baseRefName: string;
+  }>;
+  if (prs.length === 0) return null;
+  return {
+    number: prs[0].number,
+    url: prs[0].url,
+    state: 'open',
+    head: prs[0].headRefName,
+    base: prs[0].baseRefName,
+    created: false,
+  };
 }
 
 function createGithubPr(args: Input, head: string, cwd: string): NormalizedPr {
@@ -85,13 +110,21 @@ function createGithubPr(args: Input, head: string, cwd: string): NormalizedPr {
   ];
   if (args.draft) createCmd.push('--draft');
 
-  const created = run(createCmd, cwd);
-  if (created.exitCode !== 0) {
-    throw new Error(`gh pr create failed: ${created.stderr.trim() || created.stdout.trim()}`);
+  const result = run(createCmd, cwd);
+  if (result.exitCode !== 0) {
+    const errText = (result.stderr + result.stdout).toLowerCase();
+    // gh says "a pull request for branch ... already exists" on duplicate
+    if (errText.includes('already exists')) {
+      const existing = lookupGithubPr(head, cwd);
+      if (existing) return existing;
+      // Lookup failed (PR may have been closed between create and lookup)
+      throw new Error(`gh pr create: PR already exists for branch '${head}' but could not be found via lookup`);
+    }
+    throw new Error(`gh pr create failed: ${result.stderr.trim() || result.stdout.trim()}`);
   }
 
   // gh pr create prints the PR URL on stdout. Parse the number from the URL.
-  const url = created.stdout.trim().split('\n').pop() ?? '';
+  const url = result.stdout.trim().split('\n').pop() ?? '';
   const numMatch = /\/pull\/(\d+)/.exec(url);
   if (!numMatch) {
     throw new Error(`gh pr create: could not parse PR number from output: ${url}`);
@@ -119,7 +152,33 @@ function createGithubPr(args: Input, head: string, cwd: string): NormalizedPr {
     state: 'open',
     head: parsed.headRefName,
     base: parsed.baseRefName,
+    created: true,
   };
+}
+
+function lookupGitlabMr(head: string, cwd: string): NormalizedPr | null {
+  const view = run(['glab', 'mr', 'view', head, '-F', 'json'], cwd);
+  if (view.exitCode !== 0) return null;
+  try {
+    const parsed = JSON.parse(view.stdout) as {
+      iid: number;
+      web_url: string;
+      state: string;
+      source_branch: string;
+      target_branch: string;
+    };
+    if (parsed.state !== 'opened') return null;
+    return {
+      number: parsed.iid,
+      url: parsed.web_url,
+      state: 'open',
+      head: parsed.source_branch,
+      base: parsed.target_branch,
+      created: false,
+    };
+  } catch {
+    return null;
+  }
 }
 
 function createGitlabMr(args: Input, head: string, cwd: string): NormalizedPr {
@@ -139,9 +198,17 @@ function createGitlabMr(args: Input, head: string, cwd: string): NormalizedPr {
   ];
   if (args.draft) createCmd.push('--draft');
 
-  const created = run(createCmd, cwd);
-  if (created.exitCode !== 0) {
-    throw new Error(`glab mr create failed: ${created.stderr.trim() || created.stdout.trim()}`);
+  const result = run(createCmd, cwd);
+  if (result.exitCode !== 0) {
+    const errText = (result.stderr + result.stdout).toLowerCase();
+    // glab says "Another open merge request already exists" on duplicate
+    if (errText.includes('already exists')) {
+      const existing = lookupGitlabMr(head, cwd);
+      if (existing) return existing;
+      // Lookup failed (MR may have been closed between create and lookup)
+      throw new Error(`glab mr create: MR already exists for branch '${head}' but could not be found via lookup`);
+    }
+    throw new Error(`glab mr create failed: ${result.stderr.trim() || result.stdout.trim()}`);
   }
 
   // Normalize by fetching the MR we just created via `glab mr view <head> -F json`.
@@ -162,6 +229,7 @@ function createGitlabMr(args: Input, head: string, cwd: string): NormalizedPr {
     state: 'open',
     head: parsed.source_branch,
     base: parsed.target_branch,
+    created: true,
   };
 }
 

--- a/tests/pr_create.test.ts
+++ b/tests/pr_create.test.ts
@@ -128,6 +128,7 @@ echo "unhandled gh: $*" >&2; exit 1
     expect(data.state).toBe('open');
     expect(data.head).toBe('feature/76-pr-create');
     expect(data.base).toBe('main');
+    expect(data.created).toBe(true);
   });
 
   test('gitlab_happy_path — creates MR and returns normalized response', async () => {
@@ -182,6 +183,7 @@ echo "unhandled glab: $*" >&2; exit 1
     expect(data.state).toBe('open');
     expect(data.head).toBe('feature/76-pr-create');
     expect(data.base).toBe('main');
+    expect(data.created).toBe(true);
   });
 
   test('draft_flag_github — passes --draft to gh pr create', async () => {
@@ -409,6 +411,108 @@ exit 1
     expect(data.ok).toBe(false);
     expect(String(data.error)).toContain('gh pr create failed');
     expect(String(data.error)).toContain('authentication error');
+  });
+
+  test('github_idempotent — duplicate PR returns existing with created=false', async () => {
+    const { fixture, stubBin } = await makeFixture({ '.keep': '' });
+    fixtureDir = fixture;
+    stubBinDir = stubBin;
+
+    await writeStub(
+      stubBin,
+      'git',
+      `
+case "$1 $2" in
+  "branch --show-current") echo "feature/76-pr-create" ;;
+  "remote -v") echo "origin\tgit@github.com:org/repo.git (fetch)" ;;
+  *) exit 1 ;;
+esac
+`,
+    );
+
+    // gh pr create fails with "already exists"; gh pr list returns the existing PR.
+    await writeStub(
+      stubBin,
+      'gh',
+      `
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  echo "a pull request for branch \"feature/76-pr-create\" into branch \"main\" already exists" >&2
+  exit 1
+fi
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  cat <<'EOF'
+[{"number":42,"url":"https://github.com/org/repo/pull/42","state":"OPEN","headRefName":"feature/76-pr-create","baseRefName":"main"}]
+EOF
+  exit 0
+fi
+echo "unhandled gh: $*" >&2; exit 1
+`,
+    );
+
+    activate(fixture, stubBin);
+
+    const result = await handler.execute({
+      title: 'feat: add pr_create',
+      body: 'Implements the pr_create handler.',
+      base: 'main',
+    });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.number).toBe(42);
+    expect(data.url).toBe('https://github.com/org/repo/pull/42');
+    expect(data.created).toBe(false);
+  });
+
+  test('gitlab_idempotent — duplicate MR returns existing with created=false', async () => {
+    const { fixture, stubBin } = await makeFixture({ '.keep': '' });
+    fixtureDir = fixture;
+    stubBinDir = stubBin;
+
+    await writeStub(
+      stubBin,
+      'git',
+      `
+case "$1 $2" in
+  "branch --show-current") echo "feature/76-pr-create" ;;
+  "remote -v") echo "origin\tgit@gitlab.com:org/repo.git (fetch)" ;;
+  *) exit 1 ;;
+esac
+`,
+    );
+
+    // glab mr create fails with "already exists"; glab mr view returns the existing MR.
+    await writeStub(
+      stubBin,
+      'glab',
+      `
+if [ "$1" = "mr" ] && [ "$2" = "create" ]; then
+  echo "Another open merge request already exists for this source branch" >&2
+  exit 1
+fi
+if [ "$1" = "mr" ] && [ "$2" = "view" ]; then
+  cat <<'EOF'
+{"iid":7,"web_url":"https://gitlab.com/org/repo/-/merge_requests/7","state":"opened","source_branch":"feature/76-pr-create","target_branch":"main"}
+EOF
+  exit 0
+fi
+echo "unhandled glab: $*" >&2; exit 1
+`,
+    );
+
+    activate(fixture, stubBin);
+
+    const result = await handler.execute({
+      title: 'feat: add pr_create',
+      body: 'Implements the pr_create handler.',
+      base: 'main',
+    });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.number).toBe(7);
+    expect(data.url).toBe('https://gitlab.com/org/repo/-/merge_requests/7');
+    expect(data.created).toBe(false);
   });
 
   test('fallback_platform_detection — no .claude-project.md, uses git remote', async () => {


### PR DESCRIPTION
## Summary

Makes `pr_create` idempotent: when a PR/MR already exists for the source branch, return it with `created: false` instead of failing with a 409.

## Changes

- Added `lookupGithubPr()` and `lookupGitlabMr()` functions to find existing open PRs/MRs by head branch
- Wrapped `createGithubPr` and `createGitlabMr` to catch "already exists" errors and fall back to lookup
- Added `created: boolean` field to `NormalizedPr` response — `true` for new, `false` for pre-existing
- Clear error message when duplicate is detected but lookup fails (e.g., PR closed between attempts)

## Linked Issues

Closes #157

## Test Plan

- 989/989 tests pass (`bun test`)
- 2 new idempotency tests: `github_idempotent`, `gitlab_idempotent`
- Existing happy-path tests updated with `created: true` assertions
- `validate.sh` — 66/66 tools pass