### PR TITLE
feat(logging): adopt MCP logging standard

### DIFF
--- a/handlers/ci_wait_run.ts
+++ b/handlers/ci_wait_run.ts
@@ -6,6 +6,7 @@ import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
 import { detectPlatform, gitlabApiCiList, type GitlabPipeline } from '../lib/glab.js';
+import { log } from '../logger.js';
 
 const inputSchema = z
   .object({
@@ -55,9 +56,7 @@ function shortRef(ref: string): string {
 }
 
 function logPoll(ref: string, elapsedSec: number, status: string): void {
-  process.stderr.write(
-    `[ci_wait_run] ref=${shortRef(ref)} t=${elapsedSec}s status=${status}\n`
-  );
+  log.debug('poll', { tool: 'ci_wait_run', ref: shortRef(ref), elapsed_sec: elapsedSec, status });
 }
 
 // --- normalized poll result ---

--- a/handlers/commutativity_verify.ts
+++ b/handlers/commutativity_verify.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
+import { log } from '../logger.js';
 
 const changesetSchema = z.object({
   id: z.string().min(1),
@@ -99,17 +100,21 @@ const commutativityVerifyHandler: HandlerDef = {
 
     const cmd = buildCommand(args);
     let raw: string;
+    const subStart = Date.now();
     try {
       raw = execSync(cmd, {
         encoding: 'utf8',
         timeout: SUBPROCESS_TIMEOUT_MS,
         cwd: args.repo_path,
       });
+      log.info('subprocess', { cmd: 'commutativity-probe', exit_code: 0, ms: Date.now() - subStart });
     } catch (err) {
+      const subMs = Date.now() - subStart;
       // Fail safe: any subprocess error → ORACLE_REQUIRED verdict with warning.
       const message = err instanceof Error ? err.message : String(err);
       const timedOut = message.includes('ETIMEDOUT') || message.includes('timed out');
       if (timedOut) {
+        log.warn('subprocess', { cmd: 'commutativity-probe', exit_code: -1, ms: subMs }, 'Subprocess timed out');
         return {
           content: [{
             type: 'text' as const,
@@ -122,6 +127,7 @@ const commutativityVerifyHandler: HandlerDef = {
           }],
         };
       }
+      log.error('subprocess', { cmd: 'commutativity-probe', exit_code: -1, ms: subMs, stderr: message.slice(0, 200) });
       return {
         content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error: `commutativity-probe failed: ${message}` }) }],
       };

--- a/handlers/pr_wait_ci.ts
+++ b/handlers/pr_wait_ci.ts
@@ -6,6 +6,7 @@ import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
 import { detectPlatform, gitlabApiMr } from '../lib/glab';
+import { log } from '../logger.js';
 
 const inputSchema = z
   .object({
@@ -141,10 +142,14 @@ function decide(snap: ChecksSnapshot): FinalState | null {
 }
 
 function logCycle(number: number, elapsedSec: number, snap: ChecksSnapshot) {
-  // stderr only — never stdout (would corrupt MCP protocol).
-  process.stderr.write(
-    `[pr_wait_ci] #${number} t=${elapsedSec}s pending=${snap.pending}/${snap.total}\n`,
-  );
+  log.debug('poll', {
+    tool: 'pr_wait_ci',
+    number,
+    elapsed_sec: elapsedSec,
+    pending: snap.pending,
+    total: snap.total,
+    summary: snap.summary,
+  });
 }
 
 // Injection seam for tests — swap sleep + snapshot without touching real time/net.

--- a/index.ts
+++ b/index.ts
@@ -4,9 +4,12 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { CallToolRequestSchema, ErrorCode, ListToolsRequestSchema, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { handlers } from './handlers/_registry';
+import { log } from './logger';
+
+const SERVER_VERSION = '1.0.0';
 
 const server = new Server(
-  { name: 'sdlc-server', version: '1.0.0' },
+  { name: 'sdlc-server', version: SERVER_VERSION },
   { capabilities: { tools: {} } }
 );
 
@@ -23,8 +26,19 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
   if (!h) throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${req.params.name}`);
   const parsed = h.inputSchema.safeParse(req.params.arguments);
   if (!parsed.success) throw new McpError(ErrorCode.InvalidParams, parsed.error.message);
-  return h.execute(parsed.data);
+
+  const start = Date.now();
+  try {
+    const result = await h.execute(parsed.data);
+    log.info('tool_call', { tool: h.name, ok: true, ms: Date.now() - start });
+    return result;
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    log.error('tool_call', { tool: h.name, ok: false, ms: Date.now() - start, error });
+    throw err;
+  }
 });
 
 const transport = new StdioServerTransport();
 await server.connect(transport);
+log.info('startup', { version: SERVER_VERSION, config: { handler_count: handlers.length } });

--- a/logger.ts
+++ b/logger.ts
@@ -1,0 +1,61 @@
+// logger.ts — MCP structured logger (MCP Logging Standard v1)
+//
+// Usage:
+//   import { log } from './logger.ts';
+//   log.info('api_call', { method: 'POST', endpoint: '/channels/123/messages', status: 200, ms: 142 });
+//   log.warn('state_change', { what: 'kill_switch', to: 'engaged', reason: '429' });
+//   log.error('tool_call', { tool: 'pr_merge', ok: false, ms: 312 }, 'Merge failed');
+
+import { appendFileSync, mkdirSync, existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const LEVELS = { debug: 0, info: 1, warn: 2, error: 3 } as const;
+type Level = keyof typeof LEVELS;
+
+const SERVER_NAME = process.env.MCP_SERVER_NAME || 'sdlc';
+const LOG_LEVEL: Level = ((process.env.LOG_LEVEL as Level) in LEVELS)
+  ? (process.env.LOG_LEVEL as Level)
+  : 'info';
+const LOG_FILE = process.env.LOG_FILE; // e.g., ~/.claude/logs/sdlc.jsonl
+
+function shouldLog(level: Level): boolean {
+  return LEVELS[level] >= LEVELS[LOG_LEVEL];
+}
+
+function emit(level: Level, event: string, fields: Record<string, unknown>, msg?: string): void {
+  if (!shouldLog(level)) return;
+
+  const line: Record<string, unknown> = {
+    ts: new Date().toISOString(),
+    server: SERVER_NAME,
+    level,
+    event,
+    ...fields,
+  };
+  if (msg) line.msg = msg;
+
+  const json = JSON.stringify(line);
+
+  // Always stderr (MCP transport uses stdout; stderr is the only safe channel).
+  process.stderr.write(json + '\n');
+
+  // Optional file output.
+  if (LOG_FILE) {
+    try {
+      const resolved = LOG_FILE.replace(/^~/, homedir());
+      const dir = join(resolved, '..');
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+      appendFileSync(resolved, json + '\n');
+    } catch {
+      // Best-effort — don't crash the server over logging.
+    }
+  }
+}
+
+export const log = {
+  debug: (event: string, fields: Record<string, unknown> = {}, msg?: string) => emit('debug', event, fields, msg),
+  info:  (event: string, fields: Record<string, unknown> = {}, msg?: string) => emit('info', event, fields, msg),
+  warn:  (event: string, fields: Record<string, unknown> = {}, msg?: string) => emit('warn', event, fields, msg),
+  error: (event: string, fields: Record<string, unknown> = {}, msg?: string) => emit('error', event, fields, msg),
+};


### PR DESCRIPTION
## Summary

Adds structured JSON-line logging to the SDLC MCP server per the MCP Logging Standard.

## Changes

- `logger.ts` — structured logger
- `index.ts` — centralized `tool_call` logging at dispatch + `startup` event
- `handlers/ci_wait_run.ts`, `handlers/pr_wait_ci.ts` — migrated to structured logs
- `handlers/commutativity_verify.ts` — subprocess event logging

## Linked Issues

Closes #166

## Test Plan

- 1013 tests pass, 0 fail