### PR TITLE
feat(sdlc): wave_reconcile_mrs backfill handler

### DIFF
--- a/handlers/wave_reconcile_mrs.ts
+++ b/handlers/wave_reconcile_mrs.ts
@@ -1,0 +1,239 @@
+import { execSync } from 'child_process';
+import { join } from 'path';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+import { detectPlatform } from '../lib/glab';
+
+const inputSchema = z.object({
+  wave_id: z.string().optional(),
+});
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  return await Bun.file(path).exists();
+}
+
+async function readJson(path: string): Promise<unknown> {
+  return await Bun.file(path).json();
+}
+
+async function statusDir(root: string): Promise<string> {
+  const sdlc = join(root, '.sdlc');
+  if (await fileExists(sdlc)) return join(sdlc, 'waves');
+  return join(root, '.claude', 'status');
+}
+
+interface PlanIssue {
+  number: number;
+}
+interface PlanWave {
+  id: string;
+  issues?: PlanIssue[];
+}
+interface PlanPhase {
+  waves?: PlanWave[];
+}
+interface PlanData {
+  phases?: PlanPhase[];
+}
+
+interface WaveState {
+  status?: string;
+  mr_urls?: Record<string, string>;
+}
+
+interface StateData {
+  current_wave?: string | null;
+  waves?: Record<string, WaveState>;
+}
+
+function findWave(plan: PlanData, id: string): PlanWave | null {
+  for (const phase of plan.phases ?? []) {
+    for (const wave of phase.waves ?? []) {
+      if (wave.id === id) return wave;
+    }
+  }
+  return null;
+}
+
+function quoteArg(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+interface Reconciled {
+  issue_number: number;
+  mr_ref: string;
+}
+
+/** Injection seam for tests — allows mocking execSync. */
+export interface Deps {
+  execFn: (cmd: string) => string;
+}
+
+const defaultDeps: Deps = {
+  execFn: (cmd: string) => execSync(cmd, { encoding: 'utf8' }).trim(),
+};
+
+function queryGithubMergedPrs(
+  issueNumber: number,
+  deps: Deps,
+): string | null {
+  try {
+    const raw = deps.execFn(
+      `gh pr list --state merged --json number,url,headRefName --limit 50`,
+    );
+    const prs = JSON.parse(raw) as Array<{
+      number: number;
+      url: string;
+      headRefName: string;
+    }>;
+    const prefix = `feature/${issueNumber}-`;
+    const match = prs.find((pr) => pr.headRefName.startsWith(prefix));
+    return match ? match.url : null;
+  } catch {
+    return null;
+  }
+}
+
+function queryGitlabMergedMrs(
+  issueNumber: number,
+  deps: Deps,
+): string | null {
+  try {
+    const raw = deps.execFn(
+      `glab mr list --state merged --output json`,
+    );
+    const mrs = JSON.parse(raw) as Array<{
+      iid: number;
+      web_url: string;
+      source_branch: string;
+    }>;
+    const prefix = `feature/${issueNumber}-`;
+    const match = mrs.find((mr) => mr.source_branch.startsWith(prefix));
+    return match ? match.web_url : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function reconcile(
+  rawArgs: unknown,
+  deps: Deps = defaultDeps,
+): Promise<{
+  ok: boolean;
+  wave_id: string;
+  reconciled: Reconciled[];
+  already_recorded: number;
+  not_found: number[];
+  error?: string;
+}> {
+  const args = inputSchema.parse(rawArgs);
+  const dir = await statusDir(projectDir());
+  const planPath = join(dir, 'phases-waves.json');
+  const statePath = join(dir, 'state.json');
+
+  if (!(await fileExists(planPath)) || !(await fileExists(statePath))) {
+    return {
+      ok: false,
+      wave_id: '',
+      reconciled: [],
+      already_recorded: 0,
+      not_found: [],
+      error: `state files not found in ${dir}`,
+    };
+  }
+
+  const plan = (await readJson(planPath)) as PlanData;
+  const state = (await readJson(statePath)) as StateData;
+
+  const waveId = args.wave_id ?? state.current_wave ?? '';
+  if (!waveId) {
+    return {
+      ok: false,
+      wave_id: '',
+      reconciled: [],
+      already_recorded: 0,
+      not_found: [],
+      error: 'no wave_id provided and no current wave set',
+    };
+  }
+
+  const wave = findWave(plan, waveId);
+  if (!wave) {
+    return {
+      ok: false,
+      wave_id: waveId,
+      reconciled: [],
+      already_recorded: 0,
+      not_found: [],
+      error: `wave '${waveId}' not found in plan`,
+    };
+  }
+
+  const waveState = state.waves?.[waveId];
+  const existingMrUrls = waveState?.mr_urls ?? {};
+  const platform = detectPlatform();
+
+  const reconciled: Reconciled[] = [];
+  let alreadyRecorded = 0;
+  const notFound: number[] = [];
+
+  for (const issue of wave.issues ?? []) {
+    const key = String(issue.number);
+    if (existingMrUrls[key]) {
+      alreadyRecorded++;
+      continue;
+    }
+
+    const mrUrl =
+      platform === 'github'
+        ? queryGithubMergedPrs(issue.number, deps)
+        : queryGitlabMergedMrs(issue.number, deps);
+
+    if (mrUrl) {
+      try {
+        deps.execFn(
+          `wave-status record-mr ${issue.number} ${quoteArg(mrUrl)}`,
+        );
+      } catch {
+        // Best-effort — continue even if record-mr fails
+      }
+      reconciled.push({ issue_number: issue.number, mr_ref: mrUrl });
+    } else {
+      notFound.push(issue.number);
+    }
+  }
+
+  return {
+    ok: true,
+    wave_id: waveId,
+    reconciled,
+    already_recorded: alreadyRecorded,
+    not_found: notFound,
+  };
+}
+
+const waveReconcileMrsHandler: HandlerDef = {
+  name: 'wave_reconcile_mrs',
+  description:
+    'Backfill mr_urls for issues in a wave by querying the platform for merged PRs/MRs matching feature/<N>-* branches. Call site: after wave_preflight, before pr_merge or wave_close_issue.',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    try {
+      const result = await reconcile(rawArgs);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default waveReconcileMrsHandler;

--- a/tests/wave_reconcile_mrs.test.ts
+++ b/tests/wave_reconcile_mrs.test.ts
@@ -1,0 +1,226 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+// Mock child_process for platform detection (detectPlatform) and record-mr calls.
+let execMockFn: (cmd: string) => string = () => '';
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  return execMockFn(cmd);
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { reconcile, default: handler } = await import(
+  '../handlers/wave_reconcile_mrs.ts'
+);
+
+let fixtureDir = '';
+const ORIGINAL_ENV = process.env.CLAUDE_PROJECT_DIR;
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+async function setupFixture(plan: object, state: object) {
+  fixtureDir = `/tmp/wave-reconcile-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+  const statusDir = `${fixtureDir}/.claude/status`;
+  await Bun.write(`${statusDir}/phases-waves.json`, JSON.stringify(plan));
+  await Bun.write(`${statusDir}/state.json`, JSON.stringify(state));
+  process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+}
+
+function resetMocks() {
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+  fixtureDir = '';
+}
+
+function restoreEnv() {
+  if (ORIGINAL_ENV === undefined) {
+    delete process.env.CLAUDE_PROJECT_DIR;
+  } else {
+    process.env.CLAUDE_PROJECT_DIR = ORIGINAL_ENV;
+  }
+}
+
+const PLAN = {
+  phases: [
+    {
+      waves: [
+        {
+          id: 'w1',
+          issues: [{ number: 10 }, { number: 11 }, { number: 12 }],
+        },
+      ],
+    },
+  ],
+};
+
+describe('wave_reconcile_mrs handler', () => {
+  beforeEach(resetMocks);
+  afterEach(restoreEnv);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('wave_reconcile_mrs');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('happy path — backfills missing mr_urls from merged PRs', async () => {
+    const state = {
+      current_wave: 'w1',
+      waves: {
+        w1: { status: 'in_progress', mr_urls: {} },
+      },
+    };
+    await setupFixture(PLAN, state);
+
+    // Mock: detectPlatform → github, gh pr list returns merged PRs
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote'))
+        return 'https://github.com/org/repo.git\n';
+      if (cmd.startsWith('gh pr list'))
+        return JSON.stringify([
+          {
+            number: 50,
+            url: 'https://github.com/org/repo/pull/50',
+            headRefName: 'feature/10-some-feature',
+          },
+          {
+            number: 51,
+            url: 'https://github.com/org/repo/pull/51',
+            headRefName: 'feature/11-another-feature',
+          },
+        ]);
+      // wave-status record-mr calls — return success
+      if (cmd.startsWith('wave-status record-mr')) return '';
+      return '';
+    };
+
+    const recordMrCalls: string[] = [];
+    const deps = {
+      execFn: (cmd: string) => {
+        if (cmd.startsWith('wave-status record-mr')) {
+          recordMrCalls.push(cmd);
+        }
+        return execMockFn(cmd);
+      },
+    };
+
+    const result = await reconcile({}, deps);
+    expect(result.ok).toBe(true);
+    expect(result.wave_id).toBe('w1');
+    expect(result.reconciled).toHaveLength(2);
+    expect(result.reconciled[0].issue_number).toBe(10);
+    expect(result.reconciled[0].mr_ref).toBe(
+      'https://github.com/org/repo/pull/50',
+    );
+    expect(result.reconciled[1].issue_number).toBe(11);
+    expect(result.already_recorded).toBe(0);
+    expect(result.not_found).toEqual([12]);
+    expect(recordMrCalls).toHaveLength(2);
+  });
+
+  test('already-recorded — skips issues that have mr_url', async () => {
+    const state = {
+      current_wave: 'w1',
+      waves: {
+        w1: {
+          status: 'completed',
+          mr_urls: {
+            '10': 'https://github.com/org/repo/pull/50',
+            '11': 'https://github.com/org/repo/pull/51',
+          },
+        },
+      },
+    };
+    await setupFixture(PLAN, state);
+
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote'))
+        return 'https://github.com/org/repo.git\n';
+      if (cmd.startsWith('gh pr list')) return JSON.stringify([]);
+      return '';
+    };
+
+    const deps = {
+      execFn: (cmd: string) => execMockFn(cmd),
+    };
+
+    const result = await reconcile({}, deps);
+    expect(result.ok).toBe(true);
+    expect(result.already_recorded).toBe(2);
+    expect(result.reconciled).toHaveLength(0);
+    expect(result.not_found).toEqual([12]);
+  });
+
+  test('no matching PR — issue goes to not_found', async () => {
+    const state = {
+      current_wave: 'w1',
+      waves: {
+        w1: { status: 'in_progress', mr_urls: {} },
+      },
+    };
+    await setupFixture(PLAN, state);
+
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote'))
+        return 'https://github.com/org/repo.git\n';
+      if (cmd.startsWith('gh pr list')) return JSON.stringify([]);
+      return '';
+    };
+
+    const deps = {
+      execFn: (cmd: string) => execMockFn(cmd),
+    };
+
+    const result = await reconcile({}, deps);
+    expect(result.ok).toBe(true);
+    expect(result.reconciled).toHaveLength(0);
+    expect(result.not_found).toEqual([10, 11, 12]);
+  });
+
+  test('missing state files — returns structured error', async () => {
+    fixtureDir = `/tmp/wave-reconcile-empty-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+    process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+
+    const deps = {
+      execFn: (cmd: string) => execMockFn(cmd),
+    };
+
+    const result = await reconcile({}, deps);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('state files not found');
+  });
+
+  test('idempotent — second call produces reconciled: []', async () => {
+    const state = {
+      current_wave: 'w1',
+      waves: {
+        w1: {
+          status: 'completed',
+          mr_urls: {
+            '10': 'https://github.com/org/repo/pull/50',
+            '11': 'https://github.com/org/repo/pull/51',
+            '12': 'https://github.com/org/repo/pull/52',
+          },
+        },
+      },
+    };
+    await setupFixture(PLAN, state);
+
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote'))
+        return 'https://github.com/org/repo.git\n';
+      return '';
+    };
+
+    const deps = {
+      execFn: (cmd: string) => execMockFn(cmd),
+    };
+
+    const result = await reconcile({}, deps);
+    expect(result.ok).toBe(true);
+    expect(result.reconciled).toHaveLength(0);
+    expect(result.already_recorded).toBe(3);
+    expect(result.not_found).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

New `wave_reconcile_mrs` handler that backfills `mr_urls` for issues in a wave when a wavemachine worker dies mid-flight and another resumes. Queries the platform for merged PRs/MRs matching `feature/<N>-*` branch naming convention and calls `wave-status record-mr` for each match.

## Changes

- `handlers/wave_reconcile_mrs.ts`: New handler with input schema `{ wave_id?: string }`. Reads state/plan files, queries platform for merged PRs matching branch naming convention, calls record-mr. Idempotent, platform-aware (GitHub/GitLab).
- `tests/wave_reconcile_mrs.test.ts`: 6 tests covering happy path backfill, already-recorded skip, no matching PR, missing state files, idempotent.

## Test Results

- 6 tests pass
- `validate.sh` green (1038 tests, 68 handlers — auto-registered by codegen)

## Linked Issues

Closes #173