### PR TITLE
fix(wave_compute): story-self fallback for single-story /prepwaves input

### DIFF
--- a/handlers/wave_compute.ts
+++ b/handlers/wave_compute.ts
@@ -9,6 +9,15 @@ const inputSchema = z.object({
   epic_ref: z.string().min(1, 'epic_ref must be a non-empty string'),
 });
 
+// Mirrors REQUIRED_SECTION_ALIASES in handlers/spec_validate_structure.ts (lines 14-18).
+// Kept in lockstep so the story-self fallback applies the same "valid spec" test
+// that /prepwaves uses upstream.
+const REQUIRED_SECTION_ALIASES: Record<string, readonly string[]> = {
+  changes: ['changes', 'implementation_steps'],
+  tests: ['tests', 'test_procedures'],
+  acceptance_criteria: ['acceptance_criteria'],
+};
+
 function fetchIssue(ref: IssueRef): { body: string; title: string } {
   const platform = detectPlatform();
   if (platform === 'github') {
@@ -174,6 +183,68 @@ const waveComputeHandler: HandlerDef = {
         }
       }
 
+      // Story-self fallback: no sub-issues found → check whether the issue
+      // itself is a valid spec. If so, treat it as a single-issue single-wave
+      // plan. If not, error loudly (do NOT silently return an empty plan).
+      if (dedupedSubs.length === 0) {
+        const presence: Record<string, boolean> = {};
+        for (const [canonical, aliases] of Object.entries(REQUIRED_SECTION_ALIASES)) {
+          presence[`has_${canonical}`] = aliases.some(
+            alias => epicSections[alias] && epicSections[alias].trim().length > 0,
+          );
+        }
+        const specValid =
+          presence.has_changes && presence.has_tests && presence.has_acceptance_criteria;
+        if (!specValid) {
+          const missing = Object.entries(REQUIRED_SECTION_ALIASES)
+            .filter(([canonical]) => !presence[`has_${canonical}`])
+            .map(([canonical]) => canonical);
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({
+                  ok: false,
+                  error: `no sub-issues found and epic spec is missing required sections: ${missing.join(', ')}`,
+                  missing_sections: missing,
+                }),
+              },
+            ],
+          };
+        }
+        const selfRef = slug ? `${slug}#${ref.number}` : `#${ref.number}`;
+        const selfNode: DepNode = {
+          ref: selfRef,
+          title: epicData.title,
+          depends_on: [],
+        };
+        const selfResult = computeWaves([selfNode]);
+        const selfResponse: {
+          ok: true;
+          epic_ref: string;
+          waves: typeof selfResult.waves;
+          topology: string;
+          reason: string;
+          total_issues: number;
+          fetched_count: number;
+          fallback_reason: string;
+        } = {
+          ok: true,
+          epic_ref: args.epic_ref,
+          waves: selfResult.waves,
+          topology: selfResult.topology,
+          reason: selfResult.reason,
+          total_issues: selfResult.total_issues,
+          fetched_count: 1,
+          fallback_reason: 'story-self',
+        };
+        return {
+          content: [
+            { type: 'text' as const, text: JSON.stringify(selfResponse) },
+          ],
+        };
+      }
+
       // Fetch dependencies for each sub-issue.
       const nodes: DepNode[] = [];
       const failures: string[] = [];
