### PR TITLE
feat(sdlc): commutativity_verify tool + pr_merge skip_train

### DIFF
--- a/handlers/commutativity_verify.ts
+++ b/handlers/commutativity_verify.ts
@@ -1,0 +1,163 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+const changesetSchema = z.object({
+  id: z.string().min(1),
+  head_ref: z.string().min(1),
+});
+
+const inputSchema = z.object({
+  repo_path: z.string().min(1),
+  base_ref: z.string().min(1),
+  changesets: z.array(changesetSchema).min(2, 'At least 2 changesets required for pairwise analysis'),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+interface ProbePair {
+  a: string;
+  b: string;
+  verdict: string;
+  reason: string;
+  file_overlaps: string[];
+  symbol_collisions: string[];
+  import_overlaps: string[];
+}
+
+interface ProbeOutput {
+  changesets: string[];
+  flight_verdict: string;
+  pairs: ProbePair[];
+}
+
+const VALID_VERDICTS = ['STRONG', 'MEDIUM', 'WEAK', 'ORACLE_REQUIRED'] as const;
+
+function isValidVerdict(v: string): v is (typeof VALID_VERDICTS)[number] {
+  return (VALID_VERDICTS as readonly string[]).includes(v);
+}
+
+/** Build the commutativity-probe CLI command. */
+function buildCommand(args: Input): string {
+  const branches = args.changesets.map(c => c.head_ref);
+  return [
+    'commutativity-probe',
+    'analyze',
+    '--repo', args.repo_path,
+    '--base', args.base_ref,
+    '--json',
+    ...branches,
+  ].join(' ');
+}
+
+/** Map probe changeset IDs (branch refs) back to caller-provided IDs. */
+function mapPairIds(
+  pairs: ProbePair[],
+  refToId: Map<string, string>,
+): ProbePair[] {
+  return pairs.map(p => ({
+    ...p,
+    a: refToId.get(p.a) ?? p.a,
+    b: refToId.get(p.b) ?? p.b,
+  }));
+}
+
+const SUBPROCESS_TIMEOUT_MS = 30_000;
+
+const commutativityVerifyHandler: HandlerDef = {
+  name: 'commutativity_verify',
+  description:
+    'Verify changeset commutativity from actual git diffs. Determines whether the merge train pipeline is needed for a flight of MRs. ' +
+    'Call AFTER all MR pipelines in a flight pass (pr_wait_ci green) and BEFORE pr_merge. ' +
+    'Requires at least 2 changesets — skip for single-MR flights.',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: Input;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    // Build ref→id mapping so we return caller-provided IDs, not raw branch refs.
+    const refToId = new Map<string, string>();
+    for (const cs of args.changesets) {
+      refToId.set(cs.head_ref, cs.id);
+    }
+
+    const cmd = buildCommand(args);
+    let raw: string;
+    try {
+      raw = execSync(cmd, {
+        encoding: 'utf8',
+        timeout: SUBPROCESS_TIMEOUT_MS,
+        cwd: args.repo_path,
+      });
+    } catch (err) {
+      // Fail safe: any subprocess error → ORACLE_REQUIRED verdict with warning.
+      const message = err instanceof Error ? err.message : String(err);
+      const timedOut = message.includes('ETIMEDOUT') || message.includes('timed out');
+      if (timedOut) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              group_verdict: 'ORACLE_REQUIRED',
+              pairs: [],
+              warnings: [`Subprocess timed out after ${SUBPROCESS_TIMEOUT_MS}ms. Failing safe to ORACLE_REQUIRED.`],
+            }),
+          }],
+        };
+      }
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error: `commutativity-probe failed: ${message}` }) }],
+      };
+    }
+
+    let probe: ProbeOutput;
+    try {
+      probe = JSON.parse(raw) as ProbeOutput;
+    } catch {
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify({ ok: false, error: `Failed to parse commutativity-probe JSON output` }),
+        }],
+      };
+    }
+
+    // Validate the verdict value from the probe.
+    const groupVerdict = isValidVerdict(probe.flight_verdict)
+      ? probe.flight_verdict
+      : 'ORACLE_REQUIRED';
+
+    const warnings: string[] = [];
+    if (!isValidVerdict(probe.flight_verdict)) {
+      warnings.push(`Unknown verdict '${probe.flight_verdict}' from probe — defaulting to ORACLE_REQUIRED`);
+    }
+
+    // Validate per-pair verdicts.
+    const pairs = mapPairIds(probe.pairs, refToId).map(p => ({
+      ...p,
+      verdict: isValidVerdict(p.verdict) ? p.verdict : 'ORACLE_REQUIRED',
+    }));
+
+    return {
+      content: [{
+        type: 'text' as const,
+        text: JSON.stringify({
+          ok: true,
+          group_verdict: groupVerdict,
+          pairs,
+          warnings: warnings.length > 0 ? warnings : undefined,
+        }),
+      }],
+    };
+  },
+};
+
+export default commutativityVerifyHandler;

