### PR TITLE
fix(wave_init): collision guard + rich success payload in extend mode

### DIFF
--- a/handlers/wave_init.ts
+++ b/handlers/wave_init.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'child_process';
 import { writeFileSync } from 'fs';
+import { join } from 'path';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
 
@@ -10,6 +11,27 @@ const inputSchema = z.object({
 
 type Input = z.infer<typeof inputSchema>;
 
+interface PlanWave {
+  id?: string;
+  issues?: unknown[];
+}
+
+interface PlanPhase {
+  waves?: PlanWave[];
+}
+
+interface PlanData {
+  phases?: PlanPhase[];
+}
+
+interface StateData {
+  waves?: Record<string, unknown>;
+}
+
+interface PhasesWavesData {
+  phases?: Array<{ waves?: unknown[] }>;
+}
+
 function projectDir(): string {
   return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
 }
@@ -18,6 +40,54 @@ function writePlanFile(planJson: string): string {
   const path = `/tmp/wave-init-plan-${Date.now()}-${Math.floor(Math.random() * 1e6)}.json`;
   writeFileSync(path, planJson);
   return path;
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  return await Bun.file(path).exists();
+}
+
+async function readJson(path: string): Promise<unknown> {
+  return await Bun.file(path).json();
+}
+
+async function statusDir(root: string): Promise<string> {
+  // Prefer .sdlc/waves/ if .sdlc/ exists; otherwise fall back to .claude/status/.
+  const sdlc = join(root, '.sdlc');
+  if (await fileExists(sdlc)) return join(sdlc, 'waves');
+  return join(root, '.claude', 'status');
+}
+
+function countIssuesFromPlan(plan: PlanData): {
+  phases_added: number;
+  waves_added: number;
+  issues_added: number;
+} {
+  const phases = plan.phases ?? [];
+  let waves_added = 0;
+  let issues_added = 0;
+  for (const phase of phases) {
+    for (const wave of phase.waves ?? []) {
+      waves_added += 1;
+      issues_added += (wave.issues ?? []).length;
+    }
+  }
+  return {
+    phases_added: phases.length,
+    waves_added,
+    issues_added,
+  };
+}
+
+function extractPlanWaveIds(plan: PlanData): string[] {
+  const ids: string[] = [];
+  for (const phase of plan.phases ?? []) {
+    for (const wave of phase.waves ?? []) {
+      if (typeof wave.id === 'string' && wave.id.length > 0) {
+        ids.push(wave.id);
+      }
+    }
+  }
+  return ids;
 }
 
 const waveInitHandler: HandlerDef = {
@@ -35,17 +105,116 @@ const waveInitHandler: HandlerDef = {
       };
     }
 
+    // Extend-mode collision pre-scan: defense in depth on top of the CLI's
+    // own collision guard. Parse the plan, read the existing state file, and
+    // refuse before touching the CLI if any wave IDs already exist.
+    if (args.extend) {
+      let planParsed: PlanData;
+      try {
+        planParsed = JSON.parse(args.plan_json) as PlanData;
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                ok: false,
+                error: `plan_json is not valid JSON: ${detail}`,
+              }),
+            },
+          ],
+        };
+      }
+
+      try {
+        const dir = await statusDir(projectDir());
+        const statePath = join(dir, 'state.json');
+
+        if (!(await fileExists(statePath))) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({ ok: false, error: 'no existing plan found' }),
+              },
+            ],
+          };
+        }
+
+        const state = (await readJson(statePath)) as StateData;
+        const existingIds = new Set(Object.keys(state.waves ?? {}));
+        const incomingIds = extractPlanWaveIds(planParsed);
+        const colliding = incomingIds.filter(id => existingIds.has(id));
+
+        if (colliding.length > 0) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({
+                  ok: false,
+                  error: `wave ID collision: ${colliding.join(', ')} already exist`,
+                  colliding_ids: colliding,
+                }),
+              },
+            ],
+          };
+        }
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+        };
+      }
+    }
+
     try {
       const planFile = writePlanFile(args.plan_json);
       const extendFlag = args.extend ? ' --extend' : '';
       const cmd = `wave-status init${extendFlag} ${planFile}`;
-      const output = execSync(cmd, {
+      execSync(cmd, {
         cwd: projectDir(),
         encoding: 'utf8',
       });
+
+      // Rich success payload: count what the plan added, then re-read the
+      // phases-waves.json the CLI just wrote to report project totals.
+      const planParsed = JSON.parse(args.plan_json) as PlanData;
+      const { phases_added, waves_added, issues_added } = countIssuesFromPlan(planParsed);
+
+      let total_phases = 0;
+      let total_waves = 0;
+      try {
+        const dir = await statusDir(projectDir());
+        const phasesPath = join(dir, 'phases-waves.json');
+        if (await fileExists(phasesPath)) {
+          const phasesData = (await readJson(phasesPath)) as PhasesWavesData;
+          const phases = phasesData.phases ?? [];
+          total_phases = phases.length;
+          for (const p of phases) {
+            total_waves += (p.waves ?? []).length;
+          }
+        }
+      } catch {
+        // If the phases file can't be read, leave totals at 0 rather than
+        // failing the whole call — the CLI already succeeded.
+      }
+
       return {
         content: [
-          { type: 'text' as const, text: JSON.stringify({ ok: true, data: output.trim() }) },
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              mode: args.extend ? 'extend' : 'init',
+              phases_added,
+              waves_added,
+              issues_added,
+              total_phases,
+              total_waves,
+            }),
+          },
         ],
       };
     } catch (err) {

--- a/tests/wave_init.test.ts
+++ b/tests/wave_init.test.ts
@@ -16,6 +16,8 @@ mock.module('fs', () => ({ writeFileSync: mockWriteFileSync }));
 
 const { default: handler } = await import('../handlers/wave_init.ts');
 
+const ORIGINAL_ENV = process.env.CLAUDE_PROJECT_DIR;
+
 function resetMocks() {
   lastExecCall = '';
   execMockFn = () => 'wave plan initialized\n';
@@ -27,9 +29,36 @@ function parseResult(result: { content: Array<{ type: string; text: string }> })
   return JSON.parse(result.content[0].text);
 }
 
+async function setupStatusFixture(
+  state: object | null,
+  phasesWaves: object | null = null
+): Promise<string> {
+  const fixtureDir = `/tmp/wave-init-fixture-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+  const statusDir = `${fixtureDir}/.claude/status`;
+  if (state !== null) {
+    await Bun.write(`${statusDir}/state.json`, JSON.stringify(state));
+  }
+  if (phasesWaves !== null) {
+    await Bun.write(`${statusDir}/phases-waves.json`, JSON.stringify(phasesWaves));
+  }
+  process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+  return fixtureDir;
+}
+
+function clearEnv() {
+  if (ORIGINAL_ENV === undefined) {
+    delete process.env.CLAUDE_PROJECT_DIR;
+  } else {
+    process.env.CLAUDE_PROJECT_DIR = ORIGINAL_ENV;
+  }
+}
+
 describe('wave_init handler', () => {
   beforeEach(resetMocks);
-  afterEach(resetMocks);
+  afterEach(() => {
+    resetMocks();
+    clearEnv();
+  });
 
   test('handler exports valid HandlerDef shape', () => {
     expect(handler).toBeDefined();
@@ -42,6 +71,10 @@ describe('wave_init handler', () => {
 
   // ---- happy_path ---------------------------------------------------------
   test('happy_path — invokes wave-status init with plan file', async () => {
+    // Fresh init (no --extend) does NOT read state.json, so no fixture required.
+    // Point CLAUDE_PROJECT_DIR at a tempdir so the post-CLI phases-waves read
+    // simply reports 0 totals.
+    await setupStatusFixture(null);
     const planJson = JSON.stringify({ project: 'foo', phases: [] });
     const result = await handler.execute({ plan_json: planJson });
     expect(mockExecSync.mock.calls.length).toBe(1);
@@ -49,17 +82,19 @@ describe('wave_init handler', () => {
     expect(lastExecCall).not.toContain('--extend');
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
-    expect(parsed.data).toBe('wave plan initialized');
+    expect(parsed.mode).toBe('init');
   });
 
   test('happy_path — passes --extend flag when extend=true', async () => {
-    const planJson = JSON.stringify({ phases: [{ name: 'extra' }] });
+    await setupStatusFixture({ waves: {} }, { phases: [] });
+    const planJson = JSON.stringify({ phases: [{ name: 'extra', waves: [] }] });
     await handler.execute({ plan_json: planJson, extend: true });
     expect(lastExecCall).toContain('wave-status init');
     expect(lastExecCall).toContain('--extend');
   });
 
   test('happy_path — writes plan_json to a temp file', async () => {
+    await setupStatusFixture(null);
     const planJson = JSON.stringify({ project: 'cc-workflow' });
     await handler.execute({ plan_json: planJson });
     expect(mockWriteFileSync.mock.calls.length).toBe(1);
@@ -71,6 +106,7 @@ describe('wave_init handler', () => {
 
   // ---- cli_error ----------------------------------------------------------
   test('cli_error — returns ok:false on non-zero exit, does not throw', async () => {
+    await setupStatusFixture(null);
     execMockFn = () => {
       throw new Error('wave-status: refusing to overwrite existing plan');
     };
@@ -99,5 +135,105 @@ describe('wave_init handler', () => {
     const result = await handler.execute({ plan_json: 123 });
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(false);
+  });
+
+  // ---- extend_collision ---------------------------------------------------
+  test('extend_collision — returns ok:false with colliding_ids, does NOT invoke CLI', async () => {
+    await setupStatusFixture(
+      { waves: { 'W-1': { status: 'completed' } } },
+      { phases: [{ waves: [{ id: 'W-1' }] }] }
+    );
+    const planJson = JSON.stringify({
+      phases: [{ name: 'p1', waves: [{ id: 'W-1', issues: [{ number: 10 }] }] }],
+    });
+    const result = await handler.execute({ plan_json: planJson, extend: true });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(Array.isArray(parsed.colliding_ids)).toBe(true);
+    expect(parsed.colliding_ids).toContain('W-1');
+    expect(mockExecSync.mock.calls.length).toBe(0);
+  });
+
+  // ---- extend_no_collision ------------------------------------------------
+  test('extend_no_collision — rich payload on success', async () => {
+    await setupStatusFixture(
+      { waves: { 'W-1': { status: 'completed' } } },
+      {
+        phases: [
+          { waves: [{ id: 'W-1' }] },
+          { waves: [{ id: 'W-2' }] },
+        ],
+      }
+    );
+    const planJson = JSON.stringify({
+      phases: [
+        {
+          name: 'p2',
+          waves: [
+            {
+              id: 'W-2',
+              issues: [
+                { number: 20 },
+                { number: 21 },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const result = await handler.execute({ plan_json: planJson, extend: true });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.mode).toBe('extend');
+    expect(parsed.waves_added).toBeGreaterThanOrEqual(1);
+    expect(parsed.phases_added).toBeGreaterThanOrEqual(1);
+    expect(parsed.issues_added).toBe(2);
+    expect(typeof parsed.total_phases).toBe('number');
+    expect(typeof parsed.total_waves).toBe('number');
+    expect(mockExecSync.mock.calls.length).toBe(1);
+  });
+
+  // ---- fresh_init_rich_payload --------------------------------------------
+  test('fresh_init_rich_payload — non-extend path returns numeric totals', async () => {
+    await setupStatusFixture(null, {
+      phases: [
+        { waves: [{ id: 'W-1' }, { id: 'W-2' }] },
+      ],
+    });
+    const planJson = JSON.stringify({
+      phases: [
+        {
+          name: 'p1',
+          waves: [
+            { id: 'W-1', issues: [{ number: 1 }] },
+            { id: 'W-2', issues: [{ number: 2 }, { number: 3 }] },
+          ],
+        },
+      ],
+    });
+    const result = await handler.execute({ plan_json: planJson, extend: false });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.mode).toBe('init');
+    expect(typeof parsed.phases_added).toBe('number');
+    expect(parsed.phases_added).toBe(1);
+    expect(parsed.waves_added).toBe(2);
+    expect(parsed.issues_added).toBe(3);
+    expect(typeof parsed.total_waves).toBe('number');
+  });
+
+  // ---- extend_missing_state -----------------------------------------------
+  test('extend_missing_state — returns ok:false without throwing', async () => {
+    // Point at a fresh empty tempdir; no state.json exists.
+    const fixtureDir = `/tmp/wave-init-empty-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+    process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+    const planJson = JSON.stringify({
+      phases: [{ name: 'p1', waves: [{ id: 'W-9', issues: [] }] }],
+    });
+    const result = await handler.execute({ plan_json: planJson, extend: true });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(typeof parsed.error).toBe('string');
+    expect(mockExecSync.mock.calls.length).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Two correlated fixes:

1. **Collision pre-scan (extend mode):** parse `plan_json`, read `state.json`; reject with `{ok:false, colliding_ids:[...]}` if any wave IDs already exist, before touching the CLI. Prevents silent overwrite of completed-wave records. Defense-in-depth on top of the Python CLI's own guard.
2. **Rich success payload:** replace `{ok:true, data:""}` with `{ok:true, mode, phases_added, waves_added, issues_added, total_phases, total_waves}` so callers can verify the merge without a follow-up file read.

Part of epic #189.

## Changes

- `handlers/wave_init.ts`: pre-scan block (JSON validation → state read → ID intersection); `statusDir`/`fileExists`/`readJson` helpers (pattern copied from `wave_next_pending.ts`); rich payload construction reading `phases-waves.json` post-CLI.

## Test Plan

- 12 tests pass in `tests/wave_init.test.ts` (8 pre-existing + 4 new)
- Full suite delta: +4 passing, 0 new failures
- New cases: colliding reject (CLI not invoked), non-colliding rich payload, fresh init rich payload, missing-state structured error

Note: 3 existing happy-path tests updated to assert the new payload shape instead of the old `data` field — the response contract genuinely changed per the fix.

## Linked Issues

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)