@@ -241,6 +312,7 @@ const waveComputeHandler: HandlerDef = {
         total_issues: number;
         fetched_count: number;
         warnings?: string[];
+        fallback_reason?: string;
       } = {
         ok: true,
         epic_ref: args.epic_ref,

--- a/tests/wave_compute.test.ts
+++ b/tests/wave_compute.test.ts
@@ -223,6 +223,92 @@ describe('wave_compute handler', () => {
     expect(parsed.error).toContain('all 2 spec fetches failed');
   });
 
+  test('story_self_fallback — no sub-issues, valid spec → single-wave plan', async () => {
+    // Story body has all three required sections but no ## Sub-Issues section.
+    const storyBody = `## Changes
+
+- Do the thing.
+
+## Tests
+
+- Verify the thing.
+
+## Acceptance Criteria
+
+- [ ] Thing done.
+`;
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      if (cmd.includes('gh issue view 398')) {
+        return JSON.stringify({ body: storyBody, title: 'Story 398' });
+      }
+      return '';
+    };
+    const result = await handler.execute({ epic_ref: '#398' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.waves.length).toBe(1);
+    expect(parsed.waves[0].issues.length).toBe(1);
+    expect(parsed.waves[0].issues[0].ref).toBe('org/repo#398');
+    expect(parsed.topology).toBe('serial');
+    expect(parsed.reason).toBe('single issue (trivial)');
+    expect(parsed.fallback_reason).toBe('story-self');
+    expect(parsed.total_issues).toBe(1);
+    expect(parsed.fetched_count).toBe(1);
+  });
+
+  test('story_self_fallback — no sub-issues, invalid spec → errors loudly', async () => {
+    // Story body missing ## Acceptance Criteria → must NOT silently return empty.
+    const storyBody = `## Changes
+
+- Do the thing.
+
+## Tests
+
+- Verify the thing.
+`;
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      if (cmd.includes('gh issue view 398')) {
+        return JSON.stringify({ body: storyBody, title: 'Story 398' });
+      }
+      return '';
+    };
+    const result = await handler.execute({ epic_ref: '#398' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    // Must NOT be the old silent-empty shape.
+    expect(parsed.reason).not.toBe('no issues');
+    expect(parsed.waves).toBeUndefined();
+    // Error must name what's missing.
+    expect(parsed.error).toContain('acceptance_criteria');
+    expect(parsed.missing_sections).toEqual(['acceptance_criteria']);
+  });
+
+  // Regression: epic with sub-issues continues to work as before.
+  // The existing `linear_chain_produces_serial_topology`,
+  // `independent_issues_produce_single_parallel_wave`, `diamond_dependency`,
+  // and `fetched_count — all success` tests exercise the multi-sub-issue path.
+  // This test double-checks that the fallback logic does NOT fire when sub-issues exist.
+  test('epic_with_subissues_regression — fallback does not fire', async () => {
+    const epicBody = `## Sub-Issues
+
+- #5 first
+- #6 second
+`;
+    const subs: Record<string, { body: string; title?: string }> = {
+      'org/repo#5': { body: '## Dependencies\nNone\n', title: 'first' },
+      'org/repo#6': { body: '## Dependencies\nNone\n', title: 'second' },
+    };
+    mockGraph(epicBody, subs);
+    const result = await handler.execute({ epic_ref: '#100' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.fallback_reason).toBeUndefined();
+    expect(parsed.total_issues).toBe(2);
+    expect(parsed.waves[0].issues.length).toBe(2);
+  });
+
   test('epic_fetch_failure_surfaces_loudly', async () => {
     execMockFn = (cmd: string) => {
       if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';


### PR DESCRIPTION
## Summary

Adds a story-self fallback to `wave_compute`: when an issue has no sub-issues but is itself a valid spec (has `## Changes`, `## Tests`, `## Acceptance Criteria`), return a 1-issue single-wave plan with `fallback_reason: 'story-self'` instead of a silent empty result. Missing sections surface a clear error.

Part of epic #189 (v2 rollout bug fixes, round 1) — exercised the v2 parallel-flight path from claudecode-workflow's orchestrator.

## Changes

- `handlers/wave_compute.ts`: fallback branch when `dedupedSubs.length === 0`; reuses `parseSections` and `computeWaves`; adds `REQUIRED_SECTION_ALIASES` constant mirroring `spec_validate_structure.ts`.
- Response type literal extended with optional `fallback_reason?: string`.

## Test Plan

- 13 tests pass in `tests/wave_compute.test.ts` (10 pre-existing + 3 new)
- Full suite: 1087/0
- `bun run lint` clean
- New cases: valid-spec fallback, invalid-spec error surfaces `missing_sections`, epic-with-subissues regression

## Linked Issues

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)