### PR TITLE
fix(ci_wait_run): merge-queue-only CI fallback via event field

### DIFF
--- a/handlers/ci_wait_run.ts
+++ b/handlers/ci_wait_run.ts
@@ -5,7 +5,12 @@
 import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform, gitlabApiCiList, type GitlabPipeline } from '../lib/glab.js';
+import {
+  detectPlatform,
+  gitlabApiCiList,
+  parseRepoSlug,
+  type GitlabPipeline,
+} from '../lib/glab.js';
 import { log } from '../logger.js';
 
 const inputSchema = z
@@ -27,7 +32,15 @@ const NO_RUN_YET_WINDOW_SEC = 60; // wait up to 60s for a run to appear before m
 const NO_RUN_YET_POLL_SEC = 5; // how often to poll during the no-run-yet window
 
 // Final-status domain (what we return to the caller).
-type FinalStatus = 'success' | 'failure' | 'cancelled' | 'timed_out';
+// `not_applicable` covers merge-queue-only repos whose CI has no push:main
+// trigger — there's nothing to wait on, but the merge_group run that gated
+// the PR already ran and we can surface that fact distinctly from failure.
+type FinalStatus =
+  | 'success'
+  | 'failure'
+  | 'cancelled'
+  | 'timed_out'
+  | 'not_applicable';
 
 // --- injectable sleep (tests replace with a no-op) ---
 let sleepFn: (ms: number) => Promise<void> = (ms) =>