--- a/handlers/commutativity_verify.ts
+++ b/handlers/commutativity_verify.ts
@@ -37,14 +37,23 @@ function isValidVerdict(v: string): v is (typeof VALID_VERDICTS)[number] {
   return (VALID_VERDICTS as readonly string[]).includes(v);
 }
 
-/** Build the commutativity-probe CLI command. */
+/**
+ * Shell-escape a value for safe inclusion in a single-quoted shell argument.
+ * Prevents injection when user-provided values (repo paths, refs) contain
+ * spaces, quotes, or metacharacters.
+ */
+function shellEscape(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Build the commutativity-probe CLI command with shell-escaped arguments. */
 function buildCommand(args: Input): string {
-  const branches = args.changesets.map(c => c.head_ref);
+  const branches = args.changesets.map(c => shellEscape(c.head_ref));
   return [
     'commutativity-probe',
     'analyze',
-    '--repo', args.repo_path,
-    '--base', args.base_ref,
+    '--repo', shellEscape(args.repo_path),
+    '--base', shellEscape(args.base_ref),
     '--json',
     ...branches,
   ].join(' ');

--- a/handlers/pr_merge.ts
+++ b/handlers/pr_merge.ts
@@ -20,6 +20,7 @@ const inputSchema = z.object({
   number: z.number().int().positive('number must be a positive integer'),
   squash_message: z.string().optional(),
   use_merge_queue: z.boolean().optional(),
+  skip_train: z.boolean().optional(),
 });
 
 type Input = z.infer<typeof inputSchema>;
@@ -196,7 +197,7 @@ function mergeGithub(args: Input): MergeSuccess | MergeFailure {
     };
   }
 
-  // Default: direct-squash first, fall back to --auto on merge-queue rejection.
+  // Direct-squash merge (no merge-queue enrollment).
   const directCmd = buildGithubMergeCommand(args.number, false, args.squash_message);
   try {
     exec(directCmd);
@@ -211,6 +212,14 @@ function mergeGithub(args: Input): MergeSuccess | MergeFailure {
     };
   } catch (err) {
     const fail = extractFailure(err);
+    // When skip_train is set, commutativity analysis has proven the merge is safe.
+    // Do not fall back to the merge queue — surface the error directly.
+    if (args.skip_train === true) {
+      return {
+        ok: false,
+        error: `gh pr merge failed (skip_train): ${fail.message}`,
+      };
+    }
     if (!stderrIndicatesMergeQueue(fail.stderr) && !stderrIndicatesMergeQueue(fail.message)) {
       return {
         ok: false,
@@ -219,7 +228,7 @@ function mergeGithub(args: Input): MergeSuccess | MergeFailure {
     }
   }
 
-  // Merge-queue fallback.
+  // Merge-queue fallback (only reached when skip_train is not set).
   const autoCmd = buildGithubMergeCommand(args.number, true, args.squash_message);
   try {
     exec(autoCmd);
@@ -265,7 +274,9 @@ function mergeGitlab(args: Input): MergeSuccess | MergeFailure {
 const prMergeHandler: HandlerDef = {
   name: 'pr_merge',
   description:
-    'Merge a PR/MR with squash + delete source branch. Auto-detects merge-queue enforcement on GitHub and falls back to --auto mode. Supports custom multi-line squash messages.',
+    'Merge a PR/MR with squash + delete source branch. Auto-detects merge-queue enforcement on GitHub and falls back to --auto mode. ' +
+    'Set skip_train=true to bypass merge queue enrollment when commutativity analysis (commutativity_verify) has proven the merge is safe. ' +
+    'Supports custom multi-line squash messages.',
   inputSchema,
   async execute(rawArgs: unknown) {
     let args: Input;

--- a/tests/commutativity_verify.test.ts
+++ b/tests/commutativity_verify.test.ts
@@ -310,11 +310,33 @@ describe('commutativity_verify handler', () => {
     expect(execCalls).toHaveLength(1);
     const cmd = execCalls[0];
     expect(cmd).toContain('commutativity-probe analyze');
-    expect(cmd).toContain('--repo /my/repo');
-    expect(cmd).toContain('--base v1.0.0');
+    expect(cmd).toContain("--repo '/my/repo'");
+    expect(cmd).toContain("--base 'v1.0.0'");
     expect(cmd).toContain('--json');
-    expect(cmd).toContain('feature/alpha');
-    expect(cmd).toContain('feature/beta');
+    expect(cmd).toContain("'feature/alpha'");
+    expect(cmd).toContain("'feature/beta'");
+  });
+
+  // --- shell escaping: spaces in repo path ---
+  test('shell-escapes repo path with spaces', async () => {
+    onExec('commutativity-probe', probeJson('STRONG', [{
+      a: 'feature/a',
+      b: 'feature/b',
+      verdict: 'STRONG',
+      reason: 'Disjoint',
+    }]));
+
+    await handler.execute({
+      repo_path: '/my repo/with spaces',
+      base_ref: 'main',
+      changesets: [
+        { id: 'mr-1', head_ref: 'feature/a' },
+        { id: 'mr-2', head_ref: 'feature/b' },
+      ],
+    });
+
+    const cmd = execCalls[0];
+    expect(cmd).toContain("--repo '/my repo/with spaces'");
   });
 
   // --- three changesets produce correct pair count ---

--- a/tests/commutativity_verify.test.ts
+++ b/tests/commutativity_verify.test.ts
@@ -1,0 +1,355 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+type Responder = string | (() => string);
+
+let execRegistry: Array<{ match: string; respond: Responder }> = [];
+let execCalls: string[] = [];
+
+function mockExec(cmd: string): string {
+  execCalls.push(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  throw new Error(`Unexpected exec call: ${cmd}`);
+}
+
+mock.module('child_process', () => ({
+  execSync: (cmd: string, _opts?: unknown) => mockExec(cmd),
+}));
+
+const { default: handler } = await import('../handlers/commutativity_verify.ts');
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text) as Record<string, unknown>;
+}
+
+function onExec(match: string, respond: Responder) {
+  execRegistry.push({ match, respond });
+}
+
+function probeJson(verdict: string, pairs: Array<{
+  a: string; b: string; verdict: string; reason: string;
+  file_overlaps?: string[]; symbol_collisions?: string[]; import_overlaps?: string[];
+}>): string {
+  return JSON.stringify({
+    changesets: pairs.length > 0 ? [pairs[0].a, pairs[0].b] : [],
+    flight_verdict: verdict,
+    pairs: pairs.map(p => ({
+      a: p.a,
+      b: p.b,
+      verdict: p.verdict,
+      reason: p.reason,
+      file_overlaps: p.file_overlaps ?? [],
+      symbol_collisions: p.symbol_collisions ?? [],
+      import_overlaps: p.import_overlaps ?? [],
+    })),
+  });
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+afterEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('commutativity_verify handler', () => {
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('commutativity_verify');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  // --- schema validation ---
+  test('schema rejects single changeset (minItems: 2)', async () => {
+    const result = await handler.execute({
+      repo_path: '/repo',
+      base_ref: 'main',
+      changesets: [{ id: 'mr-1', head_ref: 'feature/1' }],
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+    expect(data.error as string).toContain('2 changesets');
+  });
+
+  test('schema rejects missing repo_path', async () => {
+    const result = await handler.execute({
+      base_ref: 'main',
+      changesets: [
+        { id: 'mr-1', head_ref: 'feature/1' },
+        { id: 'mr-2', head_ref: 'feature/2' },
+      ],
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+  });
+
+  test('schema rejects empty changeset id', async () => {
+    const result = await handler.execute({
+      repo_path: '/repo',
+      base_ref: 'main',
+      changesets: [
+        { id: '', head_ref: 'feature/1' },
+        { id: 'mr-2', head_ref: 'feature/2' },
+      ],
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+  });
+
+  // --- happy path: STRONG verdict ---
+  test('STRONG verdict — file-disjoint and symbol-disjoint changesets', async () => {
+    onExec('commutativity-probe', probeJson('STRONG', [{
+      a: 'feature/1',
+      b: 'feature/2',
+      verdict: 'STRONG',
+      reason: 'Syntactically disjoint and symbol-disjoint',
+    }]));
+
+    const result = await handler.execute({
+      repo_path: '/repo',
+      base_ref: 'main',
+      changesets: [
+        { id: 'mr-1', head_ref: 'feature/1' },
+        { id: 'mr-2', head_ref: 'feature/2' },
+      ],
+    });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.group_verdict).toBe('STRONG');
+    const pairs = data.pairs as Array<{ a: string; b: string; verdict: string }>;
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].a).toBe('mr-1');
+    expect(pairs[0].b).toBe('mr-2');
+    expect(pairs[0].verdict).toBe('STRONG');
+  });
+
+  // --- MEDIUM verdict ---
+  test('MEDIUM verdict — import chain but no symbol cross-reference', async () => {
+    onExec('commutativity-probe', probeJson('MEDIUM', [{
+      a: 'feature/1',
+      b: 'feature/2',
+      verdict: 'MEDIUM',
+      reason: 'Import chain overlap but no symbol cross-reference',
+      import_overlaps: ['lib/shared.ts'],
+    }]));
+
+    const result = await handler.execute({
+      repo_path: '/repo',
+      base_ref: 'main',
+      changesets: [
+        { id: 'mr-1', head_ref: 'feature/1' },
+        { id: 'mr-2', head_ref: 'feature/2' },
+      ],
+    });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.group_verdict).toBe('MEDIUM');
+  });
+
+  // --- WEAK verdict ---
+  test('WEAK verdict — symbol cross-reference detected', async () => {
+    onExec('commutativity-probe', probeJson('WEAK', [{
+      a: 'feature/1',
+      b: 'feature/2',
+      verdict: 'WEAK',
+      reason: 'Symbol cross-reference: processOrder modified by feature/1, referenced by feature/2',
+      symbol_collisions: ['handlers/order.ts::processOrder'],
+    }]));
+
+    const result = await handler.execute({
+      repo_path: '/repo',
+      base_ref: 'main',
+      changesets: [
+        { id: 'mr-1', head_ref: 'feature/1' },
+        { id: 'mr-2', head_ref: 'feature/2' },
+      ],
+    });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.group_verdict).toBe('WEAK');
+    const pairs = data.pairs as Array<{ symbol_collisions: string[] }>;
+    expect(pairs[0].symbol_collisions).toContain('handlers/order.ts::processOrder');
+  });
+
+  // --- ORACLE_REQUIRED verdict ---
+  test('ORACLE_REQUIRED verdict — CI_INFRA file changed', async () => {
+    onExec('commutativity-probe', probeJson('ORACLE_REQUIRED', [{
+      a: 'feature/1',
+      b: 'feature/2',
+      verdict: 'ORACLE_REQUIRED',
+      reason: 'CI_INFRA file changed: .github/workflows/ci.yml',
+      file_overlaps: ['.github/workflows/ci.yml'],
+    }]));
+
+    const result = await handler.execute({
+      repo_path: '/repo',
+      base_ref: 'main',
+      changesets: [
+        { id: 'mr-1', head_ref: 'feature/1' },
+        { id: 'mr-2', head_ref: 'feature/2' },
+      ],
+    });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.group_verdict).toBe('ORACLE_REQUIRED');
+  });
+
+  // --- subprocess error ---
+  test('subprocess error — returns ok:false with error message', async () => {
+    onExec('commutativity-probe', () => {
+      throw new Error('commutativity-probe: command not found');
+    });
+
+    const result = await handler.execute({
+      repo_path: '/repo',
+      base_ref: 'main',
+      changesets: [
+        { id: 'mr-1', head_ref: 'feature/1' },
+        { id: 'mr-2', head_ref: 'feature/2' },
+      ],
+    });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(false);
+    expect(data.error as string).toContain('commutativity-probe failed');
+  });
+
+  // --- subprocess timeout ---
+  test('subprocess timeout — returns ORACLE_REQUIRED (fail safe)', async () => {
+    onExec('commutativity-probe', () => {
+      throw new Error('ETIMEDOUT: command timed out');
+    });
+
+    const result = await handler.execute({
+      repo_path: '/repo',
+      base_ref: 'main',
+      changesets: [
+        { id: 'mr-1', head_ref: 'feature/1' },
+        { id: 'mr-2', head_ref: 'feature/2' },
+      ],
+    });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.group_verdict).toBe('ORACLE_REQUIRED');
+    const warnings = data.warnings as string[];
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('timed out');
+  });
+
+  // --- malformed JSON from probe ---
+  test('malformed JSON output — returns ok:false', async () => {
+    onExec('commutativity-probe', 'this is not json');
+
+    const result = await handler.execute({
+      repo_path: '/repo',
+      base_ref: 'main',
+      changesets: [
+        { id: 'mr-1', head_ref: 'feature/1' },
+        { id: 'mr-2', head_ref: 'feature/2' },
+      ],
+    });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(false);
+    expect(data.error as string).toContain('parse');
+  });
+
+  // --- unknown verdict from probe falls back to ORACLE_REQUIRED ---
+  test('unknown verdict from probe — defaults to ORACLE_REQUIRED with warning', async () => {
+    onExec('commutativity-probe', probeJson('BANANA', [{
+      a: 'feature/1',
+      b: 'feature/2',
+      verdict: 'BANANA',
+      reason: 'Something unexpected',
+    }]));
+
+    const result = await handler.execute({
+      repo_path: '/repo',
+      base_ref: 'main',
+      changesets: [
+        { id: 'mr-1', head_ref: 'feature/1' },
+        { id: 'mr-2', head_ref: 'feature/2' },
+      ],
+    });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.group_verdict).toBe('ORACLE_REQUIRED');
+    const warnings = data.warnings as string[];
+    expect(warnings[0]).toContain('BANANA');
+  });
+
+  // --- verifies CLI command structure ---
+  test('builds correct CLI command with repo, base, and branch refs', async () => {
+    onExec('commutativity-probe', probeJson('STRONG', [{
+      a: 'feature/alpha',
+      b: 'feature/beta',
+      verdict: 'STRONG',
+      reason: 'Disjoint',
+    }]));
+
+    await handler.execute({
+      repo_path: '/my/repo',
+      base_ref: 'v1.0.0',
+      changesets: [
+        { id: 'mr-10', head_ref: 'feature/alpha' },
+        { id: 'mr-11', head_ref: 'feature/beta' },
+      ],
+    });
+
+    expect(execCalls).toHaveLength(1);
+    const cmd = execCalls[0];
+    expect(cmd).toContain('commutativity-probe analyze');
+    expect(cmd).toContain('--repo /my/repo');
+    expect(cmd).toContain('--base v1.0.0');
+    expect(cmd).toContain('--json');
+    expect(cmd).toContain('feature/alpha');
+    expect(cmd).toContain('feature/beta');
+  });
+
+  // --- three changesets produce correct pair count ---
+  test('three changesets — maps all three pair IDs correctly', async () => {
+    const pairs = [
+      { a: 'feature/a', b: 'feature/b', verdict: 'STRONG', reason: 'Disjoint' },
+      { a: 'feature/a', b: 'feature/c', verdict: 'STRONG', reason: 'Disjoint' },
+      { a: 'feature/b', b: 'feature/c', verdict: 'WEAK', reason: 'File overlap' },
+    ];
+    onExec('commutativity-probe', JSON.stringify({
+      changesets: ['feature/a', 'feature/b', 'feature/c'],
+      flight_verdict: 'WEAK',
+      pairs: pairs.map(p => ({ ...p, file_overlaps: [], symbol_collisions: [], import_overlaps: [] })),
+    }));
+
+    const result = await handler.execute({
+      repo_path: '/repo',
+      base_ref: 'main',
+      changesets: [
+        { id: 'mr-1', head_ref: 'feature/a' },
+        { id: 'mr-2', head_ref: 'feature/b' },
+        { id: 'mr-3', head_ref: 'feature/c' },
+      ],
+    });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.group_verdict).toBe('WEAK');
+    const resultPairs = data.pairs as Array<{ a: string; b: string; verdict: string }>;
+    expect(resultPairs).toHaveLength(3);
+    // Verify ref→id mapping
+    expect(resultPairs[0].a).toBe('mr-1');
+    expect(resultPairs[0].b).toBe('mr-2');
+    expect(resultPairs[2].a).toBe('mr-2');
+    expect(resultPairs[2].b).toBe('mr-3');
+    expect(resultPairs[2].verdict).toBe('WEAK');
+  });
+});

--- a/tests/pr_merge.test.ts
+++ b/tests/pr_merge.test.ts
@@ -345,4 +345,98 @@ describe('pr_merge handler', () => {
     expect(data.ok).toBe(false);
     expect((data.error as string)).toContain('glab mr merge failed');
   });
+
+  // --- skip_train: true ---
+  test('github skip_train — direct merge succeeds without merge-queue fallback', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    onExec('gh pr merge 60 --squash --delete-branch', '');
+    onExec(
+      'gh pr view 60 --json mergeCommit,url',
+      JSON.stringify({
+        mergeCommit: { oid: 'skip123' },
+        url: 'https://github.com/org/repo/pull/60',
+      }),
+    );
+
+    const result = await prMergeHandler.execute({ number: 60, skip_train: true });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.merge_method).toBe('direct_squash');
+    expect(data.merge_commit_sha).toBe('skip123');
+    // No --auto call should have been made.
+    const autoCall = execCalls.find(
+      c => c.includes('gh pr merge 60') && c.includes('--auto'),
+    );
+    expect(autoCall).toBeUndefined();
+  });
+
+  test('github skip_train — merge-queue rejection surfaces as error (no fallback)', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    onExec('gh pr merge 61 --squash --delete-branch', () => {
+      throw mergeQueueError();
+    });
+
+    const result = await prMergeHandler.execute({ number: 61, skip_train: true });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(false);
+    expect((data.error as string)).toContain('skip_train');
+    // Confirm no --auto fallback was attempted.
+    const autoCall = execCalls.find(
+      c => c.includes('gh pr merge 61') && c.includes('--auto'),
+    );
+    expect(autoCall).toBeUndefined();
+  });
+
+  test('github skip_train=false — preserves normal merge-queue fallback behavior', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+
+    let directCalled = false;
+    onExec('gh pr merge 62 --squash --delete-branch', () => {
+      if (!directCalled) {
+        directCalled = true;
+        throw mergeQueueError();
+      }
+      return '';
+    });
+    onExec(
+      'gh pr view 62 --json url',
+      JSON.stringify({ url: 'https://github.com/org/repo/pull/62' }),
+    );
+
+    const result = await prMergeHandler.execute({ number: 62, skip_train: false });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.merge_method).toBe('merge_queue');
+    // --auto fallback WAS attempted.
+    const autoCall = execCalls.find(
+      c => c.includes('gh pr merge 62') && c.includes('--auto'),
+    );
+    expect(autoCall).toBeDefined();
+  });
+
+  test('github skip_train omitted — preserves normal merge-queue fallback behavior', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+
+    let directCalled = false;
+    onExec('gh pr merge 63 --squash --delete-branch', () => {
+      if (!directCalled) {
+        directCalled = true;
+        throw mergeQueueError();
+      }
+      return '';
+    });
+    onExec(
+      'gh pr view 63 --json url',
+      JSON.stringify({ url: 'https://github.com/org/repo/pull/63' }),
+    );
+
+    const result = await prMergeHandler.execute({ number: 63 });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.merge_method).toBe('merge_queue');
+  });
 });


