### PR TITLE
feat(sdlc): commutativity_predict handler + probe manifest mode

### DIFF
--- a/handlers/commutativity_predict.ts
+++ b/handlers/commutativity_predict.ts
@@ -1,0 +1,177 @@
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+import { log } from '../logger.js';
+
+const fileEntrySchema = z.object({
+  path: z.string().min(1),
+  action: z.string().optional().default('modify'),
+  symbols: z.array(z.string()).optional(),
+});
+
+const changesetSchema = z.object({
+  id: z.string().min(1),
+  files: z.array(fileEntrySchema),
+});
+
+const inputSchema = z.object({
+  changesets: z
+    .array(changesetSchema)
+    .min(2, 'At least 2 changesets required for pairwise analysis'),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+interface ProbePair {
+  a: string;
+  b: string;
+  verdict: string;
+  reason: string;
+  file_overlaps: string[];
+  symbol_collisions: string[];
+  import_overlaps: string[];
+}
+
+interface ProbeOutput {
+  changesets: string[];
+  flight_verdict: string;
+  pairs: ProbePair[];
+}
+
+const VALID_VERDICTS = ['STRONG', 'MEDIUM', 'WEAK', 'ORACLE_REQUIRED'] as const;
+
+function isValidVerdict(v: string): v is (typeof VALID_VERDICTS)[number] {
+  return (VALID_VERDICTS as readonly string[]).includes(v);
+}
+
+const SUBPROCESS_TIMEOUT_MS = 10_000;
+
+export interface Deps {
+  execFn: (cmd: string, input: string) => string;
+}
+
+function defaultExec(cmd: string, input: string): string {
+  return execSync(cmd, {
+    encoding: 'utf8',
+    timeout: SUBPROCESS_TIMEOUT_MS,
+    input,
+  });
+}
+
+const defaultDeps: Deps = {
+  execFn: defaultExec,
+};
+
+export async function runPredict(
+  rawArgs: unknown,
+  deps: Deps = defaultDeps,
+): Promise<{
+  ok: boolean;
+  group_verdict?: string;
+  pairs?: ProbePair[];
+  warnings?: string[];
+  error?: string;
+}> {
+  let args: Input;
+  try {
+    args = inputSchema.parse(rawArgs);
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return { ok: false, error };
+  }
+
+  const manifest = JSON.stringify({ changesets: args.changesets });
+  const cmd = 'commutativity-probe predict --manifest --json';
+
+  let raw: string;
+  const subStart = Date.now();
+  try {
+    raw = deps.execFn(cmd, manifest);
+    log.info('subprocess', {
+      cmd: 'commutativity-probe',
+      exit_code: 0,
+      ms: Date.now() - subStart,
+    });
+  } catch (err) {
+    const subMs = Date.now() - subStart;
+    const message = err instanceof Error ? err.message : String(err);
+    const timedOut =
+      message.includes('ETIMEDOUT') || message.includes('timed out');
+    if (timedOut) {
+      log.warn(
+        'subprocess',
+        { cmd: 'commutativity-probe', exit_code: -1, ms: subMs },
+        'Subprocess timed out',
+      );
+      return {
+        ok: true,
+        group_verdict: 'ORACLE_REQUIRED',
+        pairs: [],
+        warnings: [
+          `Subprocess timed out after ${SUBPROCESS_TIMEOUT_MS}ms. Failing safe to ORACLE_REQUIRED.`,
+        ],
+      };
+    }
+    log.error('subprocess', {
+      cmd: 'commutativity-probe',
+      exit_code: -1,
+      ms: subMs,
+      stderr: message.slice(0, 200),
+    });
+    return {
+      ok: false,
+      error: `commutativity-probe predict failed: ${message}`,
+    };
+  }
+
+  let probe: ProbeOutput;
+  try {
+    probe = JSON.parse(raw) as ProbeOutput;
+  } catch {
+    return {
+      ok: false,
+      error: 'Failed to parse commutativity-probe JSON output',
+    };
+  }
+
+  const groupVerdict = isValidVerdict(probe.flight_verdict)
+    ? probe.flight_verdict
+    : 'ORACLE_REQUIRED';
+
+  const warnings: string[] = [];
+  if (!isValidVerdict(probe.flight_verdict)) {
+    warnings.push(
+      `Unknown verdict '${probe.flight_verdict}' from probe — defaulting to ORACLE_REQUIRED`,
+    );
+  }
+
+  const pairs = probe.pairs.map((p) => ({
+    ...p,
+    verdict: isValidVerdict(p.verdict) ? p.verdict : 'ORACLE_REQUIRED',
+  }));
+
+  return {
+    ok: true,
+    group_verdict: groupVerdict,
+    pairs,
+    warnings: warnings.length > 0 ? warnings : undefined,
+  };
+}
+
+const commutativityPredictHandler: HandlerDef = {
+  name: 'commutativity_predict',
+  description:
+    'Predict changeset commutativity from planning manifests (file paths, actions, symbols) ' +
+    'WITHOUT requiring actual git branches or diffs. Returns STRONG/MEDIUM/WEAK/ORACLE_REQUIRED. ' +
+    'Call during flight planning to inform partition decisions. ' +
+    'commutativity_verify at merge time remains the definitive safety net.',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    const result = await runPredict(rawArgs);
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+    };
+  },
+};
+
+export default commutativityPredictHandler;

