### PR TITLE
fix(wave_previous_merged): verify PR-merged closure via GraphQL

### DIFF
--- a/handlers/wave_previous_merged.ts
+++ b/handlers/wave_previous_merged.ts
@@ -2,7 +2,7 @@ import { execSync } from 'child_process';
 import { join } from 'path';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform, gitlabApiIssue } from '../lib/glab';
+import { detectPlatform, gitlabApiIssue, parseRepoSlug } from '../lib/glab';
 
 const inputSchema = z.object({}).strict();
 
@@ -84,21 +84,74 @@ function findPreviousWaveId(plan: PlanData, state: StateData): string | null {
   return null;
 }
 
-interface GhIssueState {
-  state: string;
-  stateReason?: string;
+interface IssueClosureInfo {
+  state: 'OPEN' | 'CLOSED';
+  closedByMergedPR: boolean;
 }
 
-function fetchGithubIssueState(n: number): GhIssueState {
-  const raw = execSync(`gh issue view ${n} --json state,stateReason`, { encoding: 'utf8' });
-  const parsed = JSON.parse(raw) as { state: string; stateReason?: string };
-  return { state: parsed.state.toUpperCase(), stateReason: parsed.stateReason };
+// GraphQL query that returns both the closure state AND the linkage to any
+// merging PR. `closedByPullRequestsReferences` captures body-keyword closures
+// (`Closes #N`) which the REST events API misses (commit_id is null for those),
+// while `timelineItems[ClosedEvent].closer` covers the broader "closed by a PR"
+// timeline event. An issue counts as closed-via-merged-PR iff CLOSED and at
+// least one linked PR is merged, OR the closer is explicitly a PullRequest.
+const GH_ISSUE_CLOSURE_QUERY =
+  'query($owner:String!,$repo:String!,$num:Int!)' +
+  '{repository(owner:$owner,name:$repo){issue(number:$num){' +
+  'state ' +
+  'closedByPullRequestsReferences(first:5,includeClosedPrs:true){nodes{merged}} ' +
+  'timelineItems(first:1,itemTypes:[CLOSED_EVENT]){nodes{... on ClosedEvent{closer{__typename}}}}' +
+  '}}}';
+
+interface GhGraphqlResponse {
+  data?: {
+    repository?: {
+      issue?: {
+        state?: string;
+        closedByPullRequestsReferences?: { nodes?: Array<{ merged?: boolean }> };
+        timelineItems?: { nodes?: Array<{ closer?: { __typename?: string } }> };
+      };
+    };
+  };
 }
 
-function fetchGitlabIssueState(n: number): GhIssueState {
+// GitHub's owner/repo grammar: alphanumerics plus `.`, `_`, `-`. Enforcing this
+// at the boundary prevents a maliciously-crafted git remote URL from smuggling
+// shell metacharacters through `parseRepoSlug()` into the `execSync` string.
+const GITHUB_SLUG_SEGMENT = /^[A-Za-z0-9._-]+$/;
+
+function fetchGithubClosureInfo(n: number, slug: string): IssueClosureInfo {
+  const [owner, repo] = slug.split('/', 2);
+  if (!owner || !repo) throw new Error(`invalid github slug: ${slug}`);
+  if (!GITHUB_SLUG_SEGMENT.test(owner) || !GITHUB_SLUG_SEGMENT.test(repo)) {
+    throw new Error(`invalid github slug characters: ${slug}`);
+  }
+  const cmd =
+    `gh api graphql -f 'query=${GH_ISSUE_CLOSURE_QUERY}' ` +
+    `-F owner=${owner} -F repo=${repo} -F num=${n}`;
+  const raw = execSync(cmd, { encoding: 'utf8' });
+  const parsed = JSON.parse(raw) as GhGraphqlResponse;
+  const issue = parsed.data?.repository?.issue;
+  if (!issue) throw new Error(`github issue ${n} not found`);
+  const state = (issue.state ?? '').toUpperCase() === 'CLOSED' ? 'CLOSED' : 'OPEN';
+  if (state !== 'CLOSED') return { state: 'OPEN', closedByMergedPR: false };
+  const prRefs = issue.closedByPullRequestsReferences?.nodes ?? [];
+  const hasMergedPR = prRefs.some((ref) => ref?.merged === true);
+  const closerIsPR =
+    issue.timelineItems?.nodes?.[0]?.closer?.__typename === 'PullRequest';
+  return { state: 'CLOSED', closedByMergedPR: hasMergedPR || closerIsPR };
+}
+
+// GitLab: `wave_previous_merged` still treats state-only as closed. The
+// reported #183 repro was GitHub-specific (body-keyword closures); GitLab's
+// default commit-trailer style populates closer info through a different path
+// and hasn't been reported as broken. Leaving the GitLab code path untouched
+// avoids a cross-platform regression; strengthening it to "closed by merged
+// MR" is a separate feature.
+function fetchGitlabClosureInfo(n: number): IssueClosureInfo {
   const parsed = gitlabApiIssue(n);
-  const state = parsed.state === 'opened' ? 'OPEN' : parsed.state.toUpperCase();
-  return { state };
+  const state = parsed.state === 'opened' ? 'OPEN' : 'CLOSED';
+  return { state, closedByMergedPR: state === 'CLOSED' };
 }
 
 const wavePreviousMergedHandler: HandlerDef = {
@@ -170,15 +223,29 @@ const wavePreviousMergedHandler: HandlerDef = {
       }
 
       const platform = detectPlatform();
+      const githubSlug = platform === 'github' ? parseRepoSlug() : null;
+      if (platform === 'github' && !githubSlug) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                ok: false,
+                error: 'could not parse github repo slug from origin url',
+              }),
+            },
+          ],
+        };
+      }
       const openIssues: number[] = [];
 
       for (const issue of prevWave.issues ?? []) {
         try {
           const info =
             platform === 'github'
-              ? fetchGithubIssueState(issue.number)
-              : fetchGitlabIssueState(issue.number);
-          if (info.state !== 'CLOSED') {
+              ? fetchGithubClosureInfo(issue.number, githubSlug as string)
+              : fetchGitlabClosureInfo(issue.number);
+          if (info.state !== 'CLOSED' || !info.closedByMergedPR) {
             openIssues.push(issue.number);
           }
         } catch {

--- a/tests/wave_previous_merged.test.ts
+++ b/tests/wave_previous_merged.test.ts
@@ -12,6 +12,34 @@ const mockExecSync = mock((cmd: string, _opts?: unknown) => {
 
 mock.module('child_process', () => ({ execSync: mockExecSync }));
 
+// Helper to build a GraphQL response matching what `gh api graphql` returns
+// for the wave_previous_merged closure query. `merged` controls whether the
+// linked PR counts as a merged closure; `closerIsPR` controls the timeline
+// fallback. Default (both null) represents an OPEN issue.
+function ghClosureResponse(opts: {
+  state: 'OPEN' | 'CLOSED';
+  mergedPRs?: boolean[];
+  closerIsPR?: boolean;
+}): string {
+  return JSON.stringify({
+    data: {
+      repository: {
+        issue: {
+          state: opts.state,
+          closedByPullRequestsReferences: {
+            nodes: (opts.mergedPRs ?? []).map((merged) => ({ merged })),
+          },
+          timelineItems: {
+            nodes: opts.closerIsPR
+              ? [{ closer: { __typename: 'PullRequest' } }]
+              : [],
+          },
+        },
+      },
+    },
+  });
+}
+
 const { default: handler } = await import('../handlers/wave_previous_merged.ts');
 
 let fixtureDir = '';
@@ -52,7 +80,7 @@ describe('wave_previous_merged handler', () => {
     expect(typeof handler.execute).toBe('function');
   });
 
-  test('all_merged_returns_true — mock gh returning CLOSED for all', async () => {
+  test('all_merged_returns_true — every issue closed by a merged PR', async () => {
     const plan = {
       phases: [
         {
@@ -73,7 +101,7 @@ describe('wave_previous_merged handler', () => {
     await setupFixture(plan, state);
     execMockFn = (cmd: string) => {
       if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
-      return JSON.stringify({ state: 'closed' });
+      return ghClosureResponse({ state: 'CLOSED', mergedPRs: [true], closerIsPR: true });
     };
     const result = await handler.execute({});
     const parsed = parseResult(result);
@@ -81,6 +109,54 @@ describe('wave_previous_merged handler', () => {
     expect(parsed.previous_wave_id).toBe('w1');
     expect(parsed.all_merged).toBe(true);
     expect(parsed.open_issues).toEqual([]);
+  });
+
+  test('body_keyword_closure — Closes #N body closure counts as merged', async () => {
+    // Repro of #183 from cc-workflow beget: an issue CLOSED via `Closes #N`
+    // body keyword should resolve as merged. The GraphQL response populates
+    // `closedByPullRequestsReferences` even though the REST events API
+    // returns `commit_id: null` for this closure style.
+    const plan = {
+      phases: [{ waves: [{ id: 'w1', issues: [{ number: 10 }] }, { id: 'w2', issues: [] }] }],
+    };
+    const state = {
+      current_wave: 'w2',
+      waves: { w1: { status: 'completed' }, w2: { status: 'in_progress' } },
+    };
+    await setupFixture(plan, state);
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/bakeb7j0/beget.git\n';
+      // Classic body-keyword shape: timelineItems.closer is PullRequest AND
+      // closedByPullRequestsReferences lists the merged PR.
+      return ghClosureResponse({ state: 'CLOSED', mergedPRs: [true], closerIsPR: true });
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.all_merged).toBe(true);
+    expect(parsed.open_issues).toEqual([]);
+  });
+
+  test('manually_closed_not_planned — CLOSED without merged PR stays in open_issues', async () => {
+    // Semantic guard: the tool claims "closed via MERGED PR", so a manually
+    // closed ("not planned") issue with no linked merged PR must NOT count.
+    const plan = {
+      phases: [{ waves: [{ id: 'w1', issues: [{ number: 42 }] }, { id: 'w2', issues: [] }] }],
+    };
+    const state = {
+      current_wave: 'w2',
+      waves: { w1: { status: 'completed' }, w2: { status: 'in_progress' } },
+    };
+    await setupFixture(plan, state);
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      return ghClosureResponse({ state: 'CLOSED', mergedPRs: [], closerIsPR: false });
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.all_merged).toBe(false);
+    expect(parsed.open_issues).toEqual([42]);
   });
 
   test('some_open_returns_list — mix of closed/open issues', async () => {
@@ -104,16 +180,62 @@ describe('wave_previous_merged handler', () => {
     await setupFixture(plan, state);
     execMockFn = (cmd: string) => {
       if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
-      if (cmd.includes('gh issue view 1')) return JSON.stringify({ state: 'closed' });
-      if (cmd.includes('gh issue view 2')) return JSON.stringify({ state: 'open' });
-      if (cmd.includes('gh issue view 3')) return JSON.stringify({ state: 'open' });
-      return JSON.stringify({ state: 'closed' });
+      if (cmd.includes('num=1'))
+        return ghClosureResponse({ state: 'CLOSED', mergedPRs: [true] });
+      if (cmd.includes('num=2')) return ghClosureResponse({ state: 'OPEN' });
+      if (cmd.includes('num=3')) return ghClosureResponse({ state: 'OPEN' });
+      return ghClosureResponse({ state: 'CLOSED', mergedPRs: [true] });
     };
     const result = await handler.execute({});
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
     expect(parsed.all_merged).toBe(false);
     expect(parsed.open_issues).toEqual([2, 3]);
+  });
+
+  test('pr_merged_without_timeline_closer — merged PR ref alone is sufficient', async () => {
+    // Covers the case where the ClosedEvent's closer is a commit (trailer
+    // closure) rather than a PullRequest, but the PR is still listed in
+    // closedByPullRequestsReferences. The `merged` flag there should be
+    // enough on its own.
+    const plan = {
+      phases: [{ waves: [{ id: 'w1', issues: [{ number: 5 }] }, { id: 'w2', issues: [] }] }],
+    };
+    const state = {
+      current_wave: 'w2',
+      waves: { w1: { status: 'completed' }, w2: { status: 'in_progress' } },
+    };
+    await setupFixture(plan, state);
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      return ghClosureResponse({ state: 'CLOSED', mergedPRs: [true], closerIsPR: false });
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.all_merged).toBe(true);
+  });
+
+  test('gh_command_throws — issue reported as open (safe default)', async () => {
+    // Auth failure, missing repo context, network error — any gh invocation
+    // failure must land the issue in open_issues rather than crashing the
+    // handler or silently reporting success.
+    const plan = {
+      phases: [{ waves: [{ id: 'w1', issues: [{ number: 7 }] }, { id: 'w2', issues: [] }] }],
+    };
+    const state = {
+      current_wave: 'w2',
+      waves: { w1: { status: 'completed' }, w2: { status: 'in_progress' } },
+    };
+    await setupFixture(plan, state);
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      throw new Error('gh: not authenticated');
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.open_issues).toEqual([7]);
+    expect(parsed.all_merged).toBe(false);
   });
 
   test('no_previous_wave — first wave case returns ok:true with null id', async () => {


### PR DESCRIPTION
## Summary

Fixes #183 — `wave_previous_merged` false-positively reported merged issues as still-open when the closing PR used `Closes #N` body-keyword closure (the GitHub-recommended default). Two layered defects: (1) the semantic check was just `state === 'CLOSED'`, ignoring whether a merged PR was responsible; (2) `gh issue view N` ran without `--repo`, so it threw whenever the MCP server's cwd wasn't inside the target repo — and a throw falls into the catch block that pushes the issue to `open_issues`.

Switched to `gh api graphql` with explicit `owner`/`repo` arguments. Query pulls `issue.state`, `closedByPullRequestsReferences{merged}`, and `timelineItems[ClosedEvent].closer.__typename`. Decision rule: closed-via-merged-PR iff state is `CLOSED` AND (any linked PR has `merged: true` OR the closer is a `PullRequest`). Either signal alone produces false negatives in edge cases, so the OR is load-bearing.

## Changes

- `handlers/wave_previous_merged.ts` — dropped `fetchGithubIssueState` (state-only REST); added `fetchGithubClosureInfo` (GraphQL, returns `{state, closedByMergedPR}`). Per-issue loop check is now `!CLOSED || !closedByMergedPR → open_issues[]`. Explicit `-F owner -F repo` from `parseRepoSlug()` removes the cwd dependency that manifested the #183 repro. Slug segments validated against `[A-Za-z0-9._-]` before shell interpolation to close a shell-injection class via adversarial git remote URLs (code-reviewer finding at confidence 83, fixed inline).
- `tests/wave_previous_merged.test.ts` — 4 new cases + updated 2 existing: body-keyword closure (the #183 repro), manual `not_planned` close (stays in `open_issues` now that semantics are tight), PR-ref-without-timeline-closer (commit-trailer style), gh-command-throws (preserves safe default).
- GitLab path deliberately unchanged — genesis-block's repro is GitHub-only; analogous GitLab strengthening is a separate feature.

## Linked Issues

Closes #183

## Test Plan

- [x] `bun test tests/wave_previous_merged.test.ts` — 10/10 pass (was 6/6)
- [x] `bun test` (full suite) — 1060/1060, no regressions
- [x] `bunx tsc --noEmit` — clean
- [x] `./scripts/ci/validate.sh` — 69/69 per-tool assertions passed
- [x] `trivy fs --scanners vuln --severity HIGH,CRITICAL` — 0 findings
- [x] Live GraphQL call against `Wave-Engineering/claudecode-workflow#382` (closed by merged PR #383, body-keyword style) — returns `state=CLOSED, closedByPullRequestsReferences.nodes=[{merged:true}], closer.__typename=PullRequest`, which my code classifies as `closedByMergedPR: true` ✓
- [x] `feature-dev:code-reviewer` pass — 1 finding at confidence 85 (per-issue retry non-determinism) explicitly flagged as follow-up per reviewer; 1 at 83 (slug-based shell injection) fixed inline; confidence-0 items (GraphQL quoting, revert semantics) confirmed non-issues
- [ ] Post-merge live verification: re-run the `beget` Wave-2b launch that triggered #183 — unblocks genesis-block; only verifiable in a real CC session since the MCP-server-cwd interaction can't be pytest-simulated

## Follow-up (will file)

**`wave_previous_merged` per-issue retry gap** — code-reviewer 85: on transient `gh` failures mid-loop, the current catch-block-means-open behavior is non-deterministic across retries (first 50 issues succeed, last 10 fail → `open_issues: [spurious last 10]`). This PR doesn't make it worse vs. the original handler semantically, but the per-issue GraphQL call multiplies the blast radius on flaky networks. Fix path: distinguish `UNKNOWN` from `OPEN`, expose `unverified_issues: number[]` alongside `open_issues` so wavemachine can choose to retry rather than abort. Separate issue.
