### PR TITLE
fix(parsers): align spec handler grammar with ecosystem templates

### DIFF
--- a/docs/issue-body-grammar.md
+++ b/docs/issue-body-grammar.md
@@ -1,0 +1,133 @@
+# Issue Body Grammar
+
+Authoritative specification for the issue-body shapes that `sdlc-server`'s
+`spec_*` and `epic_*` handlers parse. This document is the contract between
+the handlers and the skills/templates that author issues (e.g.
+`/devspec upshift`, `/issue`, `docs/devspec-template.md` in
+`claudecode-workflow`, and `.gitlab/issue_templates/feature.md` in
+downstream projects).
+
+If a template or skill authors issues outside this grammar, the handlers
+should be updated to accept the new shape (or the authoring side brought
+into the grammar) — NOT left to silently return empty results. Silent empty
+is the worst failure mode; every parser in this cluster surfaces a
+diagnostic hint (`accepted_sections`, `accepted_headings`, `source`) so
+consumers can tell the difference between "no data" and "data present but
+shape not recognized."
+
+## Section parsing (shared)
+
+All handlers delegate body parsing to `parseSections` in
+`lib/spec_parser.ts`. Only `## H2` headings create sections. H3 and below
+are treated as section content. Heading titles are normalized
+(`Acceptance Criteria` → `acceptance_criteria`: lowercase, punctuation
+stripped, whitespace/hyphens collapsed to `_`).
+
+Content appearing before the first H2 is discarded by the parser. If a
+story's structured content needs to be parsed, it must live under an H2
+heading.
+
+## spec_validate_structure
+
+Validates that a story issue has the sections an implementing agent needs.
+
+### Required sections
+
+Each canonical key is satisfied by any of its aliases (listed as accepted H2
+headings):
+
+| Canonical key | Accepted H2 headings |
+|---------------|----------------------|
+| `changes` | `## Changes`, `## Implementation Steps` |
+| `tests` | `## Tests`, `## Test Procedures` |
+| `acceptance_criteria` | `## Acceptance Criteria` |
+
+A section with zero non-whitespace content counts as missing. When any
+required section is absent, the response includes an `accepted_headings`
+object naming the H2 forms that would have satisfied each missing key.
+
+### Optional sections
+
+| Canonical key | Accepted H2 headings |
+|---------------|----------------------|
+| `dependencies` | `## Dependencies` |
+
+## epic_sub_issues
+
+Extracts ordered sub-issue references from an epic body.
+
+### Accepted H2 section names
+
+The handler picks the first section whose normalized key matches any of:
+
+- Explicit sub-issue names: `sub_issues`, `subissues`, `children`, `tasks`, `task_list`
+- Wave-plan shape: `waves`, `wave_map`, `phases`, `phased_implementation_plan`, `implementation_plan`, `stories`, `backlog`
+
+When no matching section is present, the response includes
+`accepted_sections` and `reason` fields so the caller knows what would have
+been recognized.
+
+### Content shapes within the section
+
+Tried in order. First one to yield rows wins:
+
+1. **Table with `Order` / `Issue` / `Title` columns.** Column matching is
+   case-insensitive substring — `| Order | Issue | Title | Dependencies |`
+   works. Each row produces one sub-issue; order comes from the `Order`
+   column if present.
+2. **Checklist or bullet list.** Each `- [ ]`, `- [x]`, or `- ` line that
+   contains a recognized ref produces one sub-issue; order comes from
+   position within the section. Works unchanged with H3 wave groupings
+   (e.g. `### Wave 1 — Foundation` followed by bullets) — the H3 lines are
+   skipped as non-bullets, and the bullets parse correctly.
+
+### Accepted ref forms
+
+- `#N` — resolved to the current repo slug (derived via `git remote`)
+- `org/repo#N` — preserved verbatim
+- `https://github.com/org/repo/issues/N` or
+  `https://gitlab.com/org/repo/-/issues/N` — normalized to `org/repo#N`
+
+## spec_dependencies
+
+Extracts dependency refs from a story body.
+
+### Primary source
+
+The `## Dependencies` H2 section. Content may be a bullet list, table, or
+free-form text — the ref-harvesting regexes handle any arrangement.
+
+### Fallback source
+
+When `## Dependencies` is absent or empty, the handler scans every section
+for a `**Dependencies:**` bold-label line (e.g. inside a `## Metadata`
+section) and harvests refs from its content (up to the next bold label,
+next H2, or end of section).
+
+The response's `source` field reports which path was taken:
+`dependencies_section`, `bold_label_fallback`, or `none`.
+
+### Accepted ref forms
+
+- `#N` — resolved to the current repo slug
+- `org/repo#N`
+- Full `github.com` / `gitlab.com` issue URLs
+- Literal `None` (case-insensitive, word-anchored) — returns an empty list
+
+## Regression fixtures
+
+`tests/fixtures/parser-grammar/` holds verbatim issue bodies produced by
+`/devspec upshift` and `/issue` at the grammar's current acceptance point.
+Parser tests assert clean extraction against these fixtures. If the
+authoring side changes its output shape, the fixture test fails loudly —
+preventing silent downstream empties.
+
+## When to update this document
+
+- Before adding a new accepted section alias: add it here and to the
+  handler.
+- Before changing an accepted ref form: add a regression test and update
+  this document.
+- When renaming a canonical key: update here + handler + all referencing
+  tool descriptions in one PR. Breaking the grammar is a tracked event,
+  not an accident.