--- a/handlers/flight_partition.ts
+++ b/handlers/flight_partition.ts
@@ -13,6 +13,12 @@ const manifestSchema = z.object({
   files_to_modify: z.array(z.string()).optional(),
 });
 
+const predictedVerdictSchema = z.object({
+  a: z.string().min(1),
+  b: z.string().min(1),
+  verdict: z.enum(['STRONG', 'MEDIUM', 'WEAK', 'ORACLE_REQUIRED']),
+});
+
 const inputSchema = z.object({
   manifests: z.array(manifestSchema),
   strategy: z.enum(['safe', 'aggressive']).optional().default('safe'),
@@ -20,6 +26,10 @@ const inputSchema = z.object({
    *  built-in `classifyFile()` for the specified paths. Useful when the
    *  caller already has classification data from commutativity-probe. */
   file_classifications: z.record(z.string(), z.string()).optional(),
+  /** Optional predicted verdicts from commutativity_predict. When present,
+   *  pairs with STRONG/MEDIUM verdicts are allowed in the same flight even
+   *  if they have file-level conflicts. */
+  predicted_verdicts: z.array(predictedVerdictSchema).optional(),
 });
 
 interface Flight {
@@ -63,7 +73,7 @@ const flightPartitionHandler: HandlerDef = {
       }
 
       const conflicts = computePairConflicts(manifests);
-      const groups = conflictFreeGroups(manifests, conflicts);
+      const groups = conflictFreeGroups(manifests, conflicts, args.predicted_verdicts);
 
       const flights: Flight[] = groups.map((issues, idx) => {
         let reason: string;

--- a/lib/flight_overlap.ts
+++ b/lib/flight_overlap.ts
@@ -120,6 +120,16 @@ export function computePairConflicts(manifests: Manifest[]): Conflict[] {
   return conflicts;
 }
 
+// ---------------------------------------------------------------------------
+// Predicted verdict support
+// ---------------------------------------------------------------------------
+
+export interface PredictedVerdict {
+  a: string;
+  b: string;
+  verdict: 'STRONG' | 'MEDIUM' | 'WEAK' | 'ORACLE_REQUIRED';
+}
+
 /**
  * Group issues into conflict-free sets greedily: for each issue, assign
  * it to the first group that has no conflict with any existing member.
@@ -128,13 +138,35 @@ export function computePairConflicts(manifests: Manifest[]): Conflict[] {
  * on DEPENDENCY_MANIFEST files (e.g. both add deps to package.json) are
  * allowed in the same group.  `commutativity_verify` at merge time
  * remains the safety net.
+ *
+ * When `predictedVerdicts` are provided, pairs with STRONG or MEDIUM
+ * verdicts are also discounted even if they have source/mixed file
+ * conflicts.  This enables smarter partitioning using planning-time
+ * commutativity prediction.
  */
 export function conflictFreeGroups(
   manifests: Manifest[],
   conflicts: Conflict[],
+  predictedVerdicts?: PredictedVerdict[],
 ): string[][] {
-  // Only source and mixed conflicts block co-flight grouping.
-  const blockingConflicts = conflicts.filter(c => c.overlap_type !== 'manifest_only');
+  // Build a set of pairs that predicted verdicts say are safe.
+  const safeByPrediction = new Set<string>();
+  if (predictedVerdicts) {
+    for (const pv of predictedVerdicts) {
+      if (pv.verdict === 'STRONG' || pv.verdict === 'MEDIUM') {
+        safeByPrediction.add(`${pv.a}|${pv.b}`);
+        safeByPrediction.add(`${pv.b}|${pv.a}`);
+      }
+    }
+  }
+
+  // Only source and mixed conflicts block co-flight grouping,
+  // unless a predicted verdict says the pair is safe.
+  const blockingConflicts = conflicts.filter(c => {
+    if (c.overlap_type === 'manifest_only') return false;
+    if (safeByPrediction.has(`${c.a}|${c.b}`)) return false;
+    return true;
+  });
 
   const conflictSet = new Set<string>();
   for (const c of blockingConflicts) {

--- a/tests/commutativity_predict.test.ts
+++ b/tests/commutativity_predict.test.ts
@@ -1,0 +1,266 @@
+import { describe, test, expect } from 'bun:test';
+
+const { runPredict, default: handler } = await import(
+  '../handlers/commutativity_predict.ts'
+);
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('commutativity_predict handler', () => {
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('commutativity_predict');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('STRONG verdict — file-disjoint changesets', async () => {
+    const deps = {
+      execFn: (_cmd: string, _input: string) =>
+        JSON.stringify({
+          changesets: ['#1', '#2'],
+          flight_verdict: 'STRONG',
+          pairs: [
+            {
+              a: '#1',
+              b: '#2',
+              verdict: 'STRONG',
+              reason: 'No file, symbol, or import coupling detected',
+              file_overlaps: [],
+              symbol_collisions: [],
+              import_overlaps: [],
+            },
+          ],
+        }),
+    };
+
+    const result = await runPredict(
+      {
+        changesets: [
+          { id: '#1', files: [{ path: 'src/a.ts', action: 'modify' }] },
+          { id: '#2', files: [{ path: 'src/b.ts', action: 'modify' }] },
+        ],
+      },
+      deps,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.group_verdict).toBe('STRONG');
+    expect(result.pairs).toHaveLength(1);
+    expect(result.pairs![0].verdict).toBe('STRONG');
+  });
+
+  test('MEDIUM verdict — dependency manifest overlap', async () => {
+    const deps = {
+      execFn: (_cmd: string, _input: string) =>
+        JSON.stringify({
+          changesets: ['#1', '#2'],
+          flight_verdict: 'MEDIUM',
+          pairs: [
+            {
+              a: '#1',
+              b: '#2',
+              verdict: 'MEDIUM',
+              reason: 'Dependency manifest overlap only: Cargo.toml',
+              file_overlaps: ['Cargo.toml'],
+              symbol_collisions: [],
+              import_overlaps: [],
+            },
+          ],
+        }),
+    };
+
+    const result = await runPredict(
+      {
+        changesets: [
+          {
+            id: '#1',
+            files: [
+              { path: 'Cargo.toml', action: 'modify' },
+              { path: 'src/a.rs', action: 'create' },
+            ],
+          },
+          {
+            id: '#2',
+            files: [
+              { path: 'Cargo.toml', action: 'modify' },
+              { path: 'src/b.rs', action: 'create' },
+            ],
+          },
+        ],
+      },
+      deps,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.group_verdict).toBe('MEDIUM');
+  });
+
+  test('WEAK verdict — source file overlap', async () => {
+    const deps = {
+      execFn: (_cmd: string, _input: string) =>
+        JSON.stringify({
+          changesets: ['#1', '#2'],
+          flight_verdict: 'WEAK',
+          pairs: [
+            {
+              a: '#1',
+              b: '#2',
+              verdict: 'WEAK',
+              reason: 'File overlap: src/shared.ts',
+              file_overlaps: ['src/shared.ts'],
+              symbol_collisions: [],
+              import_overlaps: [],
+            },
+          ],
+        }),
+    };
+
+    const result = await runPredict(
+      {
+        changesets: [
+          { id: '#1', files: [{ path: 'src/shared.ts', action: 'modify' }] },
+          { id: '#2', files: [{ path: 'src/shared.ts', action: 'modify' }] },
+        ],
+      },
+      deps,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.group_verdict).toBe('WEAK');
+  });
+
+  test('ORACLE_REQUIRED verdict — CI infra', async () => {
+    const deps = {
+      execFn: (_cmd: string, _input: string) =>
+        JSON.stringify({
+          changesets: ['#1', '#2'],
+          flight_verdict: 'ORACLE_REQUIRED',
+          pairs: [
+            {
+              a: '#1',
+              b: '#2',
+              verdict: 'ORACLE_REQUIRED',
+              reason: 'CI_INFRA file(s) in: #1',
+              file_overlaps: [],
+              symbol_collisions: [],
+              import_overlaps: [],
+            },
+          ],
+        }),
+    };
+
+    const result = await runPredict(
+      {
+        changesets: [
+          {
+            id: '#1',
+            files: [{ path: '.github/workflows/ci.yml', action: 'modify' }],
+          },
+          { id: '#2', files: [{ path: 'src/b.ts', action: 'modify' }] },
+        ],
+      },
+      deps,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.group_verdict).toBe('ORACLE_REQUIRED');
+  });
+
+  test('subprocess timeout — fails safe to ORACLE_REQUIRED', async () => {
+    const deps = {
+      execFn: (_cmd: string, _input: string) => {
+        throw new Error('timed out after 10000ms');
+      },
+    };
+
+    const result = await runPredict(
+      {
+        changesets: [
+          { id: '#1', files: [{ path: 'a.ts' }] },
+          { id: '#2', files: [{ path: 'b.ts' }] },
+        ],
+      },
+      deps,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.group_verdict).toBe('ORACLE_REQUIRED');
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings![0]).toContain('timed out');
+  });
+
+  test('subprocess error — returns ok:false', async () => {
+    const deps = {
+      execFn: (_cmd: string, _input: string) => {
+        throw new Error('commutativity-probe: command not found');
+      },
+    };
+
+    const result = await runPredict(
+      {
+        changesets: [
+          { id: '#1', files: [{ path: 'a.ts' }] },
+          { id: '#2', files: [{ path: 'b.ts' }] },
+        ],
+      },
+      deps,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('commutativity-probe predict failed');
+  });
+
+  test('malformed JSON from probe — returns ok:false', async () => {
+    const deps = {
+      execFn: (_cmd: string, _input: string) => 'not valid json {{{',
+    };
+
+    const result = await runPredict(
+      {
+        changesets: [
+          { id: '#1', files: [{ path: 'a.ts' }] },
+          { id: '#2', files: [{ path: 'b.ts' }] },
+        ],
+      },
+      deps,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('Failed to parse');
+  });
+
+  test('schema validation — rejects fewer than 2 changesets', async () => {
+    const result = await runPredict({
+      changesets: [{ id: '#1', files: [{ path: 'a.ts' }] }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('2 changesets');
+  });
+
+  test('unknown verdict from probe — defaults to ORACLE_REQUIRED', async () => {
+    const deps = {
+      execFn: (_cmd: string, _input: string) =>
+        JSON.stringify({
+          changesets: ['#1', '#2'],
+          flight_verdict: 'UNKNOWN_VERDICT',
+          pairs: [],
+        }),
+    };
+
+    const result = await runPredict(
+      {
+        changesets: [
+          { id: '#1', files: [{ path: 'a.ts' }] },
+          { id: '#2', files: [{ path: 'b.ts' }] },
+        ],
+      },
+      deps,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.group_verdict).toBe('ORACLE_REQUIRED');
+    expect(result.warnings).toBeDefined();
+  });
+});

--- a/tests/flight_partition.test.ts
+++ b/tests/flight_partition.test.ts
@@ -119,6 +119,56 @@ describe('flight_partition handler', () => {
     expect(parsed.flights.length).toBe(1);
   });
 
+  test('predicted_verdicts_STRONG_discounts_source_overlap', async () => {
+    const result = await handler.execute({
+      manifests: [
+        { issue_ref: '#1', files_to_modify: ['src/shared.ts'] },
+        { issue_ref: '#2', files_to_modify: ['src/shared.ts'] },
+      ],
+      predicted_verdicts: [
+        { a: '#1', b: '#2', verdict: 'STRONG' },
+      ],
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    // Source overlap normally creates 2 flights, but predicted verdict
+    // STRONG discounts the conflict → single flight
+    expect(parsed.flights.length).toBe(1);
+    expect(parsed.flights[0].issues).toEqual(['#1', '#2']);
+  });
+
+  test('predicted_verdicts_WEAK_preserves_serialization', async () => {
+    const result = await handler.execute({
+      manifests: [
+        { issue_ref: '#1', files_to_modify: ['src/shared.ts'] },
+        { issue_ref: '#2', files_to_modify: ['src/shared.ts'] },
+      ],
+      predicted_verdicts: [
+        { a: '#1', b: '#2', verdict: 'WEAK' },
+      ],
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    // WEAK verdict does NOT discount → separate flights
+    expect(parsed.flights.length).toBe(2);
+  });
+
+  test('predicted_verdicts_MEDIUM_discounts_conflict', async () => {
+    const result = await handler.execute({
+      manifests: [
+        { issue_ref: '#1', files_to_modify: ['src/shared.ts'] },
+        { issue_ref: '#2', files_to_modify: ['src/shared.ts'] },
+      ],
+      predicted_verdicts: [
+        { a: '#1', b: '#2', verdict: 'MEDIUM' },
+      ],
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    // MEDIUM verdict discounts → single flight
+    expect(parsed.flights.length).toBe(1);
+  });
+
   test('aggressive_strategy — currently equivalent to safe (v1)', async () => {
     const result = await handler.execute({
       manifests: [


### PR DESCRIPTION
## Summary

New `commutativity_predict` MCP handler that predicts changeset commutativity from planning manifests (file paths, actions, symbols) without requiring actual git branches or diffs. Enables smarter flight partitioning at planning time. Together with `commutativity_verify` (merge-time), forms a predict-then-verify pipeline.

## Changes

### MCP Handler (mcp-server-sdlc)
- `handlers/commutativity_predict.ts`: New handler. Pipes manifest JSON to `commutativity-probe predict --manifest --json` via stdin. Returns `{ ok, group_verdict, pairs[], warnings? }`. 10s timeout, fail-safe to ORACLE_REQUIRED.
- `tests/commutativity_predict.test.ts`: 9 tests covering all verdict levels, subprocess errors, timeout, malformed JSON.
- `handlers/flight_partition.ts`: Extended with `predicted_verdicts` parameter.
- `lib/flight_overlap.ts`: Extended `conflictFreeGroups()` with `PredictedVerdict` support — STRONG/MEDIUM verdicts discount file conflicts.
- `tests/flight_partition.test.ts`: 3 new tests for verdict-based partitioning.

### Probe (commutativity-probe — local changes)
- `probe/analyzer.py`: New `analyze_flight_from_manifests()`.
- `probe/diff_parser.py`: New `changeset_from_manifest()`.
- `probe/cli.py`: New `predict` subcommand with lazy imports.
- 13 probe tests pass.

## Test Results

- 1056 TS tests pass, 13 Python probe tests pass
- `validate.sh` green (69 handlers)

## Linked Issues

Closes #171