### PR TITLE
fix(pr_wait_ci): add MCP-side heartbeat for CI polling

### DIFF
--- a/handlers/pr_wait_ci.ts
+++ b/handlers/pr_wait_ci.ts
@@ -157,12 +157,27 @@ interface Deps {
   snapshotFn: (number: number) => ChecksSnapshot;
   sleepFn: (ms: number) => Promise<void>;
   nowFn: () => number;
+  /** Optional heartbeat called on each poll iteration for wave-status updates. */
+  heartbeatFn?: (number: number, attempt: number, snap: ChecksSnapshot) => void;
+}
+
+function defaultHeartbeat(number: number, attempt: number, snap: ChecksSnapshot): void {
+  const detail = `PR #${number} attempt ${attempt}: ${snap.summary}`;
+  try {
+    execSync(`wave-status waiting-ci '${detail.replace(/'/g, "'\\''")}'`, {
+      encoding: 'utf8',
+      timeout: 5000,
+    });
+  } catch {
+    // Best-effort — swallow all errors silently.
+  }
 }
 
 const defaultDeps: Deps = {
   snapshotFn: snapshotChecks,
   sleepFn: (ms: number) => new Promise((r) => setTimeout(r, ms)),
   nowFn: () => Date.now(),
+  heartbeatFn: defaultHeartbeat,
 };
 
 export async function runPollLoop(
@@ -189,13 +204,17 @@ export async function runPollLoop(
     url: '',
   };
 
+  let attempt = 0;
+
   // Loop: snapshot → decide → (sleep | return). Timeout is checked after each
   // snapshot AND before each sleep so we can't over-shoot by a full interval.
   // eslint-disable-next-line no-constant-condition
   while (true) {
+    attempt++;
     lastSnap = deps.snapshotFn(args.number);
     const elapsedSec = Math.floor((deps.nowFn() - start) / 1000);
     logCycle(args.number, elapsedSec, lastSnap);
+    deps.heartbeatFn?.(args.number, attempt, lastSnap);
 
     const decision = decide(lastSnap);
     if (decision) {

--- a/tests/pr_wait_ci.test.ts
+++ b/tests/pr_wait_ci.test.ts
@@ -28,7 +28,12 @@ function makeDeps(sequence: ChecksSnapshot[], intervalSec: number) {
   const snapshotCalls: number[] = [];
   const sleepCalls: number[] = [];
 
-  const deps = {
+  const deps: {
+    snapshotFn: (n: number) => ChecksSnapshot;
+    sleepFn: (ms: number) => Promise<void>;
+    nowFn: () => number;
+    heartbeatFn?: (number: number, attempt: number, snap: ChecksSnapshot) => void;
+  } = {
     snapshotFn: (_n: number) => {
       snapshotCalls.push(now);
       // Last element sticks if we run past the script end.
@@ -239,6 +244,49 @@ describe('pr_wait_ci handler', () => {
     const checks = data.checks as Record<string, number>;
     expect(checks.failed).toBe(1);
     expect(checks.pending).toBe(1); // proves early termination preserved state
+  });
+
+  test('heartbeatFn called on each poll iteration with correct args', async () => {
+    const heartbeatCalls: Array<{ number: number; attempt: number; total: number }> = [];
+    const { deps } = makeDeps(
+      [
+        snap({ total: 3, passed: 1, pending: 2 }),
+        snap({ total: 3, passed: 2, pending: 1 }),
+        snap({ total: 3, passed: 3, pending: 0 }),
+      ],
+      5,
+    );
+
+    deps.heartbeatFn = (number: number, attempt: number, s: ChecksSnapshot) => {
+      heartbeatCalls.push({ number, attempt, total: s.total });
+    };
+
+    const result = await runWithDeps(
+      { number: 42, poll_interval_sec: 5, timeout_sec: 600 },
+      deps,
+    );
+
+    expect(result.final_state).toBe('passed');
+    // 3 snapshots → 3 heartbeat calls
+    expect(heartbeatCalls).toHaveLength(3);
+    expect(heartbeatCalls[0]).toEqual({ number: 42, attempt: 1, total: 3 });
+    expect(heartbeatCalls[1]).toEqual({ number: 42, attempt: 2, total: 3 });
+    expect(heartbeatCalls[2]).toEqual({ number: 42, attempt: 3, total: 3 });
+  });
+
+  test('heartbeatFn omitted — poll loop still works', async () => {
+    const { deps } = makeDeps(
+      [snap({ total: 1, passed: 1, pending: 0 })],
+      5,
+    );
+    // Explicitly set heartbeatFn to undefined
+    deps.heartbeatFn = undefined;
+
+    const result = await runWithDeps(
+      { number: 1, poll_interval_sec: 5, timeout_sec: 60 },
+      deps,
+    );
+    expect(result.final_state).toBe('passed');
   });
 
   test('execute — gitlab mr with successful pipeline', async () => {


### PR DESCRIPTION
## Summary

Adds a heartbeat to `pr_wait_ci` that calls `wave-status waiting-ci` on each poll iteration, keeping `state.json` timestamps fresh during long CI waits. Prevents observers from seeing 36+ minute stale timestamps and assuming the worker is dead.

## Changes

### TypeScript (mcp-server-sdlc)
- `handlers/pr_wait_ci.ts`: Extended `Deps` with optional `heartbeatFn`. Default implementation calls `wave-status waiting-ci` with 5s timeout, errors swallowed. Added `attempt` counter to poll loop.
- `tests/pr_wait_ci.test.ts`: Added explicit Deps typing, 2 new tests (heartbeat called with correct args, heartbeat omitted works).

### Python (claudecode-workflow — separate PR)
- `src/wave_status/state.py`: New `waiting_ci()` function.
- `src/wave_status/__main__.py`: New `waiting-ci` CLI subcommand.
- `tests/test_state.py`: New `TestWaitingCi` class with 3 tests.

## Test Results

- 14 TS tests pass, 87 Python tests pass
- `validate.sh` green (1038 tests, 68 handlers)

## Linked Issues

Closes #172