@@ -74,6 +87,23 @@ function shellQuote(value: string): string {
   return value.replace(/(["\\$`])/g, '\\$1');
 }
 
+// Resolve a branch ref to its HEAD commit SHA via `gh api`.
+// Only invoked when we need to compare a branch ref against a run.headSha
+// (e.g. merge-queue fallback). Uses the same authenticated gh subprocess
+// pattern the rest of the handler relies on. Returns null if resolution
+// fails for any reason — the caller treats that as "no SHA match".
+function resolveBranchToSha(slug: string, branch: string): string | null {
+  try {
+    const sha = exec(
+      `gh api repos/${slug}/git/refs/heads/${shellQuote(branch)} --jq .object.sha`
+    );
+    if (/^[0-9a-f]{40}$/i.test(sha)) return sha;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 // --- GitHub polling ---
 
 function githubListCmd(ref: string, workflowName: string | undefined): string {
@@ -83,7 +113,7 @@ function githubListCmd(ref: string, workflowName: string | undefined): string {
     ? ` --workflow "${shellQuote(workflowName)}"`
     : '';
   // Pull a generous set of fields so we can surface good error messages.
-  return `gh run list ${refFlag}${workflowFlag} --limit 20 --json databaseId,name,status,conclusion,url,headSha,headBranch,workflowName,createdAt`;
+  return `gh run list ${refFlag}${workflowFlag} --limit 20 --json databaseId,name,status,conclusion,url,headSha,headBranch,workflowName,createdAt,event`;
 }
 
 interface GithubRun {
@@ -96,6 +126,7 @@ interface GithubRun {
   headSha: string;
   headBranch?: string;
   createdAt?: string;
+  event?: string;
 }
 
 function fetchGithubRuns(
@@ -283,7 +314,7 @@ function normalizeConclusion(
 const ciWaitRunHandler: HandlerDef = {
   name: 'ci_wait_run',
   description:
-    "Block on a CI workflow/pipeline run for a commit SHA or branch ref, polling server-side until it completes or times out. Returns the final status without burning agent tokens in a busy-wait loop.",
+    "Block on a CI workflow/pipeline run for a commit SHA or branch ref, polling server-side until it completes or times out. Returns the final status without burning agent tokens in a busy-wait loop. Merge-queue-only GitHub repos (workflows gated on `merge_group`/`pull_request` with no `push` trigger) are handled specially: if no push-triggered runs exist for the ref but a `merge_group` run matches its HEAD SHA, returns `final_status: \"not_applicable\"` with `reason: \"merge_group_validated\"` — distinguishable from a real failure.",
   inputSchema,
   async execute(rawArgs: unknown) {
     let args: Input;
@@ -309,6 +340,74 @@ const ciWaitRunHandler: HandlerDef = {
       Math.floor((Date.now() - startMs) / 1000);
 
     try {
+      // --- Phase 0 (GitHub only): merge-queue pre-flight ---
+      // If the ref has NO push-triggered runs but DOES have a merge_group run
+      // matching its HEAD SHA, treat that as validation — don't wait for a
+      // push-triggered run that will never arrive.
+      if (platform === 'github') {
+        const initialRuns = fetchGithubRuns(ref, workflowName);
+        if (initialRuns.length > 0) {
+          const anyPush = initialRuns.some((r) => r.event === 'push');
+          if (!anyPush) {
+            // Resolve ref to a HEAD SHA for comparison against run.headSha.
+            let headSha: string | null = isSha(ref) ? ref.toLowerCase() : null;
+            if (!headSha) {
+              const slug = parseRepoSlug();
+              if (slug) headSha = resolveBranchToSha(slug, ref);
+            }
+            const mergeGroupMatch = initialRuns.find(
+              (r) =>
+                r.event === 'merge_group' &&
+                headSha !== null &&
+                r.headSha?.toLowerCase() === headSha
+            );
+            if (mergeGroupMatch) {
+              return {
+                content: [
+                  {
+                    type: 'text' as const,
+                    text: JSON.stringify({
+                      ok: true,
+                      final_status: 'not_applicable' satisfies FinalStatus,
+                      reason: 'merge_group_validated',
+                      run_id: mergeGroupMatch.databaseId,
+                      workflow_name:
+                        mergeGroupMatch.workflowName ??
+                        mergeGroupMatch.name ??
+                        '(unknown)',
+                      url: mergeGroupMatch.url,
+                      ref,
+                      sha: mergeGroupMatch.headSha,
+                      waited_sec: 0,
+                    }),
+                  },
+                ],
+              };
+            }
+            // No push-triggered runs and no matching merge_group run. Fail
+            // fast with a structured not_applicable error — distinguishable
+            // from a real CI failure and from a generic timeout.
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: JSON.stringify({
+                    ok: false,
+                    final_status: 'not_applicable' satisfies FinalStatus,
+                    error: `ref '${ref}' has no push-triggered workflows and no matching merge_group run found`,
+                    ref,
+                  }),
+                },
+              ],
+            };
+          }
+          // At least one push-triggered run exists — fall through to the
+          // existing poll loop. (Phase 1 will re-fetch and pick up the run.)
+        }
+        // Empty initial list → fall through; existing phase 1 handles
+        // no-run-yet window and the "no CI run found" error.
+      }
+
       // --- Phase 1: wait for a run to appear (no-run-yet window) ---
       let snapshot: RunSnapshot | null = null;
       while (elapsedSec() < NO_RUN_YET_WINDOW_SEC) {

--- a/tests/ci_wait_run.test.ts
+++ b/tests/ci_wait_run.test.ts
@@ -54,6 +54,7 @@ function ghRun(overrides: Record<string, unknown> = {}) {
     headSha: '1234567890abcdef1234567890abcdef12345678',
     headBranch: 'feature/1-demo',
     createdAt: '2026-04-07T12:00:00Z',
+    event: 'push',
     ...overrides,
   };
 }
@@ -98,8 +99,10 @@ describe('ci_wait_run handler', () => {
       sleeps.push(ms);
     });
     execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    // Three entries: pre-flight (issue #187), phase 1 initial, phase 1 post-sleep.
     execRegistry['gh run list'] = [
-      JSON.stringify([ghRun({ status: 'in_progress' })]),
+      JSON.stringify([ghRun({ status: 'in_progress' })]), // pre-flight
+      JSON.stringify([ghRun({ status: 'in_progress' })]), // phase 1 initial
       JSON.stringify([ghRun({ status: 'completed', conclusion: 'success' })]),
     ];
 
@@ -364,5 +367,134 @@ describe('ci_wait_run handler', () => {
     __setSleep(async (_ms: number) => {
       // no-op
     });
+  });
+
+  // --- Issue #187: merge-queue fallback behavior ---
+
+  // Push trigger present + success → regression coverage for the happy path.
+  // The pre-flight must see event=push on at least one run and fall through
+  // to the existing poll loop; the final_status must remain "success".
+  test('push_trigger_present_success — push-event run completes as success (regression)', async () => {
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    execRegistry['gh run list'] = JSON.stringify([
+      ghRun({
+        databaseId: 777,
+        status: 'completed',
+        conclusion: 'success',
+        event: 'push',
+      }),
+    ]);
+
+    const result = await ciWaitRunHandler.execute({ ref: 'main' });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    expect(data.final_status).toBe('success');
+    expect(data.run_id).toBe(777);
+  });
+
+  // Merge-queue-only repo + matching merge_group run → not_applicable success.
+  // Pass ref as a 40-char SHA so the handler skips branch-to-SHA resolution
+  // (no gh api call needed — exec registry is intentionally silent on it).
+  test('merge_group_only_sha_match — returns not_applicable success', async () => {
+    const sha = 'b'.repeat(40);
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    execRegistry['gh run list'] = JSON.stringify([
+      ghRun({
+        databaseId: 555,
+        status: 'completed',
+        conclusion: 'success',
+        event: 'merge_group',
+        headSha: sha,
+        url: 'https://github.com/org/repo/actions/runs/555',
+      }),
+    ]);
+
+    const result = await ciWaitRunHandler.execute({ ref: sha });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    expect(data.final_status).toBe('not_applicable');
+    expect(data.reason).toBe('merge_group_validated');
+    expect(data.run_id).toBe(555);
+    expect(data.url).toBe('https://github.com/org/repo/actions/runs/555');
+    expect(data.waited_sec).toBe(0);
+  });
+
+  // Merge-queue-only repo + no matching merge_group run → not_applicable error.
+  test('merge_group_only_no_sha_match — returns not_applicable error', async () => {
+    const refSha = 'c'.repeat(40);
+    const otherSha = 'd'.repeat(40);
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    execRegistry['gh run list'] = JSON.stringify([
+      ghRun({
+        databaseId: 444,
+        status: 'completed',
+        conclusion: 'success',
+        event: 'merge_group',
+        headSha: otherSha,
+      }),
+    ]);
+
+    const result = await ciWaitRunHandler.execute({ ref: refSha });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+    expect(data.final_status).toBe('not_applicable');
+    expect(data.error as string).toContain('no push-triggered workflows');
+    expect(data.ref).toBe(refSha);
+  });
+
+  // Empty run list → existing "no CI run found" path must still fire.
+  // The pre-flight must NOT mask this case; fall through to Phase 1 / error.
+  test('empty_run_list — preserves existing no-run-found error', async () => {
+    const realDateNow = Date.now;
+    let fakeNow = realDateNow();
+    Date.now = () => fakeNow;
+    __setSleep(async (ms: number) => {
+      fakeNow += ms;
+    });
+    try {
+      execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+      execRegistry['gh run list'] = JSON.stringify([]); // sticky empty
+
+      const result = await ciWaitRunHandler.execute({
+        ref: 'main',
+        timeout_sec: 30,
+      });
+      const data = parseResult(result.content);
+      expect(data.ok).toBe(false);
+      expect((data.error as string).toLowerCase()).toContain('no ci run found');
+      // Must NOT be the merge-queue error path.
+      expect(data.final_status).toBeUndefined();
+    } finally {
+      Date.now = realDateNow;
+    }
+  });
+
+  // Timeout still fires for push-triggered runs that never complete.
+  // Verifies the pre-flight doesn't swallow the existing timeout path.
+  test('timeout_still_fires_for_push_triggered — push run stays in_progress, times out', async () => {
+    const realDateNow = Date.now;
+    let fakeNow = realDateNow();
+    Date.now = () => fakeNow;
+    __setSleep(async (ms: number) => {
+      fakeNow += ms;
+    });
+    try {
+      execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+      execRegistry['gh run list'] = JSON.stringify([
+        ghRun({ status: 'in_progress', event: 'push' }),
+      ]);
+
+      const result = await ciWaitRunHandler.execute({
+        ref: 'main',
+        poll_interval_sec: 10,
+        timeout_sec: 30,
+      });
+      const data = parseResult(result.content);
+      expect(data.ok).toBe(true);
+      expect(data.final_status).toBe('timed_out');
+      expect(data.waited_sec as number).toBeGreaterThanOrEqual(30);
+    } finally {
+      Date.now = realDateNow;
+    }
   });
 });


### PR DESCRIPTION
## Summary

On repos whose CI is gated on `merge_group` + `pull_request` only (no `push: main` trigger), `ci_wait_run(ref=main)` previously timed out after 60s+ with a misleading "no CI run found" error — even though the merge queue had validated via the `merge_group` event and the merge had landed cleanly.

Fix: add `event` to the existing `gh run list --json` field list; detect the merge-queue-only pattern; if a `merge_group` run matches the ref's HEAD SHA, return `{ok:true, final_status:"not_applicable", reason:"merge_group_validated"}` immediately. Otherwise, structured `ok:false` error (distinguishable from a real CI failure).

Part of epic #189.

## Changes

- `handlers/ci_wait_run.ts`:
  - `gh run list --json` field list extended with `event`
  - `GithubRun` interface gains `event?: string`
  - `FinalStatus` union gains `'not_applicable'`
  - `resolveBranchToSha` helper using `gh api repos/{slug}/git/refs/heads/{branch} --jq .object.sha`
  - Phase 0 pre-flight block before the existing Phase 1 poll loop
  - Handler description string documents the merge-queue handling

**No new dependencies.** No YAML parsing. Option B of the two proposed paths — simpler than Option A.

## Test Plan

- 21 tests pass in `tests/ci_wait_run.test.ts` (16 pre-existing + 5 new)
- Full suite: 1089/0
- `bun run lint` clean
- New cases: push-trigger happy path (regression), merge_group + SHA match → success, merge_group + no SHA match → structured error, empty run list preserves existing error, timeout still fires for push-triggered runs

## Linked Issues

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)