### PR DESCRIPTION
## Summary

Implements the merge-time commutativity analysis gate from the [Isolation-Composition Equivalence](https://github.com/Wave-Engineering/mcp-server-sdlc/blob/main/docs/isolation-composition-equivalence-theory.md) spec. Adds a new `commutativity_verify` MCP tool and a `skip_train` parameter on `pr_merge` to enable CI oracle elimination for commutative changeset flights.

## Changes

- **New handler: `commutativity_verify`** — Shells out to `commutativity-probe analyze` CLI, parses JSON output, returns pairwise commutativity matrix with group verdict (`STRONG`/`MEDIUM`/`WEAK`/`ORACLE_REQUIRED`). Fail-safe: subprocess timeout → `ORACLE_REQUIRED`, unknown verdicts → `ORACLE_REQUIRED`. Maps branch refs back to caller-provided IDs.
- **New parameter: `pr_merge.skip_train`** — Optional boolean (default `false`). When `true`, forces direct-squash merge and suppresses merge-queue fallback on GitHub. Surfaces queue-enforcement errors instead of silently enrolling.
- **12 new tests** for `commutativity_verify` (all 4 verdicts, timeout, parse failure, unknown verdict, CLI command structure, 3-changeset ID mapping)
- **4 new tests** for `pr_merge` `skip_train` (success path, queue rejection without fallback, `false` preserves fallback, omitted preserves fallback)

## Integration Point

Designed for `/nextwave` Step 3 insertion:
```
pr_wait_ci (all green) → commutativity_verify → pr_merge(skip_train: verdict ∈ {STRONG, MEDIUM})
```

Phase 1 (advisory): log verdict, still use train. Phase 2 (gate): skip train on STRONG/MEDIUM.

## Linked Issues

Part of the Isolation-Composition Equivalence implementation. v1 scope — `commutativity_predict` (planning-time) deferred to v2.

## Test Plan

- [x] 1012 tests pass across 70 files
- [x] 67 tools registered (codegen + smoke)
- [x] TypeScript lint clean (`bunx tsc --noEmit`)
- [x] ShellCheck clean (5 files)
- [x] Full `scripts/ci/validate.sh` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)