### PR TITLE
fix(wave_next_pending): populate topology via computeWaves fallback

### DIFF
--- a/handlers/wave_next_pending.ts
+++ b/handlers/wave_next_pending.ts
@@ -1,6 +1,7 @@
 import { join } from 'path';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
+import { computeWaves, type DepNode } from '../lib/dependency_graph.js';
 
 const inputSchema = z.object({}).strict();
 
@@ -61,14 +62,33 @@ function findNextPending(plan: PlanData, state: StateData): NextPendingResult | 
     for (const wave of phase.waves ?? []) {
       const status = waves[wave.id]?.status ?? 'pending';
       if (status === 'pending') {
+        const issues = (wave.issues ?? []).map(i => ({
+          number: i.number,
+          title: i.title ?? '',
+        }));
+
+        let topology: string;
+        if (wave.topology != null) {
+          // Pass through caller-supplied topology from the plan file as-is.
+          topology = wave.topology;
+        } else {
+          // Fallback classifier sees zero-dep nodes because PlanWave doesn't store
+          // per-issue edges. Multi-issue waves without explicit deps will classify as
+          // 'parallel'; true 'mixed'/'serial' classification would require fetching
+          // issue bodies, which would make this handler network-bound — accept the
+          // limitation.
+          const nodes: DepNode[] = issues.map(i => ({
+            ref: String(i.number),
+            depends_on: [],
+          }));
+          topology = computeWaves(nodes).topology;
+        }
+
         return {
           id: wave.id,
-          issues: (wave.issues ?? []).map(i => ({
-            number: i.number,
-            title: i.title ?? '',
-          })),
+          issues,
           depends_on: wave.depends_on ?? [],
-          topology: wave.topology ?? null,
+          topology,
         };
       }
     }

--- a/tests/wave_next_pending.test.ts
+++ b/tests/wave_next_pending.test.ts
@@ -128,4 +128,108 @@ describe('wave_next_pending handler', () => {
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(false);
   });
+
+  test('single_issue_wave → topology "serial"', async () => {
+    // Plan wave has one issue and no topology field; fallback classifier
+    // should return 'serial' per computeWaves single-issue rule.
+    const plan = {
+      phases: [
+        {
+          waves: [{ id: 'w1', issues: [{ number: 101, title: 'only' }] }],
+        },
+      ],
+    };
+    const state = { waves: { w1: { status: 'pending' } } };
+    await setupFixture(plan, state);
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.wave.id).toBe('w1');
+    expect(parsed.wave.topology).toBe('serial');
+  });
+
+  test('multi_issue_wave → topology "parallel"', async () => {
+    // Plan wave has 2+ issues and no topology field. Per the architectural
+    // limitation documented in the handler, the fallback classifier sees
+    // zero-dep nodes (PlanWave doesn't store per-issue edges), so multi-issue
+    // waves classify as 'parallel' — true 'mixed'/'serial' would require
+    // fetching issue bodies.
+    const plan = {
+      phases: [
+        {
+          waves: [
+            {
+              id: 'w1',
+              issues: [
+                { number: 201, title: 'a' },
+                { number: 202, title: 'b' },
+                { number: 203, title: 'c' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const state = { waves: { w1: { status: 'pending' } } };
+    await setupFixture(plan, state);
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.wave.id).toBe('w1');
+    expect(parsed.wave.topology).toBe('parallel');
+  });
+
+  test('plan_includes_topology → pass-through (not recomputed)', async () => {
+    // Plan wave already declares topology: 'mixed'. The handler must preserve
+    // the caller-supplied value rather than recomputing it.
+    const plan = {
+      phases: [
+        {
+          waves: [
+            {
+              id: 'w1',
+              issues: [
+                { number: 301, title: 'a' },
+                { number: 302, title: 'b' },
+              ],
+              topology: 'mixed',
+            },
+          ],
+        },
+      ],
+    };
+    const state = { waves: { w1: { status: 'pending' } } };
+    await setupFixture(plan, state);
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.wave.topology).toBe('mixed');
+  });
+
+  test('no_pending_waves → wave null, no topology leak', async () => {
+    // With no pending waves, handler must return wave: null and must not
+    // emit a spurious topology value at the top level.
+    const plan = {
+      phases: [
+        {
+          waves: [
+            { id: 'w1', issues: [{ number: 401 }] },
+            { id: 'w2', issues: [{ number: 402 }, { number: 403 }] },
+          ],
+        },
+      ],
+    };
+    const state = {
+      waves: {
+        w1: { status: 'completed' },
+        w2: { status: 'completed' },
+      },
+    };
+    await setupFixture(plan, state);
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.wave).toBe(null);
+    expect(parsed).not.toHaveProperty('topology');
+  });
 });


### PR DESCRIPTION
## Summary

`wave_next_pending` returned `topology: null` for any wave whose plan entry omitted that field, forcing callers (notably `/nextwave`) to reclassify locally. Fix: delegate to `computeWaves` when the plan omits topology; pass through the plan-file value when present.

Part of epic #189.

## Architectural note (documented inline)

`PlanWave` stores no per-issue `depends_on` edges, so the fallback classifier will always return `'parallel'` for multi-issue waves or `'serial'` for single-issue waves. Full `'mixed'` classification from plan-file data alone would require network-bound issue-body fetches, which conflicts with this handler's zero-I/O design. Accept the limitation as best-effort; `wave_topology` remains the authoritative classifier for callers needing full fidelity.

## Changes

- `handlers/wave_next_pending.ts`:
  - Import `computeWaves` + `DepNode` from `lib/dependency_graph.js`
  - `findNextPending`: fallback branch when `wave.topology` is null/undefined
  - 5-line code comment documenting the architectural limitation

No type changes needed.

## Test Plan

- 9 tests pass in `tests/wave_next_pending.test.ts` (5 pre-existing + 4 new)
- Full suite: 1088/0
- `bun run lint` clean
- New cases: single-issue wave → 'serial', multi-issue → 'parallel' (with limitation comment), plan-supplied topology passes through, null wave → no topology leak

## Linked Issues

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)