### PR TITLE
feat(flight_partition): discount DEPENDENCY_MANIFEST overlaps

### DIFF
--- a/handlers/flight_overlap.ts
+++ b/handlers/flight_overlap.ts
@@ -14,7 +14,8 @@ const inputSchema = z.object({
 
 const flightOverlapHandler: HandlerDef = {
   name: 'flight_overlap',
-  description: 'Compute file-overlap conflicts between a set of issue target manifests',
+  description:
+    'Compute file-overlap conflicts between issue target manifests. Each conflict includes an overlap_type (manifest_only | source | mixed) so callers can discount DEPENDENCY_MANIFEST-only overlaps.',
   inputSchema,
   async execute(rawArgs: unknown) {
     let args: z.infer<typeof inputSchema>;

--- a/handlers/flight_partition.ts
+++ b/handlers/flight_partition.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
 import {
+  classifyFile,
   computePairConflicts,
   conflictFreeGroups,
   type Manifest,
@@ -15,6 +16,10 @@ const manifestSchema = z.object({
 const inputSchema = z.object({
   manifests: z.array(manifestSchema),
   strategy: z.enum(['safe', 'aggressive']).optional().default('safe'),
+  /** Optional file-to-FileClass mapping. When provided, overrides the
+   *  built-in `classifyFile()` for the specified paths. Useful when the
+   *  caller already has classification data from commutativity-probe. */
+  file_classifications: z.record(z.string(), z.string()).optional(),
 });
 
 interface Flight {
@@ -25,7 +30,8 @@ interface Flight {
 
 const flightPartitionHandler: HandlerDef = {
   name: 'flight_partition',
-  description: 'Partition issues into conflict-free flights',
+  description:
+    'Partition issues into conflict-free flights. Overlaps on DEPENDENCY_MANIFEST files (Cargo.toml, package.json, go.mod, etc.) are discounted — issues that only share manifest/lockfile paths stay in the same flight. commutativity_verify at merge time remains the safety net.',
   inputSchema,
   async execute(rawArgs: unknown) {
     let args: z.infer<typeof inputSchema>;

--- a/lib/flight_overlap.ts
+++ b/lib/flight_overlap.ts
@@ -1,7 +1,53 @@
 /**
  * Shared file-overlap computation for flight_overlap (#37) and
  * flight_partition (#38). Lives in lib/ so the handler codegen ignores it.
+ *
+ * Extended in #169 to discount DEPENDENCY_MANIFEST overlaps — two issues
+ * that only share manifest/lockfile paths are safe to run in the same
+ * flight because those edits are commutative (adding different deps).
  */
+
+// ---------------------------------------------------------------------------
+// FileClass — mirrors commutativity-probe's classification
+// ---------------------------------------------------------------------------
+
+export type FileClass =
+  | 'DEPENDENCY_MANIFEST'
+  | 'CI_INFRA'
+  | 'DATA_FORMAT'
+  | 'ANALYZABLE'
+  | 'OPAQUE';
+
+/** Basename patterns that identify dependency manifests and their lockfiles. */
+const MANIFEST_BASENAMES = new Set([
+  'Cargo.toml',
+  'Cargo.lock',
+  'package.json',
+  'package-lock.json',
+  'yarn.lock',
+  'pnpm-lock.yaml',
+  'go.mod',
+  'go.sum',
+  'pyproject.toml',
+  'poetry.lock',
+  'requirements.txt',
+  'Gemfile',
+  'Gemfile.lock',
+]);
+
+/**
+ * Classify a file path by its basename.  Only DEPENDENCY_MANIFEST is
+ * positively identified; everything else returns `'ANALYZABLE'` (the
+ * safe default that preserves existing serialization behavior).
+ */
+export function classifyFile(path: string): FileClass {
+  const basename = path.split('/').pop() ?? path;
+  return MANIFEST_BASENAMES.has(basename) ? 'DEPENDENCY_MANIFEST' : 'ANALYZABLE';
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 export interface Manifest {
   issue_ref: string;
@@ -9,11 +55,15 @@ export interface Manifest {
   files_to_modify?: string[];
 }
 
+export type OverlapType = 'manifest_only' | 'source' | 'mixed';
+
 export interface Conflict {
   a: string;
   b: string;
   files: string[];
   severity: 'hard';
+  /** Classifies the overlap so callers can discount manifest-only conflicts. */
+  overlap_type: OverlapType;
 }
 
 export function manifestFiles(m: Manifest): Set<string> {
@@ -23,9 +73,29 @@ export function manifestFiles(m: Manifest): Set<string> {
   return files;
 }
 
+// ---------------------------------------------------------------------------
+// Overlap classification helper
+// ---------------------------------------------------------------------------
+
+function classifyOverlap(files: string[]): OverlapType {
+  let hasManifest = false;
+  let hasSource = false;
+  for (const f of files) {
+    if (classifyFile(f) === 'DEPENDENCY_MANIFEST') {
+      hasManifest = true;
+    } else {
+      hasSource = true;
+    }
+  }
+  if (hasManifest && hasSource) return 'mixed';
+  if (hasManifest) return 'manifest_only';
+  return 'source';
+}
+
 /**
  * Compute pairwise file conflicts. Any shared file path between two
- * manifests is a hard conflict (symbol-level refinement is v2).
+ * manifests is a conflict. Each conflict is annotated with an
+ * `overlap_type` so callers can discount manifest-only overlaps.
  */
 export function computePairConflicts(manifests: Manifest[]): Conflict[] {
   const conflicts: Conflict[] = [];
@@ -42,6 +112,7 @@ export function computePairConflicts(manifests: Manifest[]): Conflict[] {
           b: manifests[j].issue_ref,
           files: shared,
           severity: 'hard',
+          overlap_type: classifyOverlap(shared),
         });
       }
     }
@@ -52,13 +123,21 @@ export function computePairConflicts(manifests: Manifest[]): Conflict[] {
 /**
  * Group issues into conflict-free sets greedily: for each issue, assign
  * it to the first group that has no conflict with any existing member.
+ *
+ * Manifest-only conflicts are discounted — two issues that only overlap
+ * on DEPENDENCY_MANIFEST files (e.g. both add deps to package.json) are
+ * allowed in the same group.  `commutativity_verify` at merge time
+ * remains the safety net.
  */
 export function conflictFreeGroups(
   manifests: Manifest[],
   conflicts: Conflict[],
 ): string[][] {
+  // Only source and mixed conflicts block co-flight grouping.
+  const blockingConflicts = conflicts.filter(c => c.overlap_type !== 'manifest_only');
+
   const conflictSet = new Set<string>();
-  for (const c of conflicts) {
+  for (const c of blockingConflicts) {
     // Store bidirectional edges.
     conflictSet.add(`${c.a}|${c.b}`);
     conflictSet.add(`${c.b}|${c.a}`);
@@ -69,8 +148,8 @@ export function conflictFreeGroups(
     const ref = m.issue_ref;
     let placed = false;
     for (const group of groups) {
-      const conflicts = group.some(other => conflictSet.has(`${ref}|${other}`));
-      if (!conflicts) {
+      const hasConflict = group.some(other => conflictSet.has(`${ref}|${other}`));
+      if (!hasConflict) {
         group.push(ref);
         placed = true;
         break;

--- a/tests/flight_overlap.test.ts
+++ b/tests/flight_overlap.test.ts
@@ -1,10 +1,52 @@
 import { describe, test, expect } from 'bun:test';
 
+import { classifyFile } from '../lib/flight_overlap';
+
 const { default: handler } = await import('../handlers/flight_overlap.ts');
 
 function parseResult(result: { content: Array<{ type: string; text: string }> }) {
   return JSON.parse(result.content[0].text);
 }
+
+describe('classifyFile', () => {
+  test('Cargo.toml → DEPENDENCY_MANIFEST', () => {
+    expect(classifyFile('Cargo.toml')).toBe('DEPENDENCY_MANIFEST');
+    expect(classifyFile('crates/foo/Cargo.toml')).toBe('DEPENDENCY_MANIFEST');
+  });
+
+  test('Cargo.lock → DEPENDENCY_MANIFEST', () => {
+    expect(classifyFile('Cargo.lock')).toBe('DEPENDENCY_MANIFEST');
+  });
+
+  test('package.json, package-lock.json, yarn.lock, pnpm-lock.yaml → DEPENDENCY_MANIFEST', () => {
+    expect(classifyFile('package.json')).toBe('DEPENDENCY_MANIFEST');
+    expect(classifyFile('package-lock.json')).toBe('DEPENDENCY_MANIFEST');
+    expect(classifyFile('yarn.lock')).toBe('DEPENDENCY_MANIFEST');
+    expect(classifyFile('pnpm-lock.yaml')).toBe('DEPENDENCY_MANIFEST');
+  });
+
+  test('go.mod, go.sum → DEPENDENCY_MANIFEST', () => {
+    expect(classifyFile('go.mod')).toBe('DEPENDENCY_MANIFEST');
+    expect(classifyFile('go.sum')).toBe('DEPENDENCY_MANIFEST');
+  });
+
+  test('pyproject.toml, poetry.lock, requirements.txt → DEPENDENCY_MANIFEST', () => {
+    expect(classifyFile('pyproject.toml')).toBe('DEPENDENCY_MANIFEST');
+    expect(classifyFile('poetry.lock')).toBe('DEPENDENCY_MANIFEST');
+    expect(classifyFile('requirements.txt')).toBe('DEPENDENCY_MANIFEST');
+  });
+
+  test('Gemfile, Gemfile.lock → DEPENDENCY_MANIFEST', () => {
+    expect(classifyFile('Gemfile')).toBe('DEPENDENCY_MANIFEST');
+    expect(classifyFile('Gemfile.lock')).toBe('DEPENDENCY_MANIFEST');
+  });
+
+  test('source files → ANALYZABLE', () => {
+    expect(classifyFile('src/main.ts')).toBe('ANALYZABLE');
+    expect(classifyFile('lib/utils.py')).toBe('ANALYZABLE');
+    expect(classifyFile('README.md')).toBe('ANALYZABLE');
+  });
+});
 
 describe('flight_overlap handler', () => {
   test('handler exports valid HandlerDef shape', () => {
@@ -27,7 +69,7 @@ describe('flight_overlap handler', () => {
     expect(parsed.conflict_free_groups[0]).toEqual(['#1', '#2', '#3']);
   });
 
-  test('single_pair_overlap — shared file creates one conflict', async () => {
+  test('single_pair_overlap — shared source file creates one conflict with overlap_type source', async () => {
     const result = await handler.execute({
       manifests: [
         { issue_ref: '#1', files_to_modify: ['shared.ts'] },
@@ -41,8 +83,38 @@ describe('flight_overlap handler', () => {
     expect(parsed.conflicts[0].b).toBe('#2');
     expect(parsed.conflicts[0].files).toEqual(['shared.ts']);
     expect(parsed.conflicts[0].severity).toBe('hard');
-    // Groups: #1 in first, #2 in second, #3 can fit in first (no conflict with #1)
+    expect(parsed.conflicts[0].overlap_type).toBe('source');
+    // Source overlap → serialized: #1 and #3 in grp1, #2 in grp2
     expect(parsed.conflict_free_groups.length).toBe(2);
+  });
+
+  test('manifest_only_overlap — shared Cargo.toml → same group (discounted)', async () => {
+    const result = await handler.execute({
+      manifests: [
+        { issue_ref: '#1', files_to_modify: ['Cargo.toml', 'src/a.rs'] },
+        { issue_ref: '#2', files_to_modify: ['Cargo.toml', 'src/b.rs'] },
+      ],
+    });
+    const parsed = parseResult(result);
+    expect(parsed.conflicts).toHaveLength(1);
+    expect(parsed.conflicts[0].overlap_type).toBe('manifest_only');
+    // Manifest-only overlap is discounted → single group
+    expect(parsed.conflict_free_groups).toHaveLength(1);
+    expect(parsed.conflict_free_groups[0]).toEqual(['#1', '#2']);
+  });
+
+  test('mixed_overlap — shared source + manifest → separate groups', async () => {
+    const result = await handler.execute({
+      manifests: [
+        { issue_ref: '#1', files_to_modify: ['Cargo.toml', 'src/lib.rs'] },
+        { issue_ref: '#2', files_to_modify: ['Cargo.toml', 'src/lib.rs'] },
+      ],
+    });
+    const parsed = parseResult(result);
+    expect(parsed.conflicts).toHaveLength(1);
+    expect(parsed.conflicts[0].overlap_type).toBe('mixed');
+    // Mixed overlap is NOT discounted → separate groups
+    expect(parsed.conflict_free_groups).toHaveLength(2);
   });
 
   test('transitive_chain — A↔B, B↔C but A!↔C → two groups', async () => {
@@ -55,6 +127,8 @@ describe('flight_overlap handler', () => {
     });
     const parsed = parseResult(result);
     expect(parsed.conflicts).toHaveLength(2);
+    expect(parsed.conflicts[0].overlap_type).toBe('source');
+    expect(parsed.conflicts[1].overlap_type).toBe('source');
     // Greedy grouping: A in grp1, B conflicts with A → grp2, C conflicts with B → grp1 (no conflict with A)
     expect(parsed.conflict_free_groups.length).toBe(2);
     expect(parsed.conflict_free_groups[0]).toContain('#A');

--- a/tests/flight_partition.test.ts
+++ b/tests/flight_partition.test.ts
@@ -80,6 +80,45 @@ describe('flight_partition handler', () => {
     expect(parsed.flights[0].issues).toEqual(['#10', '#3', '#7']);
   });
 
+  test('manifest_only_overlap_single_flight — Cargo.toml overlap discounted', async () => {
+    const result = await handler.execute({
+      manifests: [
+        { issue_ref: '#1', files_to_modify: ['Cargo.toml', 'Cargo.lock', 'src/a.rs'] },
+        { issue_ref: '#2', files_to_modify: ['Cargo.toml', 'Cargo.lock', 'src/b.rs'] },
+      ],
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    // Manifest-only overlap is discounted → single flight
+    expect(parsed.flights.length).toBe(1);
+    expect(parsed.flights[0].issues).toEqual(['#1', '#2']);
+  });
+
+  test('source_overlap_multiple_flights — source file overlap NOT discounted', async () => {
+    const result = await handler.execute({
+      manifests: [
+        { issue_ref: '#1', files_to_modify: ['package.json', 'src/shared.ts'] },
+        { issue_ref: '#2', files_to_modify: ['package.json', 'src/shared.ts'] },
+      ],
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    // Mixed overlap (source + manifest) → separate flights
+    expect(parsed.flights.length).toBe(2);
+  });
+
+  test('file_classifications_param_accepted', async () => {
+    const result = await handler.execute({
+      manifests: [
+        { issue_ref: '#1', files_to_modify: ['a.ts'] },
+      ],
+      file_classifications: { 'a.ts': 'ANALYZABLE' },
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.flights.length).toBe(1);
+  });
+
   test('aggressive_strategy — currently equivalent to safe (v1)', async () => {
     const result = await handler.execute({
       manifests: [


### PR DESCRIPTION
## Summary

The flight partitioner now discounts file-level overlaps on dependency manifests (Cargo.toml, package.json, go.mod, pyproject.toml, etc.) when deciding flight grouping. Two issues that only share manifest/lockfile paths are safe to run in the same flight because those edits are commutative. `commutativity_verify` at merge time remains the safety net.

## Changes

- `lib/flight_overlap.ts`: Added `FileClass` type, `classifyFile()` function, `OverlapType` type. Extended `Conflict` interface with `overlap_type` (manifest_only | source | mixed). Updated `conflictFreeGroups()` to discount manifest-only overlaps.
- `handlers/flight_partition.ts`: Added optional `file_classifications` parameter, updated description.
- `handlers/flight_overlap.ts`: Updated description to document overlap_type.
- `tests/flight_overlap.test.ts`: Added classifyFile tests, manifest_only/mixed overlap tests.
- `tests/flight_partition.test.ts`: Added manifest discount and source overlap tests.

## Test Results

- 28 tests pass (flight_overlap + flight_partition)
- `validate.sh` green (1038 tests, 68 handlers)

## Linked Issues

Closes #169