--- a/handlers/epic_sub_issues.ts
+++ b/handlers/epic_sub_issues.ts
@@ -46,11 +46,32 @@ function normalizeRef(ref: string, currentSlug: string | null): string {
 
 /**
  * Find which section of the parsed body contains the sub-issues.
- * Accepts "Sub-Issues", "Sub Issues", "Sub-issues", "Children", "Tasks".
+ * Accepts (as normalized H2 heading keys):
+ *   - Explicit: sub_issues, subissues, children, tasks, task_list
+ *   - Wave-plan shape: waves, wave_map, phases, phased_implementation_plan,
+ *     implementation_plan, stories, backlog
+ *
+ * The wave-plan aliases let `/devspec upshift`-generated Epic bodies
+ * (which group `#NN` refs under `### Wave N` H3 headings inside a
+ * `## Waves` H2) parse without requiring a rename.
  */
+const SUB_ISSUE_SECTION_KEYS = [
+  'sub_issues',
+  'subissues',
+  'children',
+  'tasks',
+  'task_list',
+  'waves',
+  'wave_map',
+  'phases',
+  'phased_implementation_plan',
+  'implementation_plan',
+  'stories',
+  'backlog',
+] as const;
+
 function findSubIssueSection(sections: Record<string, string>): string | null {
-  const keys = ['sub_issues', 'subissues', 'children', 'tasks', 'task_list'];
-  for (const k of keys) {
+  for (const k of SUB_ISSUE_SECTION_KEYS) {
     if (sections[k]) return sections[k];
   }
   return null;
@@ -112,8 +133,10 @@ function parseChecklistOrBullets(section: string, currentSlug: string | null): S
     if (!refM) continue;
     const raw = refM[1];
     const ref = normalizeRef(raw, currentSlug);
-    // Title = text with the ref token stripped out.
-    const title = text.replace(refM[0], '').trim().replace(/^[-:*\s]+/, '').trim();
+    // Title = text with the ref token stripped out. Also strip leading
+    // list/separator punctuation including em/en dashes commonly used in
+    // `- #NN — Title` style bullets.
+    const title = text.replace(refM[0], '').trim().replace(/^[-:*\s—–]+/, '').trim();
     subs.push({
       ref,
       title: title.length > 0 ? title : undefined,
@@ -126,7 +149,8 @@ function parseChecklistOrBullets(section: string, currentSlug: string | null): S
 
 const epicSubIssuesHandler: HandlerDef = {
   name: 'epic_sub_issues',
-  description: "Extract sub-issue references from an epic's body",
+  description:
+    "Extract sub-issue references from an epic's body. Accepts H2 sections named: `## Sub-Issues` (or Children/Tasks/Task List), `## Waves` (or Wave Map/Phases/Phased Implementation Plan/Implementation Plan/Stories/Backlog). Content may be a table with Order/Issue/Title columns, or a checklist/bullet list with `#NN` refs. See docs/issue-body-grammar.md.",
   inputSchema,
   async execute(rawArgs: unknown) {
     let args: z.infer<typeof inputSchema>;
@@ -168,6 +192,8 @@ const epicSubIssuesHandler: HandlerDef = {
                 epic_ref: args.epic_ref,
                 sub_issues: [],
                 count: 0,
+                reason: 'no matching sub-issue section found in epic body',
+                accepted_sections: [...SUB_ISSUE_SECTION_KEYS],
               }),
             },
           ],

--- a/handlers/spec_dependencies.ts
+++ b/handlers/spec_dependencies.ts
@@ -80,9 +80,32 @@ function parseDependenciesSection(section: string, currentSlug: string | null): 
   return deps;
 }
 
+/**
+ * Fallback extractor for stories that embed dependencies as a bold label
+ * (e.g. `**Dependencies:** Stories 1.1 (#86), 2.1 (#87)`) inside another
+ * section like `## Metadata`, rather than in a dedicated `## Dependencies`
+ * H2 section.
+ *
+ * Returns the content following the first `**Dependencies:**` label in any
+ * section, up to the next bold label, next H2-equivalent break, or end of
+ * that section's content.
+ */
+function findBoldLabelDependencies(sections: Record<string, string>): string {
+  // Content after **Dependencies:** up to: next bold label (possibly on a
+  // bulleted line, e.g. `- **Reviewer:**`), next H2, or end of section.
+  const labelRe =
+    /\*\*Dependencies:?\*\*\s*(.+?)(?=\n\s*(?:[-*]\s+)?\*\*[A-Z][A-Za-z ]*:?\*\*|\n##\s|\n*$)/s;
+  for (const sec of Object.values(sections)) {
+    const m = labelRe.exec(sec);
+    if (m && m[1].trim()) return m[1].trim();
+  }
+  return '';
+}
+
 const specDependenciesHandler: HandlerDef = {
   name: 'spec_dependencies',
-  description: 'Extract the list of dependency issue references from an issue spec',
+  description:
+    "Extract the list of dependency issue references from an issue spec. Primary source: `## Dependencies` H2 section. Fallback: a `**Dependencies:**` bold label inside any other section (e.g. `## Metadata`). Accepts `#N`, `org/repo#N`, and full GitHub/GitLab issue URLs. See docs/issue-body-grammar.md.",
   inputSchema,
   async execute(rawArgs: unknown) {
     let args: z.infer<typeof inputSchema>;
@@ -113,8 +136,23 @@ const specDependenciesHandler: HandlerDef = {
     try {
       const body = fetchBody(ref);
       const { sections } = parseSections(body);
-      const depsSection = sections.dependencies ?? '';
+      let depsSection = sections.dependencies ?? '';
+      let source: 'dependencies_section' | 'bold_label_fallback' | 'none' =
+        depsSection.trim() ? 'dependencies_section' : 'none';
+      if (!depsSection.trim()) {
+        const fallback = findBoldLabelDependencies(sections);
+        if (fallback) {
+          depsSection = fallback;
+          source = 'bold_label_fallback';
+        }
+      }
       const deps = parseDependenciesSection(depsSection, parseRepoSlug());
+      // If the fallback yielded text but no refs, the bold label didn't
+      // actually provide dependency data — report source as 'none' rather
+      // than misleading the caller about where (non-existent) refs came from.
+      if (source === 'bold_label_fallback' && deps.length === 0) {
+        source = 'none';
+      }
 
       return {
         content: [
@@ -125,6 +163,7 @@ const specDependenciesHandler: HandlerDef = {
               issue_ref: args.issue_ref,
               dependencies: deps,
               count: deps.length,
+              source,
             }),
           },
         ],

--- a/handlers/spec_validate_structure.ts
+++ b/handlers/spec_validate_structure.ts
@@ -8,8 +8,21 @@ const inputSchema = z.object({
   issue_ref: z.string().min(1, 'issue_ref must be a non-empty string'),
 });
 
-const REQUIRED_SECTIONS = ['changes', 'tests', 'acceptance_criteria'] as const;
-const OPTIONAL_SECTIONS = ['dependencies'] as const;
+// Canonical section keys → accepted H2 heading aliases (after normalizeHeading).
+// `## Changes` or `## Implementation Steps` both satisfy the `changes` requirement;
+// `## Tests` or `## Test Procedures` both satisfy `tests`. See docs/issue-body-grammar.md.
+const REQUIRED_SECTION_ALIASES: Record<string, readonly string[]> = {
+  changes: ['changes', 'implementation_steps'],
+  tests: ['tests', 'test_procedures'],
+  acceptance_criteria: ['acceptance_criteria'],
+};
+const OPTIONAL_SECTION_ALIASES: Record<string, readonly string[]> = {
+  dependencies: ['dependencies'],
+};
+
+function acceptedHeadings(aliases: readonly string[]): string[] {
+  return aliases.map((a) => `## ${a.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}`);
+}
 
 function fetchBody(ref: IssueRef): string {
   const platform = detectPlatform();
@@ -25,7 +38,8 @@ function fetchBody(ref: IssueRef): string {
 
 const specValidateStructureHandler: HandlerDef = {
   name: 'spec_validate_structure',
-  description: 'Check for presence of required sections in an issue spec',
+  description:
+    'Check for presence of required sections in an issue spec. Accepts H2 heading aliases: `## Changes` or `## Implementation Steps`; `## Tests` or `## Test Procedures`; `## Acceptance Criteria`. Optional: `## Dependencies`. See docs/issue-body-grammar.md.',
   inputSchema,
   async execute(rawArgs: unknown) {
     let args: z.infer<typeof inputSchema>;
@@ -59,30 +73,36 @@ const specValidateStructureHandler: HandlerDef = {
 
       const presence: Record<string, boolean> = {};
       const missing: string[] = [];
-      for (const key of REQUIRED_SECTIONS) {
-        const has = Boolean(sections[key] && sections[key].trim().length > 0);
-        presence[`has_${key}`] = has;
-        if (!has) missing.push(key);
+      const acceptedHeadingsHint: Record<string, string[]> = {};
+      for (const [canonical, aliases] of Object.entries(REQUIRED_SECTION_ALIASES)) {
+        const has = aliases.some(
+          (alias) => sections[alias] && sections[alias].trim().length > 0,
+        );
+        presence[`has_${canonical}`] = has;
+        if (!has) {
+          missing.push(canonical);
+          acceptedHeadingsHint[canonical] = acceptedHeadings(aliases);
+        }
       }
-      for (const key of OPTIONAL_SECTIONS) {
-        presence[`has_${key}`] = Boolean(
-          sections[key] && sections[key].trim().length > 0,
+      for (const [canonical, aliases] of Object.entries(OPTIONAL_SECTION_ALIASES)) {
+        presence[`has_${canonical}`] = aliases.some(
+          (alias) => sections[alias] && sections[alias].trim().length > 0,
         );
       }
 
+      const response: Record<string, unknown> = {
+        ok: true,
+        issue_ref: args.issue_ref,
+        ...presence,
+        missing_sections: missing,
+        valid: missing.length === 0,
+      };
+      if (missing.length > 0) {
+        response.accepted_headings = acceptedHeadingsHint;
+      }
+
       return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({
-              ok: true,
-              issue_ref: args.issue_ref,
-              ...presence,
-              missing_sections: missing,
-              valid: missing.length === 0,
-            }),
-          },
-        ],
+        content: [{ type: 'text' as const, text: JSON.stringify(response) }],
       };
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);

--- a/tests/epic_sub_issues.test.ts
+++ b/tests/epic_sub_issues.test.ts
@@ -108,4 +108,86 @@ describe('epic_sub_issues handler', () => {
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(false);
   });
+
+  test('parses_wave_grouped_epic — ## Waves with ### Wave N + bullets', async () => {
+    mockBody(`## Waves
+
+### Wave 1 — Foundation (master: #88)
+
+- #86 — Story 1.1: Pipeline config schema
+- #87 — Story 1.2: Pipeline config loader
+
+### Wave 2 — Services (master: #91)
+
+- #89 — Story 2.1: Pipeline Service
+- #90 — Story 2.2: Pipeline Executor
+`);
+    const result = await handler.execute({ epic_ref: '#100' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.count).toBe(4);
+    expect(parsed.sub_issues.map((s: { ref: string }) => s.ref)).toEqual([
+      'myorg/myrepo#86',
+      'myorg/myrepo#87',
+      'myorg/myrepo#89',
+      'myorg/myrepo#90',
+    ]);
+    expect(parsed.sub_issues[0].title).toBe('Story 1.1: Pipeline config schema');
+  });
+
+  test('parses_stories_section_alias', async () => {
+    mockBody(`## Stories
+
+- #10 — Story A
+- #11 — Story B
+`);
+    const result = await handler.execute({ epic_ref: '#100' });
+    const parsed = parseResult(result);
+    expect(parsed.count).toBe(2);
+    expect(parsed.sub_issues[0].ref).toBe('myorg/myrepo#10');
+  });
+
+  test('parses_phases_alias', async () => {
+    mockBody(`## Phases
+
+- #20 — Phase 1 master
+- #21 — Phase 2 master
+`);
+    const result = await handler.execute({ epic_ref: '#100' });
+    const parsed = parseResult(result);
+    expect(parsed.count).toBe(2);
+  });
+
+  test('accepted_sections_surfaced_when_missing', async () => {
+    mockBody('## Summary\nnothing here.\n');
+    const result = await handler.execute({ epic_ref: '#100' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.count).toBe(0);
+    expect(parsed.reason).toContain('no matching');
+    expect(parsed.accepted_sections).toEqual(
+      expect.arrayContaining(['sub_issues', 'waves', 'stories', 'phases']),
+    );
+  });
+
+  test('sub_issues_section_takes_precedence_over_waves', async () => {
+    // When both exist, the explicit sub_issues section wins.
+    mockBody(`## Sub-Issues
+
+- #5 explicit
+- #6 explicit
+
+## Waves
+
+### Wave 1
+
+- #99 secondary
+`);
+    const result = await handler.execute({ epic_ref: '#100' });
+    const parsed = parseResult(result);
+    expect(parsed.sub_issues.map((s: { ref: string }) => s.ref)).toEqual([
+      'myorg/myrepo#5',
+      'myorg/myrepo#6',
+    ]);
+  });
 });

--- a/tests/fixtures/parser-grammar/epic-simple-stories.md
+++ b/tests/fixtures/parser-grammar/epic-simple-stories.md
@@ -1,0 +1,12 @@
+## Phase Definition of Done
+
+- [ ] All Phase 1 unit tests pass
+- [ ] Integration tests for ingestion path pass
+
+## Stories
+
+- #86 — Story 1.1: Pipeline config schema
+- #87 — Story 1.2: Pipeline config loader
+- #88 — Wave 1 Master
+- #89 — Story 2.1: Pipeline Service
+- #90 — Story 2.2: Pipeline Executor

--- a/tests/fixtures/parser-grammar/epic-wave-grouped.md
+++ b/tests/fixtures/parser-grammar/epic-wave-grouped.md
@@ -1,0 +1,21 @@
+## Phase Definition of Done
+
+- [ ] All Phase 1 unit tests pass
+
+## Waves
+
+### Wave 1 — Foundation (master: #88)
+
+- #86 — Story 1.1: Pipeline config schema
+- #87 — Story 1.2: Pipeline config loader
+
+### Wave 2 — Services (master: #91)
+
+- #89 — Story 2.1: Pipeline Service
+- #90 — Story 2.2: Pipeline Executor
+
+### Wave 3 — Integration (master: #95)
+
+- #92 — Story 3.1: CLI wiring
+- #93 — Story 3.2: End-to-end smoke test
+- #94 — Story 3.3: Docs

--- a/tests/fixtures/parser-grammar/story-issue-feature.md
+++ b/tests/fixtures/parser-grammar/story-issue-feature.md
@@ -1,0 +1,39 @@
+## Summary
+
+Add a JSON schema validator for pipeline configuration files, catching malformed configs at load time.
+
+## Context
+
+Today malformed configs silently produce runtime failures downstream. A schema gate at load time gives actionable errors.
+
+## Implementation Steps
+
+1. Add `schema/pipeline_config.schema.json` following JSON Schema draft-07.
+2. Implement `validatePipelineConfig(cfg)` in `src/config/validate.ts`.
+3. Call `validatePipelineConfig` from `PipelineConfigLoader.load()`.
+
+## Test Procedures
+
+### Unit Tests
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `test_valid_config_accepted` | Known-good config passes validation | `tests/config/validate.test.ts` |
+| `test_invalid_enum_rejected` | Invalid archetype enum fails with path + reason | `tests/config/validate.test.ts` |
+| `test_missing_required_field_rejected` | Missing required field fails with path | `tests/config/validate.test.ts` |
+
+### Integration/E2E Coverage
+
+- IT-03 — now runnable (loader boundary enforces schema gate).
+
+## Acceptance Criteria
+
+- [ ] `schema/pipeline_config.schema.json` exists and is valid JSON Schema.
+- [ ] `validatePipelineConfig` rejects invalid configs with path + reason.
+- [ ] `PipelineConfigLoader.load()` fails cleanly on schema violations.
+- [ ] All tests in `tests/config/validate.test.ts` pass.
+
+## Dependencies
+
+- #86
+- Wave-Engineering/mcp-server-sdlc#181

--- a/tests/fixtures/parser-grammar/story-upshift-with-deps.md
+++ b/tests/fixtures/parser-grammar/story-upshift-with-deps.md
@@ -1,0 +1,27 @@
+## Summary
+
+Implement the Pipeline Service responsible for orchestrating stage execution.
+
+## Implementation Steps
+
+1. Create `src/services/pipeline_service.ts` with the `PipelineService` class.
+2. Expose `run(config)` → returns a result record.
+3. Wire into `src/index.ts`.
+
+## Test Procedures
+
+- Unit: `tests/pipeline_service.test.ts` covering happy path and failure mode.
+- Integration: run smoke test against a fixture pipeline config.
+
+## Acceptance Criteria
+
+- [ ] `PipelineService.run()` returns a result record with `status` and `stages`.
+- [ ] Unit tests pass.
+- [ ] Integration smoke test passes.
+
+## Metadata
+
+- **Wave:** 2
+- **Phase:** 1
+- **Parent Epic:** #85
+- **Dependencies:** Stories 1.1 (#86), 1.2 (#87)

--- a/tests/parser_grammar_fixtures.test.ts
+++ b/tests/parser_grammar_fixtures.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Fixture-based regression tests for the parser grammar contract.
+ *
+ * Each fixture under `tests/fixtures/parser-grammar/` is a verbatim issue
+ * body produced by a real skill or template (`/devspec upshift`, `/issue`,
+ * etc.) at the point this contract was established. If a skill later
+ * changes its output shape, these tests fail loudly — exactly the drift
+ * signal we want.
+ *
+ * When adding a new skill or template, add a new fixture here with a
+ * dedicated test asserting clean extraction. See docs/issue-body-grammar.md.
+ */
+
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string, _opts?: unknown) => execMockFn(cmd));
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: validateHandler } = await import('../handlers/spec_validate_structure.ts');
+const { default: epicHandler } = await import('../handlers/epic_sub_issues.ts');
+const { default: depsHandler } = await import('../handlers/spec_dependencies.ts');
+
+function resetMocks() {
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+function fixture(name: string): string {
+  return readFileSync(join(import.meta.dir, 'fixtures/parser-grammar', name), 'utf8');
+}
+
+function mockBody(body: string, origin = 'https://github.com/blueshift/cue.git') {
+  execMockFn = (cmd: string) => {
+    if (cmd.startsWith('git remote')) return origin + '\n';
+    if (cmd.includes('gh issue view')) return JSON.stringify({ body });
+    return '';
+  };
+}
+
+describe('parser grammar fixtures — /devspec upshift', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('epic-simple-stories — ## Stories bullets parsed as sub-issues', async () => {
+    mockBody(fixture('epic-simple-stories.md'));
+    const result = await epicHandler.execute({ epic_ref: '#85' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.count).toBe(5);
+    expect(parsed.sub_issues[0].ref).toBe('blueshift/cue#86');
+  });
+
+  test('epic-wave-grouped — ## Waves with ### Wave N + bullets parses all refs', async () => {
+    mockBody(fixture('epic-wave-grouped.md'));
+    const result = await epicHandler.execute({ epic_ref: '#85' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.count).toBe(7);
+    expect(parsed.sub_issues.map((s: { ref: string }) => s.ref)).toEqual([
+      'blueshift/cue#86',
+      'blueshift/cue#87',
+      'blueshift/cue#89',
+      'blueshift/cue#90',
+      'blueshift/cue#92',
+      'blueshift/cue#93',
+      'blueshift/cue#94',
+    ]);
+  });
+
+  test('story-upshift-with-deps — validates as valid (aliases accepted)', async () => {
+    mockBody(fixture('story-upshift-with-deps.md'));
+    const result = await validateHandler.execute({ issue_ref: '#89' });
+    const parsed = parseResult(result);
+    expect(parsed.valid).toBe(true);
+    expect(parsed.has_changes).toBe(true);
+    expect(parsed.has_tests).toBe(true);
+    expect(parsed.has_acceptance_criteria).toBe(true);
+    expect(parsed.missing_sections).toEqual([]);
+  });
+
+  test('story-upshift-with-deps — bold-label deps extracted from ## Metadata', async () => {
+    mockBody(fixture('story-upshift-with-deps.md'));
+    const result = await depsHandler.execute({ issue_ref: '#89' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.source).toBe('bold_label_fallback');
+    expect(parsed.dependencies.map((d: { ref: string }) => d.ref)).toEqual([
+      'blueshift/cue#86',
+      'blueshift/cue#87',
+    ]);
+  });
+});
+
+describe('parser grammar fixtures — /issue feature', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('story-issue-feature — validates as valid', async () => {
+    mockBody(fixture('story-issue-feature.md'));
+    const result = await validateHandler.execute({ issue_ref: '#10' });
+    const parsed = parseResult(result);
+    expect(parsed.valid).toBe(true);
+  });
+
+  test('story-issue-feature — deps from explicit ## Dependencies section', async () => {
+    mockBody(fixture('story-issue-feature.md'));
+    const result = await depsHandler.execute({ issue_ref: '#10' });
+    const parsed = parseResult(result);
+    expect(parsed.source).toBe('dependencies_section');
+    // parseDependenciesSection iterates URLs → cross-repo → short refs, so
+    // order is by form, not input position. Assert membership, not order.
+    expect(parsed.count).toBe(2);
+    expect(parsed.dependencies.map((d: { ref: string }) => d.ref)).toEqual(
+      expect.arrayContaining(['blueshift/cue#86', 'Wave-Engineering/mcp-server-sdlc#181']),
+    );
+  });
+});

--- a/tests/spec_dependencies.test.ts
+++ b/tests/spec_dependencies.test.ts
@@ -117,4 +117,115 @@ None
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(false);
   });
+
+  test('bold_label_fallback — **Dependencies:** inside ## Metadata', async () => {
+    mockBody(`## Summary
+
+The thing.
+
+## Metadata
+
+- **Wave:** 2
+- **Phase:** 1
+- **Parent Epic:** #85
+- **Dependencies:** Stories 1.1 (#86), 1.2 (#87)
+`);
+    const result = await handler.execute({ issue_ref: '#99' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.source).toBe('bold_label_fallback');
+    expect(parsed.dependencies.map((d: { ref: string }) => d.ref)).toEqual([
+      'myorg/myrepo#86',
+      'myorg/myrepo#87',
+    ]);
+  });
+
+  test('bold_label_fallback — cross-repo refs in bold label', async () => {
+    mockBody(`## Metadata
+
+- **Dependencies:** Wave-Engineering/mcp-server-sdlc#181, #92
+`);
+    const result = await handler.execute({ issue_ref: '#99' });
+    const parsed = parseResult(result);
+    expect(parsed.source).toBe('bold_label_fallback');
+    expect(parsed.dependencies.map((d: { ref: string }) => d.ref)).toEqual([
+      'Wave-Engineering/mcp-server-sdlc#181',
+      'myorg/myrepo#92',
+    ]);
+  });
+
+  test('dependencies_section_preferred_over_bold_label', async () => {
+    mockBody(`## Dependencies
+
+- #200
+
+## Metadata
+
+- **Dependencies:** #999
+`);
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.source).toBe('dependencies_section');
+    expect(parsed.dependencies.map((d: { ref: string }) => d.ref)).toEqual([
+      'myorg/myrepo#200',
+    ]);
+  });
+
+  test('source_is_none_when_no_deps_present', async () => {
+    mockBody('## Summary\nfoo\n');
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.source).toBe('none');
+    expect(parsed.count).toBe(0);
+  });
+
+  test('source_is_dependencies_section_when_explicit', async () => {
+    mockBody(`## Dependencies
+
+- #5
+`);
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.source).toBe('dependencies_section');
+  });
+
+  test('bold_label_stops_at_next_bold_label', async () => {
+    mockBody(`## Metadata
+
+- **Dependencies:** #50
+- **Reviewer:** @alice #999
+`);
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    // Only #50 should be picked up; #999 is after **Reviewer:**
+    expect(parsed.dependencies.map((d: { ref: string }) => d.ref)).toEqual([
+      'myorg/myrepo#50',
+    ]);
+  });
+
+  test('bold_label_with_prose_but_no_refs_reverts_source_to_none', async () => {
+    mockBody(`## Metadata
+
+- **Dependencies:** See planning doc TBD, awaiting spec
+`);
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.count).toBe(0);
+    // Guard at handler: fallback yielded text but no refs → source reverts
+    // to 'none' so callers aren't misled about where non-refs came from.
+    expect(parsed.source).toBe('none');
+  });
+
+  test('empty_bold_label_yields_no_deps', async () => {
+    mockBody(`## Metadata
+
+- **Dependencies:**
+- **Wave:** 1
+`);
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.count).toBe(0);
+    // With no content in the label, source stays 'none'.
+    expect(parsed.source).toBe('none');
+  });
 });

--- a/tests/spec_validate_structure.test.ts
+++ b/tests/spec_validate_structure.test.ts
@@ -95,4 +95,60 @@ describe('spec_validate_structure handler', () => {
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(false);
   });
+
+  test('implementation_steps_satisfies_changes_alias', async () => {
+    mockBody(
+      '## Implementation Steps\n1. do stuff\n## Tests\nt\n## Acceptance Criteria\n- [ ] ok\n',
+    );
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.valid).toBe(true);
+    expect(parsed.has_changes).toBe(true);
+    expect(parsed.missing_sections).toEqual([]);
+  });
+
+  test('test_procedures_satisfies_tests_alias', async () => {
+    mockBody(
+      '## Changes\nc\n## Test Procedures\n- unit tests\n## Acceptance Criteria\n- [ ] ok\n',
+    );
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.valid).toBe(true);
+    expect(parsed.has_tests).toBe(true);
+  });
+
+  test('both_aliases_together_valid', async () => {
+    mockBody(
+      '## Implementation Steps\n1.\n## Test Procedures\n- ok\n## Acceptance Criteria\n- [ ] ok\n',
+    );
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.valid).toBe(true);
+    expect(parsed.has_changes).toBe(true);
+    expect(parsed.has_tests).toBe(true);
+  });
+
+  test('accepted_headings_surfaced_when_missing', async () => {
+    mockBody('## Summary\nnothing relevant\n');
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.valid).toBe(false);
+    expect(parsed.accepted_headings).toBeDefined();
+    expect(parsed.accepted_headings.changes).toEqual(
+      expect.arrayContaining(['## Changes', '## Implementation Steps']),
+    );
+    expect(parsed.accepted_headings.tests).toEqual(
+      expect.arrayContaining(['## Tests', '## Test Procedures']),
+    );
+  });
+
+  test('accepted_headings_absent_when_valid', async () => {
+    mockBody(
+      '## Changes\nc\n## Tests\nt\n## Acceptance Criteria\n- [ ] ok\n',
+    );
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.valid).toBe(true);
+    expect(parsed.accepted_headings).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Three silent-failure defects in `spec_validate_structure`, `epic_sub_issues`, and `spec_dependencies` imposed a canonical H2 grammar (`## Changes`, `## Tests`, `## Sub-Issues`, `## Dependencies`) that disagreed with every issue template and skill in the surrounding ecosystem (`## Implementation Steps`, `## Test Procedures`, `## Acceptance Criteria`, `## Metadata`, Epic bodies with `### Wave N` groupings). On mismatch, the handlers silently returned `{count: 0}` — blocking `/prepwaves` after `/devspec upshift` and making `/precheck` validate-false on every spec-driven story.

Aligns the parsers to the ecosystem (not the other way around) via alias maps and section-name-gated fallbacks, and adds an authoritative grammar doc + regression fixtures so future drift on either side breaks CI loudly instead of silently corrupting wave plans.

## Changes

- `handlers/spec_validate_structure.ts` — replaces strict `REQUIRED_SECTIONS` with an alias map: `changes` accepts `## Changes` or `## Implementation Steps`; `tests` accepts `## Tests` or `## Test Procedures`. Emits `accepted_headings` hint in the response when sections are missing so callers get a concrete pointer instead of a mystery.
- `handlers/epic_sub_issues.ts` — extends `SUB_ISSUE_SECTION_KEYS` with wave-plan aliases (`waves`, `wave_map`, `phases`, `phased_implementation_plan`, `implementation_plan`, `stories`, `backlog`). Emits `accepted_sections` + `reason` hint on miss. Widens title-cleanup regex to handle em/en dashes in `- #NN — title` bullets.
- `handlers/spec_dependencies.ts` — adds `findBoldLabelDependencies` fallback that harvests content after a `**Dependencies:**` bold label inside any section when `## Dependencies` is absent or empty. Reports `source` as `dependencies_section | bold_label_fallback | none`, with a guard that reverts source to `none` when the fallback yields text but no parseable refs.
- `docs/issue-body-grammar.md` — new authoritative spec documenting required/optional sections, accepted aliases, sub-issue section aliases, ref forms, fallback behavior, and when-to-update guidance. Linked from all three tool descriptions.
- `tests/fixtures/parser-grammar/` — verbatim Epic + Story bodies produced by `/devspec upshift` and `/issue feature` today. Round-trip regression tests assert clean extraction; future drift on either side of the skill ↔ parser contract breaks CI.
- 18 new tests across the three handler test files + 6 fixture-based regression tests (1080/1080 pass).

## Linked Issues

Closes #181

## Test Plan

- [x] `bun test` — 1080/1080 pass, including 24 new tests covering aliases, fallbacks, diagnostic hints, and edge cases (empty labels, prose-without-refs, dependencies-section precedence, next-bold-label termination).
- [x] `bunx tsc --noEmit` — clean typecheck.
- [x] `./scripts/ci/build.sh` — all three platform binaries built.
- [x] `./scripts/ci/validate.sh` — 69/69 validation checks pass.
- [x] Trivy vulnerability scan — 0 HIGH/CRITICAL.
- [x] `feature-dev:code-reviewer` pass — 1 confidence-82 coverage gap (untested `bold_label_with_prose_but_no_refs_reverts_source_to_none` path) — fixed inline.
- [ ] Post-merge live verification: re-run `/prepwaves` on blueshift-cue Epic #85 and confirm `epic_sub_issues` returns all 10 stories and `spec_validate_structure` returns `valid: true` on every story without hand-edited bodies (will require an install-pipeline update of `~/.local/bin/sdlc-server` on dev hosts — same path as any other handler change).
