### PR TITLE
fix(cross-repo): pr_* tools accept explicit repo param

### DIFF
--- a/handlers/pr_comment.ts
+++ b/handlers/pr_comment.ts
@@ -8,6 +8,10 @@ import type { HandlerDef } from '../types.js';
 const inputSchema = z.object({
   number: z.number().int().positive('number must be a positive integer'),
   body: z.string().min(1, 'body must be a non-empty string'),
+  repo: z
+    .string()
+    .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/, 'repo must be owner/repo format')
+    .optional(),
 });
 
 type Input = z.infer<typeof inputSchema>;
@@ -71,11 +75,12 @@ interface PostResult {
   url: string;
 }
 
-function postGithubComment(num: number, body: string, cwd: string): PostResult {
-  const proc = runCommand(
-    ['gh', 'pr', 'comment', String(num), '--body', body],
-    cwd,
-  );
+function postGithubComment(num: number, body: string, cwd: string, repo?: string): PostResult {
+  const cmd = ['gh', 'pr', 'comment', String(num), '--body', body];
+  if (repo !== undefined) {
+    cmd.push('--repo', repo);
+  }
+  const proc = runCommand(cmd, cwd);
   if (proc.exitCode !== 0) {
     throw new Error(`gh pr comment failed: ${proc.stderr.trim() || proc.stdout.trim()}`);
   }
@@ -87,11 +92,12 @@ function postGithubComment(num: number, body: string, cwd: string): PostResult {
   return { commentId, url };
 }
 
-function postGitlabComment(num: number, body: string, cwd: string): PostResult {
-  const proc = runCommand(
-    ['glab', 'mr', 'note', String(num), '--message', body],
-    cwd,
-  );
+function postGitlabComment(num: number, body: string, cwd: string, repo?: string): PostResult {
+  const cmd = ['glab', 'mr', 'note', String(num), '--message', body];
+  if (repo !== undefined) {
+    cmd.push('-R', repo);
+  }
+  const proc = runCommand(cmd, cwd);
   if (proc.exitCode !== 0) {
     throw new Error(`glab mr note failed: ${proc.stderr.trim() || proc.stdout.trim()}`);
   }
@@ -125,8 +131,8 @@ const prCommentHandler: HandlerDef = {
 
       const { commentId, url } =
         platform === 'github'
-          ? postGithubComment(args.number, args.body, cwd)
-          : postGitlabComment(args.number, args.body, cwd);
+          ? postGithubComment(args.number, args.body, cwd, args.repo)
+          : postGitlabComment(args.number, args.body, cwd, args.repo);
 
       return {
         content: [

--- a/handlers/pr_create.ts
+++ b/handlers/pr_create.ts
@@ -11,6 +11,10 @@ const inputSchema = z.object({
   base: z.string().min(1, 'base must be a non-empty string'),
   head: z.string().optional(),
   draft: z.boolean().optional().default(false),
+  repo: z
+    .string()
+    .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/, 'repo must be owner/repo format')
+    .optional(),
 });
 
 type Input = z.infer<typeof inputSchema>;
@@ -70,11 +74,10 @@ interface NormalizedPr {
   created: boolean;
 }
 
-function lookupGithubPr(head: string, cwd: string): NormalizedPr | null {
-  const list = run(
-    ['gh', 'pr', 'list', '--head', head, '--state', 'open', '--json', 'number,url,state,headRefName,baseRefName', '--limit', '1'],
-    cwd,
-  );
+function lookupGithubPr(head: string, cwd: string, repo?: string): NormalizedPr | null {
+  const cmd = ['gh', 'pr', 'list', '--head', head, '--state', 'open', '--json', 'number,url,state,headRefName,baseRefName', '--limit', '1'];
+  if (repo !== undefined) cmd.push('--repo', repo);
+  const list = run(cmd, cwd);
   if (list.exitCode !== 0) return null;
   const prs = JSON.parse(list.stdout) as Array<{
     number: number;
@@ -109,13 +112,14 @@ function createGithubPr(args: Input, head: string, cwd: string): NormalizedPr {
     head,
   ];
   if (args.draft) createCmd.push('--draft');
+  if (args.repo !== undefined) createCmd.push('--repo', args.repo);
 
   const result = run(createCmd, cwd);
   if (result.exitCode !== 0) {
     const errText = (result.stderr + result.stdout).toLowerCase();
     // gh says "a pull request for branch ... already exists" on duplicate
     if (errText.includes('already exists')) {
-      const existing = lookupGithubPr(head, cwd);
+      const existing = lookupGithubPr(head, cwd, args.repo);
       if (existing) return existing;
       // Lookup failed (PR may have been closed between create and lookup)
       throw new Error(`gh pr create: PR already exists for branch '${head}' but could not be found via lookup`);
@@ -132,10 +136,9 @@ function createGithubPr(args: Input, head: string, cwd: string): NormalizedPr {
   const prNumber = parseInt(numMatch[1], 10);
 
   // Fetch canonical details to normalize the response.
-  const view = run(
-    ['gh', 'pr', 'view', String(prNumber), '--json', 'number,url,state,headRefName,baseRefName'],
-    cwd,
-  );
+  const viewCmd = ['gh', 'pr', 'view', String(prNumber), '--json', 'number,url,state,headRefName,baseRefName'];
+  if (args.repo !== undefined) viewCmd.push('--repo', args.repo);
+  const view = run(viewCmd, cwd);
   if (view.exitCode !== 0) {
     throw new Error(`gh pr view failed: ${view.stderr.trim() || view.stdout.trim()}`);
   }
@@ -156,8 +159,10 @@ function createGithubPr(args: Input, head: string, cwd: string): NormalizedPr {
   };
 }
 
-function lookupGitlabMr(head: string, cwd: string): NormalizedPr | null {
-  const view = run(['glab', 'mr', 'view', head, '-F', 'json'], cwd);
+function lookupGitlabMr(head: string, cwd: string, repo?: string): NormalizedPr | null {
+  const cmd = ['glab', 'mr', 'view', head, '-F', 'json'];
+  if (repo !== undefined) cmd.push('-R', repo);
+  const view = run(cmd, cwd);
   if (view.exitCode !== 0) return null;
   try {
     const parsed = JSON.parse(view.stdout) as {
@@ -197,13 +202,14 @@ function createGitlabMr(args: Input, head: string, cwd: string): NormalizedPr {
     '--yes',
   ];
   if (args.draft) createCmd.push('--draft');
+  if (args.repo !== undefined) createCmd.push('-R', args.repo);
 
   const result = run(createCmd, cwd);
   if (result.exitCode !== 0) {
     const errText = (result.stderr + result.stdout).toLowerCase();
     // glab says "Another open merge request already exists" on duplicate
     if (errText.includes('already exists')) {
-      const existing = lookupGitlabMr(head, cwd);
+      const existing = lookupGitlabMr(head, cwd, args.repo);
       if (existing) return existing;
       // Lookup failed (MR may have been closed between create and lookup)
       throw new Error(`glab mr create: MR already exists for branch '${head}' but could not be found via lookup`);
@@ -212,7 +218,9 @@ function createGitlabMr(args: Input, head: string, cwd: string): NormalizedPr {
   }
 
   // Normalize by fetching the MR we just created via `glab mr view <head> -F json`.
-  const view = run(['glab', 'mr', 'view', head, '-F', 'json'], cwd);
+  const viewCmd = ['glab', 'mr', 'view', head, '-F', 'json'];
+  if (args.repo !== undefined) viewCmd.push('-R', args.repo);
+  const view = run(viewCmd, cwd);
   if (view.exitCode !== 0) {
     throw new Error(`glab mr view failed: ${view.stderr.trim() || view.stdout.trim()}`);
   }

--- a/handlers/pr_diff.ts
+++ b/handlers/pr_diff.ts
@@ -9,6 +9,10 @@ import { detectPlatform, gitlabApiMr } from '../lib/glab';
 
 const inputSchema = z.object({
   number: z.number().int().positive(),
+  repo: z
+    .string()
+    .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/, 'repo must be owner/repo format')
+    .optional(),
 });
 
 type Input = z.infer<typeof inputSchema>;
@@ -29,22 +33,33 @@ function exec(cmd: string): string {
   });
 }
 
-function getGithubDiff(num: number): string {
-  return exec(`gh pr diff ${num}`);
+function repoFlag(repo: string | undefined): string {
+  return repo !== undefined ? ` --repo ${repo}` : '';
 }
 
-function getGithubUrl(num: number): string {
-  const raw = exec(`gh pr view ${num} --json url`);
+function parseSlugOpts(slug: string | undefined): { owner?: string; repo?: string } | undefined {
+  if (slug === undefined) return undefined;
+  const idx = slug.indexOf('/');
+  if (idx <= 0 || idx === slug.length - 1) return undefined;
+  return { owner: slug.slice(0, idx), repo: slug.slice(idx + 1) };
+}
+
+function getGithubDiff(num: number, repo?: string): string {
+  return exec(`gh pr diff ${num}${repoFlag(repo)}`);
+}
+
+function getGithubUrl(num: number, repo?: string): string {
+  const raw = exec(`gh pr view ${num} --json url${repoFlag(repo)}`);
   const parsed = JSON.parse(raw) as { url: string };
   return parsed.url;
 }
 
-function getGitlabDiff(num: number): string {
-  return exec(`glab mr diff ${num}`);
+function getGitlabDiff(num: number, repo?: string): string {
+  return exec(`glab mr diff ${num}${repoFlag(repo)}`);
 }
 
-function getGitlabUrl(num: number): string {
-  const mr = gitlabApiMr(num);
+function getGitlabUrl(num: number, repo?: string): string {
+  const mr = gitlabApiMr(num, parseSlugOpts(repo));
   return mr.web_url;
 }
 
@@ -115,9 +130,13 @@ const prDiffHandler: HandlerDef = {
     try {
       const platform = detectPlatform();
       const rawDiff =
-        platform === 'github' ? getGithubDiff(args.number) : getGitlabDiff(args.number);
+        platform === 'github'
+          ? getGithubDiff(args.number, args.repo)
+          : getGitlabDiff(args.number, args.repo);
       const url =
-        platform === 'github' ? getGithubUrl(args.number) : getGitlabUrl(args.number);
+        platform === 'github'
+          ? getGithubUrl(args.number, args.repo)
+          : getGitlabUrl(args.number, args.repo);
 
       const rawLineCount = countLines(rawDiff);
       const fileCount = countFiles(rawDiff);

--- a/handlers/pr_files.ts
+++ b/handlers/pr_files.ts
@@ -9,6 +9,10 @@ import { detectPlatform, gitlabApiMr } from '../lib/glab';
 
 const inputSchema = z.object({
   number: z.number().int().positive('number must be a positive integer'),
+  repo: z
+    .string()
+    .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/, 'repo must be owner/repo format')
+    .optional(),
 });
 
 type Input = z.infer<typeof inputSchema>;
@@ -53,8 +57,19 @@ interface GithubFile {
   changeType: string;
 }
 
-function getGithubFiles(number: number): FileEntry[] {
-  const raw = exec(`gh pr view ${number} --json files`);
+function repoFlag(repo: string | undefined): string {
+  return repo !== undefined ? ` --repo ${repo}` : '';
+}
+
+function parseSlugOpts(slug: string | undefined): { owner?: string; repo?: string } | undefined {
+  if (slug === undefined) return undefined;
+  const idx = slug.indexOf('/');
+  if (idx <= 0 || idx === slug.length - 1) return undefined;
+  return { owner: slug.slice(0, idx), repo: slug.slice(idx + 1) };
+}
+
+function getGithubFiles(number: number, repo?: string): FileEntry[] {
+  const raw = exec(`gh pr view ${number} --json files${repoFlag(repo)}`);
   const parsed = JSON.parse(raw) as { files: GithubFile[] };
   const files = parsed.files ?? [];
   return files.map(f => ({
@@ -104,8 +119,8 @@ function mapGitlabStatus(change: GitlabChange): FileStatus {
   return 'modified';
 }
 
-function getGitlabFiles(number: number): FileEntry[] {
-  const mr = gitlabApiMr(number) as unknown as { changes?: GitlabChange[] };
+function getGitlabFiles(number: number, repo?: string): FileEntry[] {
+  const mr = gitlabApiMr(number, parseSlugOpts(repo)) as unknown as { changes?: GitlabChange[] };
   const changes = mr.changes ?? [];
   return changes.map(c => {
     const path = c.new_path ?? c.old_path ?? '';
@@ -134,7 +149,9 @@ const prFilesHandler: HandlerDef = {
     try {
       const platform = detectPlatform();
       const files =
-        platform === 'github' ? getGithubFiles(args.number) : getGitlabFiles(args.number);
+        platform === 'github'
+          ? getGithubFiles(args.number, args.repo)
+          : getGitlabFiles(args.number, args.repo);
 
       const total_additions = files.reduce((sum, f) => sum + f.additions, 0);
       const total_deletions = files.reduce((sum, f) => sum + f.deletions, 0);

--- a/handlers/pr_list.ts
+++ b/handlers/pr_list.ts
@@ -13,6 +13,10 @@ const inputSchema = z.object({
   state: z.enum(['open', 'closed', 'merged', 'all']).optional().default('open'),
   author: z.string().optional(),
   limit: z.number().int().positive().optional().default(20),
+  repo: z
+    .string()
+    .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/, 'repo must be owner/repo format')
+    .optional(),
 });
 
 type Input = z.infer<typeof inputSchema>;
@@ -52,6 +56,7 @@ function listGithubPrs(args: Input): NormalizedPr[] {
   if (args.author !== undefined) flags.push(`--author ${quoteArg(args.author)}`);
   flags.push(`--limit ${args.limit}`);
   flags.push('--json number,title,state,headRefName,baseRefName,url');
+  if (args.repo !== undefined) flags.push(`--repo ${quoteArg(args.repo)}`);
 
   const cmd = `gh pr list ${flags.join(' ')}`;
   const raw = exec(cmd);
@@ -66,14 +71,24 @@ function listGithubPrs(args: Input): NormalizedPr[] {
   }));
 }
 
+function parseSlugOpts(slug: string | undefined): { owner?: string; repo?: string } | undefined {
+  if (slug === undefined) return undefined;
+  const idx = slug.indexOf('/');
+  if (idx <= 0 || idx === slug.length - 1) return undefined;
+  return { owner: slug.slice(0, idx), repo: slug.slice(idx + 1) };
+}
+
 function listGitlabMrs(args: Input): NormalizedPr[] {
-  const parsed = gitlabApiMrList({
-    head: args.head,
-    base: args.base,
-    state: args.state,
-    author: args.author,
-    limit: args.limit,
-  });
+  const parsed = gitlabApiMrList(
+    {
+      head: args.head,
+      base: args.base,
+      state: args.state,
+      author: args.author,
+      limit: args.limit,
+    },
+    parseSlugOpts(args.repo),
+  );
   return parsed.map((mr) => ({
     number: mr.iid,
     title: mr.title,

--- a/handlers/pr_merge.ts
+++ b/handlers/pr_merge.ts
@@ -21,6 +21,10 @@ const inputSchema = z.object({
   squash_message: z.string().optional(),
   use_merge_queue: z.boolean().optional(),
   skip_train: z.boolean().optional(),
+  repo: z
+    .string()
+    .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/, 'repo must be owner/repo format')
+    .optional(),
 });
 
 type Input = z.infer<typeof inputSchema>;
@@ -94,10 +98,18 @@ function writeTempMessageFile(message: string): string {
   return path;
 }
 
+function parseSlugOpts(slug: string | undefined): { owner?: string; repo?: string } | undefined {
+  if (slug === undefined) return undefined;
+  const idx = slug.indexOf('/');
+  if (idx <= 0 || idx === slug.length - 1) return undefined;
+  return { owner: slug.slice(0, idx), repo: slug.slice(idx + 1) };
+}
+
 function buildGithubMergeCommand(
   number: number,
   auto: boolean,
   squashMessage?: string,
+  repo?: string,
 ): string {
   const parts = ['gh', 'pr', 'merge', String(number), '--squash', '--delete-branch'];
   if (auto) parts.push('--auto');
@@ -110,10 +122,17 @@ function buildGithubMergeCommand(
       parts.push('--body', shellEscape(squashMessage));
     }
   }
+  if (repo !== undefined) {
+    parts.push('--repo', repo);
+  }
   return parts.join(' ');
 }
 
-function buildGitlabMergeCommand(number: number, squashMessage?: string): string {
+function buildGitlabMergeCommand(
+  number: number,
+  squashMessage?: string,
+  repo?: string,
+): string {
   const parts = [
     'glab',
     'mr',
@@ -128,6 +147,9 @@ function buildGitlabMergeCommand(number: number, squashMessage?: string): string
     // preserve newlines in POSIX shells.
     parts.push('--squash-message', shellEscape(squashMessage));
   }
+  if (repo !== undefined) {
+    parts.push('-R', repo);
+  }
   return parts.join(' ');
 }
 
@@ -136,8 +158,15 @@ interface GithubPrViewResponse {
   url?: string;
 }
 
-function fetchGithubPrMergeInfo(number: number): { url: string; merge_commit_sha?: string } {
-  const raw = exec(`gh pr view ${number} --json mergeCommit,url`);
+function repoFlag(repo: string | undefined): string {
+  return repo !== undefined ? ` --repo ${repo}` : '';
+}
+
+function fetchGithubPrMergeInfo(
+  number: number,
+  repo?: string,
+): { url: string; merge_commit_sha?: string } {
+  const raw = exec(`gh pr view ${number} --json mergeCommit,url${repoFlag(repo)}`);
   const parsed = JSON.parse(raw) as GithubPrViewResponse;
   return {
     url: parsed.url ?? '',
@@ -145,14 +174,17 @@ function fetchGithubPrMergeInfo(number: number): { url: string; merge_commit_sha
   };
 }
 
-function fetchGithubPrUrl(number: number): string {
-  const raw = exec(`gh pr view ${number} --json url`);
+function fetchGithubPrUrl(number: number, repo?: string): string {
+  const raw = exec(`gh pr view ${number} --json url${repoFlag(repo)}`);
   const parsed = JSON.parse(raw) as { url?: string };
   return parsed.url ?? '';
 }
 
-function fetchGitlabMrMergeInfo(number: number): { url: string; merge_commit_sha?: string } {
-  const mr = gitlabApiMr(number);
+function fetchGitlabMrMergeInfo(
+  number: number,
+  repo?: string,
+): { url: string; merge_commit_sha?: string } {
+  const mr = gitlabApiMr(number, parseSlugOpts(repo));
   return {
     url: mr.web_url ?? '',
     merge_commit_sha: mr.merge_commit_sha ?? undefined,
@@ -177,7 +209,7 @@ interface MergeFailure {
 function mergeGithub(args: Input): MergeSuccess | MergeFailure {
   // Forced merge-queue path.
   if (args.use_merge_queue === true) {
-    const cmd = buildGithubMergeCommand(args.number, true, args.squash_message);
+    const cmd = buildGithubMergeCommand(args.number, true, args.squash_message, args.repo);
     try {
       exec(cmd);
     } catch (err) {
@@ -187,7 +219,7 @@ function mergeGithub(args: Input): MergeSuccess | MergeFailure {
         error: `gh pr merge --auto failed: ${fail.message}`,
       };
     }
-    const url = fetchGithubPrUrl(args.number);
+    const url = fetchGithubPrUrl(args.number, args.repo);
     return {
       ok: true,
       number: args.number,
@@ -198,10 +230,10 @@ function mergeGithub(args: Input): MergeSuccess | MergeFailure {
   }
 
   // Direct-squash merge (no merge-queue enrollment).
-  const directCmd = buildGithubMergeCommand(args.number, false, args.squash_message);
+  const directCmd = buildGithubMergeCommand(args.number, false, args.squash_message, args.repo);
   try {
     exec(directCmd);
-    const info = fetchGithubPrMergeInfo(args.number);
+    const info = fetchGithubPrMergeInfo(args.number, args.repo);
     return {
       ok: true,
       number: args.number,
@@ -229,7 +261,7 @@ function mergeGithub(args: Input): MergeSuccess | MergeFailure {
   }
 
   // Merge-queue fallback (only reached when skip_train is not set).
-  const autoCmd = buildGithubMergeCommand(args.number, true, args.squash_message);
+  const autoCmd = buildGithubMergeCommand(args.number, true, args.squash_message, args.repo);
   try {
     exec(autoCmd);
   } catch (err) {
@@ -239,7 +271,7 @@ function mergeGithub(args: Input): MergeSuccess | MergeFailure {
       error: `gh pr merge --auto failed after merge-queue fallback: ${fail.message}`,
     };
   }
-  const url = fetchGithubPrUrl(args.number);
+  const url = fetchGithubPrUrl(args.number, args.repo);
   return {
     ok: true,
     number: args.number,
@@ -251,7 +283,7 @@ function mergeGithub(args: Input): MergeSuccess | MergeFailure {
 
 function mergeGitlab(args: Input): MergeSuccess | MergeFailure {
   // GitLab has no merge-queue concept; always direct.
-  const cmd = buildGitlabMergeCommand(args.number, args.squash_message);
+  const cmd = buildGitlabMergeCommand(args.number, args.squash_message, args.repo);
   try {
     exec(cmd);
   } catch (err) {
@@ -260,7 +292,7 @@ function mergeGitlab(args: Input): MergeSuccess | MergeFailure {
       error: `glab mr merge failed: ${extractFailure(err).message}`,
     };
   }
-  const info = fetchGitlabMrMergeInfo(args.number);
+  const info = fetchGitlabMrMergeInfo(args.number, args.repo);
   return {
     ok: true,
     number: args.number,

--- a/handlers/pr_status.ts
+++ b/handlers/pr_status.ts
@@ -9,6 +9,10 @@ import { detectPlatform, gitlabApiMr } from '../lib/glab';
 
 const inputSchema = z.object({
   number: z.number().int().positive(),
+  repo: z
+    .string()
+    .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/, 'repo must be owner/repo format')
+    .optional(),
 });
 
 type Input = z.infer<typeof inputSchema>;
@@ -36,6 +40,17 @@ interface PrStatusResponse {
 
 function exec(cmd: string): string {
   return execSync(cmd, { encoding: 'utf8' }).trim();
+}
+
+function repoFlag(repo: string | undefined): string {
+  return repo !== undefined ? ` --repo ${repo}` : '';
+}
+
+function parseSlugOpts(slug: string | undefined): { owner?: string; repo?: string } | undefined {
+  if (slug === undefined) return undefined;
+  const idx = slug.indexOf('/');
+  if (idx <= 0 || idx === slug.length - 1) return undefined;
+  return { owner: slug.slice(0, idx), repo: slug.slice(idx + 1) };
 }
 
 // --- GitHub normalization ---
@@ -102,9 +117,9 @@ function aggregateGithubChecks(checks: GithubCheck[]): ChecksAggregate {
   return { total, passed, failed, pending, summary };
 }
 
-function getGithubPrStatus(num: number): PrStatusResponse {
+function getGithubPrStatus(num: number, repo?: string): PrStatusResponse {
   const rawPr = exec(
-    `gh pr view ${num} --json state,mergeStateStatus,mergeable,url`,
+    `gh pr view ${num} --json state,mergeStateStatus,mergeable,url${repoFlag(repo)}`,
   );
   const pr = JSON.parse(rawPr) as {
     state: string;
@@ -123,7 +138,7 @@ function getGithubPrStatus(num: number): PrStatusResponse {
 
   let checks: ChecksAggregate = { total: 0, passed: 0, failed: 0, pending: 0, summary: 'none' };
   try {
-    const rawChecks = exec(`gh pr checks ${num} --json name,state,conclusion`);
+    const rawChecks = exec(`gh pr checks ${num} --json name,state,conclusion${repoFlag(repo)}`);
     const parsed = JSON.parse(rawChecks) as GithubCheck[];
     checks = aggregateGithubChecks(parsed);
   } catch {
@@ -193,8 +208,8 @@ function aggregateGitlabPipeline(
   return { total: 1, passed: 0, failed: 0, pending: 1, summary: 'pending' };
 }
 
-function getGitlabMrStatus(num: number): PrStatusResponse {
-  const mr = gitlabApiMr(num);
+function getGitlabMrStatus(num: number, repo?: string): PrStatusResponse {
+  const mr = gitlabApiMr(num, parseSlugOpts(repo));
 
   const state = normalizeGitlabState(mr.state);
   const merge_state = normalizeGitlabMergeState(mr.detailed_merge_status, mr.merge_status);
@@ -233,8 +248,8 @@ const prStatusHandler: HandlerDef = {
       const platform = detectPlatform();
       const data =
         platform === 'github'
-          ? getGithubPrStatus(args.number)
-          : getGitlabMrStatus(args.number);
+          ? getGithubPrStatus(args.number, args.repo)
+          : getGitlabMrStatus(args.number, args.repo);
 
       return {
         content: [

--- a/handlers/pr_wait_ci.ts
+++ b/handlers/pr_wait_ci.ts
@@ -13,6 +13,10 @@ const inputSchema = z
     number: z.number().int().positive(),
     poll_interval_sec: z.number().int().optional().default(30),
     timeout_sec: z.number().int().positive().optional().default(1800),
+    repo: z
+      .string()
+      .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/, 'repo must be owner/repo format')
+      .optional(),
   })
   .strict();
 
@@ -43,8 +47,19 @@ interface GithubCheck {
   state?: string;
 }
 
-function snapshotGithub(number: number): ChecksSnapshot {
-  const raw = exec(`gh pr checks ${number} --json name,bucket,state`);
+function repoFlag(repo: string | undefined): string {
+  return repo !== undefined ? ` --repo ${repo}` : '';
+}
+
+function parseSlugOpts(slug: string | undefined): { owner?: string; repo?: string } | undefined {
+  if (slug === undefined) return undefined;
+  const idx = slug.indexOf('/');
+  if (idx <= 0 || idx === slug.length - 1) return undefined;
+  return { owner: slug.slice(0, idx), repo: slug.slice(idx + 1) };
+}
+
+function snapshotGithub(number: number, repo?: string): ChecksSnapshot {
+  const raw = exec(`gh pr checks ${number} --json name,bucket,state${repoFlag(repo)}`);
   const checks = JSON.parse(raw) as GithubCheck[];
 
   let passed = 0;
@@ -60,7 +75,7 @@ function snapshotGithub(number: number): ChecksSnapshot {
 
   const urlRaw = (() => {
     try {
-      return exec(`gh pr view ${number} --json url`);
+      return exec(`gh pr view ${number} --json url${repoFlag(repo)}`);
     } catch {
       return '{"url":""}';
     }
@@ -88,8 +103,8 @@ interface GitlabMr {
   pipeline?: GitlabPipeline;
 }
 
-function snapshotGitlab(number: number): ChecksSnapshot {
-  const mr = gitlabApiMr(number);
+function snapshotGitlab(number: number, repo?: string): ChecksSnapshot {
+  const mr = gitlabApiMr(number, parseSlugOpts(repo));
   const status = (
     mr.head_pipeline?.status ??
     mr.pipeline?.status ??
@@ -130,9 +145,9 @@ function snapshotGitlab(number: number): ChecksSnapshot {
   };
 }
 
-function snapshotChecks(number: number): ChecksSnapshot {
+function snapshotChecks(number: number, repo?: string): ChecksSnapshot {
   const platform = detectPlatform();
-  return platform === 'gitlab' ? snapshotGitlab(number) : snapshotGithub(number);
+  return platform === 'gitlab' ? snapshotGitlab(number, repo) : snapshotGithub(number, repo);
 }
 
 function decide(snap: ChecksSnapshot): FinalState | null {
@@ -154,7 +169,7 @@ function logCycle(number: number, elapsedSec: number, snap: ChecksSnapshot) {
 
 // Injection seam for tests — swap sleep + snapshot without touching real time/net.
 interface Deps {
-  snapshotFn: (number: number) => ChecksSnapshot;
+  snapshotFn: (number: number, repo?: string) => ChecksSnapshot;
   sleepFn: (ms: number) => Promise<void>;
   nowFn: () => number;
   /** Optional heartbeat called on each poll iteration for wave-status updates. */
@@ -211,7 +226,7 @@ export async function runPollLoop(
   // eslint-disable-next-line no-constant-condition
   while (true) {
     attempt++;
-    lastSnap = deps.snapshotFn(args.number);
+    lastSnap = deps.snapshotFn(args.number, args.repo);
     const elapsedSec = Math.floor((deps.nowFn() - start) / 1000);
     logCycle(args.number, elapsedSec, lastSnap);
     deps.heartbeatFn?.(args.number, attempt, lastSnap);
@@ -255,7 +270,7 @@ export async function runPollLoop(
 
     // Re-check timeout after sleep in case we slept past the deadline.
     if (deps.nowFn() - start >= timeoutMs) {
-      lastSnap = deps.snapshotFn(args.number);
+      lastSnap = deps.snapshotFn(args.number, args.repo);
       const finalElapsed = Math.floor((deps.nowFn() - start) / 1000);
       logCycle(args.number, finalElapsed, lastSnap);
       const postDecision = decide(lastSnap);

--- a/lib/glab.ts
+++ b/lib/glab.ts
@@ -264,14 +264,17 @@ export function gitlabApiMr(
  * The `head`/`base`/`author`/`limit` params are optional; only provided
  * fields become query parameters.
  */
-export function gitlabApiMrList(params: {
-  head?: string;
-  base?: string;
-  state?: 'open' | 'closed' | 'merged' | 'all';
-  author?: string;
-  limit?: number;
-}): GitlabMr[] {
-  const path = projectPath();
+export function gitlabApiMrList(
+  params: {
+    head?: string;
+    base?: string;
+    state?: 'open' | 'closed' | 'merged' | 'all';
+    author?: string;
+    limit?: number;
+  },
+  opts?: { owner?: string; repo?: string },
+): GitlabMr[] {
+  const path = projectPath(opts);
   const queryParts: string[] = [];
 
   // State translation: GitLab REST API uses 'opened' (not 'open'). 'all'

--- a/tests/pr_comment.test.ts
+++ b/tests/pr_comment.test.ts
@@ -332,4 +332,90 @@ exit 0
     expect(data.ok).toBe(false);
     expect((data.error as string)).toContain('failed to parse comment ID');
   });
+
+  // --- cross-repo routing ---
+
+  test('route_with_repo — github appends --repo and slug to gh argv', async () => {
+    // cwd remote is a DIFFERENT repo than the target.
+    fixtureDir = await makeFixture({
+      git: fakeGit('https://github.com/cwd-org/cwd-repo.git'),
+      gh: fakeGh(42, 1001),
+    });
+
+    const result = await handler.execute({
+      number: 42,
+      body: 'cross-repo comment',
+      repo: 'Wave-Engineering/mcp-server-sdlc',
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+
+    const calls = await readCalls(fixtureDir);
+    const ghCall = calls.find((c) => c[0] === 'pr' && c[1] === 'comment');
+    expect(ghCall).toBeDefined();
+    expect(ghCall).toContain('--repo');
+    expect(ghCall).toContain('Wave-Engineering/mcp-server-sdlc');
+  });
+
+  test('route_with_repo — gitlab appends -R and slug to glab argv', async () => {
+    fixtureDir = await makeFixture({
+      git: fakeGit('https://gitlab.com/cwd-org/cwd-repo.git'),
+      glab: fakeGlab(55, 9090),
+    });
+
+    const result = await handler.execute({
+      number: 55,
+      body: 'cross-repo note',
+      repo: 'target-org/target-repo',
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+
+    const calls = await readCalls(fixtureDir);
+    const glabCall = calls.find((c) => c[0] === 'mr' && c[1] === 'note');
+    expect(glabCall).toBeDefined();
+    expect(glabCall).toContain('-R');
+    expect(glabCall).toContain('target-org/target-repo');
+  });
+
+  test('regression_without_repo — gh argv does NOT contain --repo', async () => {
+    fixtureDir = await makeFixture({
+      git: fakeGit('https://github.com/org/repo.git'),
+      gh: fakeGh(42, 1001),
+    });
+
+    const result = await handler.execute({ number: 42, body: 'hi' });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+
+    const calls = await readCalls(fixtureDir);
+    const ghCall = calls.find((c) => c[0] === 'pr' && c[1] === 'comment');
+    expect(ghCall).toBeDefined();
+    expect(ghCall).not.toContain('--repo');
+  });
+
+  test('invalid_slug_early_error — returns ok:false without spawning gh/glab', async () => {
+    // Fixture has no gh/glab stubs — any spawn attempt would fail with a
+    // different error. Empty bin dir; only git stub present (which shouldn't
+    // even be reached because zod rejects first).
+    const dir = `/tmp/pr-comment-invalid-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+    await Bun.write(`${dir}/.keep`, '');
+    await Bun.write(`${dir}/bin/.keep`, '');
+    process.env.PATH = `${dir}/bin:${ORIGINAL_PATH}`;
+    process.env.CLAUDE_PROJECT_DIR = dir;
+    fixtureDir = dir;
+
+    const result = await handler.execute({
+      number: 1,
+      body: 'x',
+      repo: 'not-a-slug',
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+    expect(String(data.error)).toContain('repo');
+
+    // Calls file should not exist (no gh/glab was spawned).
+    const callsFile = Bun.file(`${dir}/bin/.calls`);
+    expect(await callsFile.exists()).toBe(false);
+  });
 });

--- a/tests/pr_create.test.ts
+++ b/tests/pr_create.test.ts
@@ -515,6 +515,198 @@ echo "unhandled glab: $*" >&2; exit 1
     expect(data.created).toBe(false);
   });
 
+  test('route_with_repo_github — appends --repo to gh pr create/view when repo provided', async () => {
+    const { fixture, stubBin } = await makeFixture({ '.keep': '' });
+    fixtureDir = fixture;
+    stubBinDir = stubBin;
+
+    // cwd remote is a DIFFERENT repo — repo arg must override.
+    await writeStub(
+      stubBin,
+      'git',
+      `
+case "$1 $2" in
+  "branch --show-current") echo "feature/196-cross-repo" ;;
+  "remote -v") echo "origin\tgit@github.com:cwd-org/cwd-repo.git (fetch)" ;;
+  *) exit 1 ;;
+esac
+`,
+    );
+
+    const createRecordPath = `${fixture}/gh-create-args.txt`;
+    const viewRecordPath = `${fixture}/gh-view-args.txt`;
+    await writeStub(
+      stubBin,
+      'gh',
+      `
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  printf '%s\\n' "$@" > "${createRecordPath}"
+  echo "https://github.com/Wave-Engineering/mcp-server-sdlc/pull/196"
+  exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  printf '%s\\n' "$@" > "${viewRecordPath}"
+  cat <<'EOF'
+{"number":196,"url":"https://github.com/Wave-Engineering/mcp-server-sdlc/pull/196","state":"OPEN","headRefName":"feature/196-cross-repo","baseRefName":"main"}
+EOF
+  exit 0
+fi
+exit 1
+`,
+    );
+
+    activate(fixture, stubBin);
+
+    const result = await handler.execute({
+      title: 't',
+      body: 'b',
+      base: 'main',
+      repo: 'Wave-Engineering/mcp-server-sdlc',
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(data.number).toBe(196);
+
+    const createArgs = await Bun.file(createRecordPath).text();
+    expect(createArgs).toContain('--repo');
+    expect(createArgs).toContain('Wave-Engineering/mcp-server-sdlc');
+    const viewArgs = await Bun.file(viewRecordPath).text();
+    expect(viewArgs).toContain('--repo');
+    expect(viewArgs).toContain('Wave-Engineering/mcp-server-sdlc');
+  });
+
+  test('route_with_repo_gitlab — appends -R to glab mr create/view when repo provided', async () => {
+    const { fixture, stubBin } = await makeFixture({ '.keep': '' });
+    fixtureDir = fixture;
+    stubBinDir = stubBin;
+
+    await writeStub(
+      stubBin,
+      'git',
+      `
+case "$1 $2" in
+  "branch --show-current") echo "feature/196-cross-repo" ;;
+  "remote -v") echo "origin\tgit@gitlab.com:cwd-org/cwd-repo.git (fetch)" ;;
+  *) exit 1 ;;
+esac
+`,
+    );
+
+    const createRecordPath = `${fixture}/glab-create-args.txt`;
+    const viewRecordPath = `${fixture}/glab-view-args.txt`;
+    await writeStub(
+      stubBin,
+      'glab',
+      `
+if [ "$1" = "mr" ] && [ "$2" = "create" ]; then
+  printf '%s\\n' "$@" > "${createRecordPath}"
+  echo "https://gitlab.com/target-org/target-repo/-/merge_requests/8"
+  exit 0
+fi
+if [ "$1" = "mr" ] && [ "$2" = "view" ]; then
+  printf '%s\\n' "$@" > "${viewRecordPath}"
+  cat <<'EOF'
+{"iid":8,"web_url":"https://gitlab.com/target-org/target-repo/-/merge_requests/8","state":"opened","source_branch":"feature/196-cross-repo","target_branch":"main"}
+EOF
+  exit 0
+fi
+exit 1
+`,
+    );
+
+    activate(fixture, stubBin);
+
+    const result = await handler.execute({
+      title: 't',
+      body: 'b',
+      base: 'main',
+      repo: 'target-org/target-repo',
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(data.number).toBe(8);
+
+    const createArgs = await Bun.file(createRecordPath).text();
+    expect(createArgs).toContain('-R');
+    expect(createArgs).toContain('target-org/target-repo');
+    const viewArgs = await Bun.file(viewRecordPath).text();
+    expect(viewArgs).toContain('-R');
+    expect(viewArgs).toContain('target-org/target-repo');
+  });
+
+  test('regression_without_repo — gh pr create argv has no --repo flag', async () => {
+    const { fixture, stubBin } = await makeFixture({ '.keep': '' });
+    fixtureDir = fixture;
+    stubBinDir = stubBin;
+
+    await writeStub(
+      stubBin,
+      'git',
+      `
+case "$1 $2" in
+  "branch --show-current") echo "feature/xyz" ;;
+  "remote -v") echo "origin\tgit@github.com:org/repo.git (fetch)" ;;
+  *) exit 1 ;;
+esac
+`,
+    );
+
+    const recordPath = `${fixture}/gh-args.txt`;
+    await writeStub(
+      stubBin,
+      'gh',
+      `
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  printf '%s\\n' "$@" > "${recordPath}"
+  echo "https://github.com/org/repo/pull/100"
+  exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  cat <<'EOF'
+{"number":100,"url":"https://github.com/org/repo/pull/100","state":"OPEN","headRefName":"feature/xyz","baseRefName":"main"}
+EOF
+  exit 0
+fi
+exit 1
+`,
+    );
+
+    activate(fixture, stubBin);
+
+    const result = await handler.execute({
+      title: 't',
+      body: 'b',
+      base: 'main',
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+
+    const argsText = await Bun.file(recordPath).text();
+    expect(argsText).not.toContain('--repo');
+  });
+
+  test('invalid_slug_early_error — returns ok:false and does not spawn any subprocess', async () => {
+    // No stubs registered — if handler spawned anything it'd fail with an
+    // unpredictable error from PATH lookup. We rely on zod validation to
+    // short-circuit before any spawn.
+    const { fixture, stubBin } = await makeFixture({ '.keep': '' });
+    fixtureDir = fixture;
+    stubBinDir = stubBin;
+
+    // Activate with an EMPTY stubBin — no git, gh, or glab available.
+    activate(fixture, stubBin);
+
+    const result = await handler.execute({
+      title: 't',
+      body: 'b',
+      base: 'main',
+      repo: 'not-a-slug',
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+    expect(String(data.error)).toContain('repo');
+  });
+
   test('fallback_platform_detection — no .claude-project.md, uses git remote', async () => {
     const { fixture, stubBin } = await makeFixture({
       // Intentionally no .claude-project.md — handler must consult `git remote -v`.

--- a/tests/pr_diff.test.ts
+++ b/tests/pr_diff.test.ts
@@ -5,8 +5,10 @@ import { describe, test, expect, mock, beforeEach } from 'bun:test';
 
 let execRegistry: Array<{ match: string; value: string }> = [];
 let execError: Error | null = null;
+let execCalls: string[] = [];
 
 function mockExec(cmd: string): string {
+  execCalls.push(cmd);
   if (execError) throw execError;
   for (const { match, value } of execRegistry) {
     if (cmd.includes(match)) return value;
@@ -32,6 +34,7 @@ function register(match: string, value: string) {
 beforeEach(() => {
   execRegistry = [];
   execError = null;
+  execCalls = [];
 });
 
 const SMALL_DIFF = `diff --git a/foo.txt b/foo.txt
@@ -237,5 +240,75 @@ describe('pr_diff handler', () => {
     const data = parseResult(result.content);
     expect(data.ok).toBe(false);
     expect((data.error as string)).toContain('authentication');
+  });
+
+  // --- cross-repo routing ---
+
+  test('route_with_repo — github threads --repo into gh pr diff and gh pr view', async () => {
+    register('git remote get-url origin', 'https://github.com/cwd-org/cwd-repo.git');
+    register('gh pr diff 42', SMALL_DIFF);
+    register(
+      'gh pr view 42 --json url',
+      JSON.stringify({ url: 'https://github.com/Wave-Engineering/mcp-server-sdlc/pull/42' }),
+    );
+
+    const result = await prDiffHandler.execute({
+      number: 42,
+      repo: 'Wave-Engineering/mcp-server-sdlc',
+    });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+
+    const diffCall = execCalls.find((c) => c.startsWith('gh pr diff 42')) ?? '';
+    expect(diffCall).toContain('--repo Wave-Engineering/mcp-server-sdlc');
+    const viewCall = execCalls.find((c) => c.startsWith('gh pr view 42')) ?? '';
+    expect(viewCall).toContain('--repo Wave-Engineering/mcp-server-sdlc');
+  });
+
+  test('route_with_repo — gitlab forwards slug into glab mr diff + glab api path', async () => {
+    register('git remote get-url origin', 'https://gitlab.com/cwd-org/cwd-repo.git');
+    register('glab mr diff 11', SMALL_DIFF);
+    register(
+      'glab api projects/target-org%2Ftarget-repo/merge_requests/11',
+      JSON.stringify({ web_url: 'https://gitlab.com/target-org/target-repo/-/merge_requests/11' }),
+    );
+
+    const result = await prDiffHandler.execute({
+      number: 11,
+      repo: 'target-org/target-repo',
+    });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+
+    const diffCall = execCalls.find((c) => c.startsWith('glab mr diff 11')) ?? '';
+    expect(diffCall).toContain('--repo target-org/target-repo');
+    const apiCall = execCalls.find((c) => c.includes('glab api projects/')) ?? '';
+    expect(apiCall).toContain('target-org%2Ftarget-repo');
+    expect(apiCall).not.toContain('cwd-org%2Fcwd-repo');
+  });
+
+  test('regression_without_repo — gh pr diff call does not contain --repo', async () => {
+    register('git remote get-url origin', 'https://github.com/org/repo.git');
+    register('gh pr diff 7', SMALL_DIFF);
+    register(
+      'gh pr view 7 --json url',
+      JSON.stringify({ url: 'https://github.com/org/repo/pull/7' }),
+    );
+
+    await prDiffHandler.execute({ number: 7 });
+
+    const diffCall = execCalls.find((c) => c.startsWith('gh pr diff 7')) ?? '';
+    expect(diffCall).not.toContain('--repo');
+    const viewCall = execCalls.find((c) => c.startsWith('gh pr view 7')) ?? '';
+    expect(viewCall).not.toContain('--repo');
+  });
+
+  test('invalid_slug_early_error — returns ok:false with zero exec calls', async () => {
+    const result = await prDiffHandler.execute({ number: 1, repo: 'no-slash' });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(false);
+    expect(typeof data.error).toBe('string');
+    expect(execCalls).toHaveLength(0);
   });
 });

--- a/tests/pr_files.test.ts
+++ b/tests/pr_files.test.ts
@@ -3,8 +3,10 @@ import { describe, test, expect, mock, beforeEach } from 'bun:test';
 // --- Mock child_process.execSync at module level ---
 let execRegistry: Record<string, string> = {};
 let execError: Error | null = null;
+let execCalls: string[] = [];
 
 function mockExec(cmd: string): string {
+  execCalls.push(cmd);
   if (execError) throw execError;
   for (const [key, value] of Object.entries(execRegistry)) {
     if (cmd.includes(key)) return value;
@@ -26,6 +28,7 @@ function parseResult(content: Array<{ type: string; text: string }>) {
 beforeEach(() => {
   execRegistry = {};
   execError = null;
+  execCalls = [];
 });
 
 describe('pr_files handler — shape', () => {
@@ -329,5 +332,62 @@ describe('pr_files handler — GitLab', () => {
     expect(data.files).toEqual([]);
     expect(data.total_additions).toBe(0);
     expect(data.total_deletions).toBe(0);
+  });
+});
+
+describe('pr_files handler — cross-repo routing', () => {
+  test('route_with_repo — github threads --repo into gh pr view --json files', async () => {
+    // cwd origin differs from target.
+    execRegistry['git remote get-url origin'] = 'https://github.com/cwd-org/cwd-repo.git';
+    execRegistry['gh pr view 42'] = JSON.stringify({
+      files: [{ path: 'src/new.ts', additions: 5, deletions: 0, changeType: 'ADDED' }],
+    });
+
+    const result = await prFilesHandler.execute({
+      number: 42,
+      repo: 'Wave-Engineering/mcp-server-sdlc',
+    });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+
+    const ghCall = execCalls.find((c) => c.startsWith('gh pr view 42')) ?? '';
+    expect(ghCall).toContain('--repo Wave-Engineering/mcp-server-sdlc');
+  });
+
+  test('route_with_repo — gitlab forwards owner/repo slug into glab api path', async () => {
+    execRegistry['git remote get-url origin'] = 'https://gitlab.com/cwd-org/cwd-repo.git';
+    execRegistry['glab api projects/target-org%2Ftarget-repo/merge_requests/7'] = JSON.stringify({
+      changes: [],
+    });
+
+    const result = await prFilesHandler.execute({
+      number: 7,
+      repo: 'target-org/target-repo',
+    });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+
+    const glabCall = execCalls.find((c) => c.includes('glab api projects/')) ?? '';
+    expect(glabCall).toContain('target-org%2Ftarget-repo');
+    expect(glabCall).not.toContain('cwd-org%2Fcwd-repo');
+  });
+
+  test('regression_without_repo — github call does not contain --repo', async () => {
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    execRegistry['gh pr view 10'] = JSON.stringify({ files: [] });
+
+    await prFilesHandler.execute({ number: 10 });
+
+    const ghCall = execCalls.find((c) => c.startsWith('gh pr view 10')) ?? '';
+    expect(ghCall).not.toContain('--repo');
+  });
+
+  test('invalid_slug_early_error — returns ok:false with zero exec calls', async () => {
+    const result = await prFilesHandler.execute({ number: 1, repo: 'not-a-slug' });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(false);
+    expect(typeof data.error).toBe('string');
+    expect(execCalls).toHaveLength(0);
   });
 });

--- a/tests/pr_list.test.ts
+++ b/tests/pr_list.test.ts
@@ -283,4 +283,57 @@ describe('pr_list handler', () => {
     expect(data.ok).toBe(false);
     expect(typeof data.error).toBe('string');
   });
+
+  // --- cross-repo: route_with_repo ---
+  test('route_with_repo — forwards --repo to gh pr list when repo arg provided (github)', async () => {
+    // cwd origin is a DIFFERENT repo — repo arg must override.
+    execRegistry['git remote get-url origin'] = 'https://github.com/Wave-Engineering/claudecode-workflow.git';
+    execRegistry['gh pr list'] = JSON.stringify([]);
+
+    await prListHandler.execute({ repo: 'Wave-Engineering/mcp-server-sdlc' });
+    const ghCall = execCalls.find((c) => c.startsWith('gh pr list')) ?? '';
+    expect(ghCall).toContain("--repo 'Wave-Engineering/mcp-server-sdlc'");
+  });
+
+  test('route_with_repo — forwards owner/repo into glab api URL path (gitlab)', async () => {
+    execRegistry['git remote get-url origin'] = 'https://gitlab.com/other-org/other-repo.git';
+    execRegistry['glab api projects/target-org%2Ftarget-repo/merge_requests'] = JSON.stringify([]);
+
+    await prListHandler.execute({ repo: 'target-org/target-repo' });
+    const glabCall = execCalls.find((c) => c.includes('glab api projects/')) ?? '';
+    expect(glabCall).toContain('target-org%2Ftarget-repo');
+    // Must NOT use the cwd-derived slug.
+    expect(glabCall).not.toContain('other-org%2Fother-repo');
+  });
+
+  // --- cross-repo: regression_without_repo ---
+  test('regression_without_repo — no repo arg preserves cwd-based behavior (github)', async () => {
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    execRegistry['gh pr list'] = JSON.stringify([]);
+
+    await prListHandler.execute({});
+    const ghCall = execCalls.find((c) => c.startsWith('gh pr list')) ?? '';
+    expect(ghCall).not.toContain('--repo');
+  });
+
+  test('regression_without_repo — glab api uses cwd slug when no repo arg (gitlab)', async () => {
+    execRegistry['git remote get-url origin'] = 'https://gitlab.com/cwd-org/cwd-repo.git';
+    execRegistry['glab api projects/cwd-org%2Fcwd-repo/merge_requests'] = JSON.stringify([]);
+
+    await prListHandler.execute({});
+    const glabCall = execCalls.find((c) => c.includes('glab api projects/')) ?? '';
+    expect(glabCall).toContain('cwd-org%2Fcwd-repo');
+  });
+
+  // --- cross-repo: invalid_slug_early_error ---
+  test('invalid_slug_early_error — malformed repo returns ok:false with zero exec calls', async () => {
+    // No registry entries — any exec attempt would throw "Unexpected".
+    const result = await prListHandler.execute({ repo: 'not-a-slug' });
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(false);
+    expect(typeof data.error).toBe('string');
+    // Crucially: no subprocess call was made.
+    expect(execCalls).toHaveLength(0);
+  });
 });

--- a/tests/pr_merge.test.ts
+++ b/tests/pr_merge.test.ts
@@ -439,4 +439,90 @@ describe('pr_merge handler', () => {
     expect(data.ok).toBe(true);
     expect(data.merge_method).toBe('merge_queue');
   });
+
+  // --- cross-repo routing ---
+
+  test('route_with_repo — github threads --repo into gh pr merge and gh pr view', async () => {
+    onExec('git remote get-url origin', 'https://github.com/cwd-org/cwd-repo.git\n');
+    onExec('gh pr merge 42 --squash --delete-branch', '');
+    onExec(
+      'gh pr view 42 --json mergeCommit,url',
+      JSON.stringify({
+        mergeCommit: { oid: 'abc123' },
+        url: 'https://github.com/Wave-Engineering/mcp-server-sdlc/pull/42',
+      }),
+    );
+
+    const result = await prMergeHandler.execute({
+      number: 42,
+      repo: 'Wave-Engineering/mcp-server-sdlc',
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+
+    const mergeCall = execCalls.find((c) => c.startsWith('gh pr merge 42')) ?? '';
+    expect(mergeCall).toContain('--repo Wave-Engineering/mcp-server-sdlc');
+    const viewCall = execCalls.find((c) => c.startsWith('gh pr view 42')) ?? '';
+    expect(viewCall).toContain('--repo Wave-Engineering/mcp-server-sdlc');
+  });
+
+  test('route_with_repo — gitlab threads -R into glab mr merge + forwards slug to glab api', async () => {
+    onExec('git remote get-url origin', 'https://gitlab.com/cwd-org/cwd-repo.git\n');
+    onExec('glab mr merge 17 --squash --remove-source-branch --yes', '');
+    onExec(
+      'glab api projects/target-org%2Ftarget-repo/merge_requests/17',
+      JSON.stringify({
+        iid: 17,
+        title: 'Test MR',
+        description: '',
+        state: 'merged',
+        source_branch: 'feature/test',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/target-org/target-repo/-/merge_requests/17',
+        labels: [],
+        merge_commit_sha: 'deadbeef',
+      }),
+    );
+
+    const result = await prMergeHandler.execute({
+      number: 17,
+      repo: 'target-org/target-repo',
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+
+    const mergeCall = execCalls.find((c) => c.startsWith('glab mr merge 17')) ?? '';
+    expect(mergeCall).toContain('-R target-org/target-repo');
+    const apiCall = execCalls.find((c) => c.includes('glab api projects/')) ?? '';
+    expect(apiCall).toContain('target-org%2Ftarget-repo');
+    expect(apiCall).not.toContain('cwd-org%2Fcwd-repo');
+  });
+
+  test('regression_without_repo — gh pr merge does not contain --repo', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    onExec('gh pr merge 42 --squash --delete-branch', '');
+    onExec(
+      'gh pr view 42 --json mergeCommit,url',
+      JSON.stringify({
+        mergeCommit: { oid: 'x' },
+        url: 'https://github.com/org/repo/pull/42',
+      }),
+    );
+
+    await prMergeHandler.execute({ number: 42 });
+
+    const mergeCall = execCalls.find((c) => c.startsWith('gh pr merge 42')) ?? '';
+    expect(mergeCall).not.toContain('--repo');
+    const viewCall = execCalls.find((c) => c.startsWith('gh pr view 42')) ?? '';
+    expect(viewCall).not.toContain('--repo');
+  });
+
+  test('invalid_slug_early_error — returns ok:false with zero exec calls', async () => {
+    const result = await prMergeHandler.execute({ number: 1, repo: 'bogus' });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(false);
+    expect(typeof data.error).toBe('string');
+    expect(execCalls).toHaveLength(0);
+  });
 });

--- a/tests/pr_status.test.ts
+++ b/tests/pr_status.test.ts
@@ -5,8 +5,10 @@ import { describe, test, expect, mock, beforeEach } from 'bun:test';
 
 let execRegistry: Array<{ match: string; value: string }> = [];
 let execError: Error | null = null;
+let execCalls: string[] = [];
 
 function mockExec(cmd: string): string {
+  execCalls.push(cmd);
   if (execError) throw execError;
   for (const { match, value } of execRegistry) {
     if (cmd.includes(match)) return value;
@@ -40,6 +42,7 @@ function registerGitlabRemote() {
 beforeEach(() => {
   execRegistry = [];
   execError = null;
+  execCalls = [];
 });
 
 describe('pr_status handler', () => {
@@ -378,5 +381,90 @@ describe('pr_status handler', () => {
     const out = parseResult(result.content);
     expect(out.ok).toBe(false);
     expect(typeof out.error).toBe('string');
+  });
+
+  // --- cross-repo routing ---
+
+  test('route_with_repo — github threads --repo into gh pr view and gh pr checks', async () => {
+    // cwd origin points at a DIFFERENT repo than the target.
+    register('git remote get-url origin', 'https://github.com/cwd-org/cwd-repo.git');
+    register(
+      'gh pr view 42 --json',
+      JSON.stringify({
+        state: 'OPEN',
+        mergeStateStatus: 'CLEAN',
+        mergeable: 'MERGEABLE',
+        url: 'https://github.com/Wave-Engineering/mcp-server-sdlc/pull/42',
+      }),
+    );
+    register('gh pr checks 42', JSON.stringify([]));
+
+    const result = await prStatusHandler.execute({
+      number: 42,
+      repo: 'Wave-Engineering/mcp-server-sdlc',
+    });
+    const out = parseResult(result.content);
+    expect(out.ok).toBe(true);
+
+    const viewCall = execCalls.find((c) => c.startsWith('gh pr view 42')) ?? '';
+    expect(viewCall).toContain('--repo Wave-Engineering/mcp-server-sdlc');
+    const checksCall = execCalls.find((c) => c.startsWith('gh pr checks 42')) ?? '';
+    expect(checksCall).toContain('--repo Wave-Engineering/mcp-server-sdlc');
+  });
+
+  test('route_with_repo — gitlab forwards owner/repo slug into glab api path', async () => {
+    register('git remote get-url origin', 'https://gitlab.com/cwd-org/cwd-repo.git');
+    register(
+      'glab api projects/target-org%2Ftarget-repo/merge_requests/7',
+      JSON.stringify({
+        iid: 7,
+        state: 'opened',
+        detailed_merge_status: 'mergeable',
+        merge_status: 'can_be_merged',
+        web_url: 'https://gitlab.com/target-org/target-repo/-/merge_requests/7',
+        head_pipeline: { status: 'success' },
+      }),
+    );
+
+    const result = await prStatusHandler.execute({
+      number: 7,
+      repo: 'target-org/target-repo',
+    });
+    const out = parseResult(result.content);
+    expect(out.ok).toBe(true);
+
+    const glabCall = execCalls.find((c) => c.includes('glab api projects/')) ?? '';
+    expect(glabCall).toContain('target-org%2Ftarget-repo');
+    expect(glabCall).not.toContain('cwd-org%2Fcwd-repo');
+  });
+
+  test('regression_without_repo — github call does not contain --repo', async () => {
+    registerGithubRemote();
+    register(
+      'gh pr view 42 --json',
+      JSON.stringify({
+        state: 'OPEN',
+        mergeStateStatus: 'CLEAN',
+        mergeable: 'MERGEABLE',
+        url: 'https://github.com/Wave-Engineering/example/pull/42',
+      }),
+    );
+    register('gh pr checks 42', JSON.stringify([]));
+
+    await prStatusHandler.execute({ number: 42 });
+
+    const viewCall = execCalls.find((c) => c.startsWith('gh pr view 42')) ?? '';
+    expect(viewCall).not.toContain('--repo');
+    const checksCall = execCalls.find((c) => c.startsWith('gh pr checks 42')) ?? '';
+    expect(checksCall).not.toContain('--repo');
+  });
+
+  test('invalid_slug_early_error — returns ok:false with zero exec calls', async () => {
+    const result = await prStatusHandler.execute({ number: 1, repo: 'not-a-slug' });
+    const out = parseResult(result.content);
+
+    expect(out.ok).toBe(false);
+    expect(typeof out.error).toBe('string');
+    expect(execCalls).toHaveLength(0);
   });
 });

--- a/tests/pr_wait_ci.test.ts
+++ b/tests/pr_wait_ci.test.ts
@@ -3,7 +3,11 @@ import { describe, test, expect, mock, beforeEach } from 'bun:test';
 // --- Mock child_process for the real-deps path (execute) ---------------------
 
 let execMockFn: (cmd: string) => string = () => '';
-const mockExecSync = mock((cmd: string, _opts?: unknown) => execMockFn(cmd));
+let execCalls: string[] = [];
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  return execMockFn(cmd);
+});
 mock.module('child_process', () => ({ execSync: mockExecSync }));
 
 // Import AFTER the module mock is registered.
@@ -14,6 +18,7 @@ const runWithDeps = mod.__runWithDeps;
 
 beforeEach(() => {
   execMockFn = () => '';
+  execCalls = [];
   mockExecSync.mockClear();
 });
 
@@ -317,5 +322,137 @@ describe('pr_wait_ci handler', () => {
     expect(data.ok).toBe(true);
     expect(data.final_state).toBe('passed');
     expect(data.url).toBe('https://gitlab.com/org/repo/-/merge_requests/3');
+  });
+
+  // --- cross-repo routing ---
+
+  test('route_with_repo — github threads --repo into gh pr checks and gh pr view', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote'))
+        return 'https://github.com/cwd-org/cwd-repo.git\n';
+      if (cmd.startsWith('gh pr checks'))
+        return JSON.stringify([{ name: 'build', bucket: 'pass', state: 'SUCCESS' }]);
+      if (cmd.startsWith('gh pr view'))
+        return JSON.stringify({
+          url: 'https://github.com/Wave-Engineering/mcp-server-sdlc/pull/5',
+        });
+      throw new Error(`unexpected exec: ${cmd}`);
+    };
+
+    const result = await handler.execute({
+      number: 5,
+      poll_interval_sec: 5,
+      timeout_sec: 10,
+      repo: 'Wave-Engineering/mcp-server-sdlc',
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(data.final_state).toBe('passed');
+
+    const checksCall = execCalls.find((c) => c.startsWith('gh pr checks')) ?? '';
+    expect(checksCall).toContain('--repo Wave-Engineering/mcp-server-sdlc');
+    const viewCall = execCalls.find((c) => c.startsWith('gh pr view')) ?? '';
+    expect(viewCall).toContain('--repo Wave-Engineering/mcp-server-sdlc');
+  });
+
+  test('route_with_repo — gitlab forwards slug into glab api URL path', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote'))
+        return 'https://gitlab.com/cwd-org/cwd-repo.git\n';
+      if (cmd.includes('glab api projects/target-org%2Ftarget-repo/merge_requests/3'))
+        return JSON.stringify({
+          iid: 3,
+          web_url: 'https://gitlab.com/target-org/target-repo/-/merge_requests/3',
+          head_pipeline: { status: 'success' },
+          title: 'Test MR',
+          description: '',
+          state: 'opened',
+          source_branch: 'feature/test',
+          target_branch: 'main',
+          labels: [],
+        });
+      throw new Error(`unexpected exec: ${cmd}`);
+    };
+
+    const result = await handler.execute({
+      number: 3,
+      poll_interval_sec: 5,
+      timeout_sec: 10,
+      repo: 'target-org/target-repo',
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(data.final_state).toBe('passed');
+
+    const apiCall = execCalls.find((c) => c.includes('glab api projects/')) ?? '';
+    expect(apiCall).toContain('target-org%2Ftarget-repo');
+    expect(apiCall).not.toContain('cwd-org%2Fcwd-repo');
+  });
+
+  test('regression_without_repo — gh pr checks/view do not contain --repo', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote'))
+        return 'https://github.com/org/repo.git\n';
+      if (cmd.startsWith('gh pr checks'))
+        return JSON.stringify([{ name: 'build', bucket: 'pass', state: 'SUCCESS' }]);
+      if (cmd.startsWith('gh pr view'))
+        return JSON.stringify({ url: 'https://github.com/org/repo/pull/5' });
+      throw new Error(`unexpected exec: ${cmd}`);
+    };
+
+    await handler.execute({
+      number: 5,
+      poll_interval_sec: 5,
+      timeout_sec: 10,
+    });
+
+    const checksCall = execCalls.find((c) => c.startsWith('gh pr checks')) ?? '';
+    expect(checksCall).not.toContain('--repo');
+    const viewCall = execCalls.find((c) => c.startsWith('gh pr view')) ?? '';
+    expect(viewCall).not.toContain('--repo');
+  });
+
+  test('invalid_slug_early_error — returns ok:false with zero exec calls', async () => {
+    const result = await handler.execute({
+      number: 1,
+      poll_interval_sec: 5,
+      timeout_sec: 10,
+      repo: 'not-a-slug',
+    });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(false);
+    expect(typeof data.error).toBe('string');
+    expect(execCalls).toHaveLength(0);
+  });
+
+  test('strict_schema_accepts_repo — .strict() schema does not reject new field', async () => {
+    // Proof that adding repo to a .strict() schema doesn't trigger InvalidParams
+    // via the real MCP dispatch surface (handler.execute), not just the test seam.
+    // If `repo` wasn't declared inside the .strict() object, Zod would reject at
+    // inputSchema.parse() and execute() would return ok:false with "repo" in the
+    // error message. Here we just need the parse to succeed and the handler to
+    // run — we don't care about the poll outcome.
+    execMockFn = (cmd: string) => {
+      if (cmd.includes('gh pr checks')) {
+        return JSON.stringify([{ name: 'ci', bucket: 'pass', state: 'SUCCESS' }]);
+      }
+      if (cmd.includes('gh pr view')) {
+        return JSON.stringify({ url: 'https://github.com/owner/repo/pull/1' });
+      }
+      return '';
+    };
+
+    const result = await handler.execute({
+      number: 1,
+      poll_interval_sec: 5,
+      timeout_sec: 10,
+      repo: 'owner/repo',
+    });
+    const data = parseResult(result);
+    // ok:true proves the .strict() schema accepted `repo`; if it had rejected,
+    // data.ok would be false with an error mentioning the unexpected field.
+    expect(data.ok).toBe(true);
+    expect(typeof data.error).toBe('undefined');
   });
 });


### PR DESCRIPTION
## Summary

Adds optional `repo: string` input to all 8 `pr_*` handlers (`pr_list`, `pr_create`, `pr_status`, `pr_diff`, `pr_files`, `pr_merge`, `pr_comment`, `pr_wait_ci`) so cross-repo orchestration can target an explicit slug instead of the cwd-resolved one. Sibling of #197 (ci_* tools); both land in round-2 epic #199.

## Changes

- **All 8 handlers:** schemas gain `repo: z.string().regex(...).optional()`; subprocess calls thread `--repo <slug>` (gh shell strings) / `['--repo', slug]` (Bun.spawnSync arrays) / `-R <slug>` (glab subcommands) / `{owner, repo}` opts (`gitlabApiMr`, `gitlabApiMrList`).
- **`lib/glab.ts`:** `gitlabApiMrList` gained `opts?: {owner?, repo?}` second param, consistent with existing `gitlabApiMr`.
- **`pr_wait_ci` `.strict()` schema:** `repo` added inside the object literal — accepted via MCP dispatch path (verified with a `handler.execute` test, not just the `__runWithDeps` seam).
- **Regex tightened** to `/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/` — GitHub's actual owner/repo character set. Closes a shell-injection hole where the permissive `/^[^/]+\/[^/]+$/` would have let `repo: "org/repo; rm -rf …"` pass validation and get interpolated into `execSync` strings.

## Test Plan

- 8 handler test files extended with 3–5 new cases each — **34 new tests total**
- Each handler covered by: `route_with_repo` (slug appears in command), `regression_without_repo` (no `--repo` in command), `invalid_slug_early_error` (Zod rejects, zero subprocess calls)
- Full suite: **1134/0 pass**
- `./scripts/ci/validate.sh` 69/69
- `bun run lint` clean

## Code review findings (pre-commit, all fixed in-branch)

- **CRITICAL** — Zod regex too permissive → shell injection risk. Fixed by tightening character set.
- **HIGH** — `pr_wait_ci` schema-acceptance test used the `__runWithDeps` test seam instead of the real `handler.execute` surface. Rewrote test to go through MCP dispatch.

## Linked Issues

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)