### PR TITLE
fix(cross-repo): ci_* tools accept explicit repo param

### DIFF
--- a/handlers/ci_failed_jobs.ts
+++ b/handlers/ci_failed_jobs.ts
@@ -10,6 +10,10 @@ import { detectPlatform } from '../lib/glab.js';
 const inputSchema = z
   .object({
     run_id: z.number().int().positive(),
+    repo: z
+      .string()
+      .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/, 'repo must be in owner/repo form')
+      .optional(),
   })
   .strict();
 
@@ -66,8 +70,9 @@ function normalizeGitlabConclusion(raw: string | undefined): string {
   return raw;
 }
 
-function fetchGithubFailedJobs(runId: number): FailedJob[] {
-  const raw = exec(`gh run view ${runId} --json jobs`);
+function fetchGithubFailedJobs(runId: number, repo: string | undefined): FailedJob[] {
+  const repoFlag = repo ? ` --repo ${repo}` : '';
+  const raw = exec(`gh run view ${runId} --json jobs${repoFlag}`);
   const parsed = JSON.parse(raw) as { jobs?: GithubJob[] };
   const jobs = parsed.jobs ?? [];
   const failed: FailedJob[] = [];
@@ -87,9 +92,11 @@ function fetchGithubFailedJobs(runId: number): FailedJob[] {
   return failed;
 }
 
-function fetchGitlabFailedJobs(runId: number): FailedJob[] {
-  // glab substitutes `:id` with the current project's numeric id.
-  const raw = exec(`glab api projects/:id/pipelines/${runId}/jobs`);
+function fetchGitlabFailedJobs(runId: number, repo: string | undefined): FailedJob[] {
+  // When repo is provided, URL-encode it as the explicit project slug; otherwise
+  // fall back to `:id` which glab substitutes with the cwd project's numeric id.
+  const projectId = repo ? encodeURIComponent(repo) : ':id';
+  const raw = exec(`glab api projects/${projectId}/pipelines/${runId}/jobs`);
   const parsed = JSON.parse(raw) as GitlabJob[];
   const failed: FailedJob[] = [];
   for (const j of parsed) {
@@ -127,8 +134,8 @@ const ciFailedJobsHandler: HandlerDef = {
       const platform = detectPlatform();
       const failed =
         platform === 'github'
-          ? fetchGithubFailedJobs(args.run_id)
-          : fetchGitlabFailedJobs(args.run_id);
+          ? fetchGithubFailedJobs(args.run_id, args.repo)
+          : fetchGitlabFailedJobs(args.run_id, args.repo);
 
       return {
         content: [

--- a/handlers/ci_run_logs.ts
+++ b/handlers/ci_run_logs.ts
@@ -15,6 +15,10 @@ const inputSchema = z.object({
   job_id: z.number().int().nonnegative().optional(),
   failed_only: z.boolean().optional().default(true),
   max_lines: z.number().int().positive().optional().default(DEFAULT_MAX_LINES),
+  repo: z
+    .string()
+    .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/, 'repo must be in owner/repo form')
+    .optional(),
 });
 
 type Input = z.infer<typeof inputSchema>;
@@ -46,10 +50,15 @@ function fetchGithub(args: Input): FetchResult {
     parts.push('--job', String(args.job_id));
   }
   parts.push(args.failed_only ? '--log-failed' : '--log');
+  if (args.repo) {
+    parts.push('--repo', args.repo);
+  }
   const cmd = parts.join(' ');
   const logs = exec(cmd);
 
-  const slug = parseRepoSlug();
+  // When `repo` is explicitly provided, use it directly for URL construction —
+  // skip the local cwd-based parseRepoSlug fallback entirely.
+  const slug = args.repo ?? parseRepoSlug();
   const url = slug
     ? `https://github.com/${slug}/actions/runs/${args.run_id}`
     : `https://github.com/actions/runs/${args.run_id}`;
@@ -67,9 +76,10 @@ interface GitlabJob {
   web_url?: string;
 }
 
-function gitlabProjectPath(): string {
-  // URL-encoded project path for glab api
-  const slug = parseRepoSlug();
+function gitlabProjectPath(repo: string | undefined): string {
+  // URL-encoded project path for glab api. Use the caller-supplied slug when
+  // provided, otherwise fall back to parsing the cwd's origin URL.
+  const slug = repo ?? parseRepoSlug();
   if (!slug) throw new Error('could not parse gitlab project path from origin url');
   return encodeURIComponent(slug);
 }
@@ -79,7 +89,7 @@ function fetchGitlab(args: Input): FetchResult {
 
   if (jobId === undefined) {
     // Fetch the first failed job from the pipeline
-    const projectPath = gitlabProjectPath();
+    const projectPath = gitlabProjectPath(args.repo);
     const raw = exec(`glab api projects/${projectPath}/pipelines/${args.run_id}/jobs`);
     const jobs = JSON.parse(raw) as GitlabJob[];
     const failed = jobs.find(j => j.status === 'failed');
@@ -89,9 +99,13 @@ function fetchGitlab(args: Input): FetchResult {
     jobId = failed.id;
   }
 
-  const logs = exec(`glab ci trace ${jobId}`);
+  // `glab ci trace` supports `-R owner/repo` for cross-repo targeting
+  // (verified against installed glab version). When `repo` is provided,
+  // append the flag so the trace runs against the explicit project.
+  const repoFlag = args.repo ? ` -R ${args.repo}` : '';
+  const logs = exec(`glab ci trace ${jobId}${repoFlag}`);
 
-  const slug = parseRepoSlug();
+  const slug = args.repo ?? parseRepoSlug();
   const url = slug
     ? `https://gitlab.com/${slug}/-/jobs/${jobId}`
     : `https://gitlab.com/-/jobs/${jobId}`;

--- a/handlers/ci_run_status.ts
+++ b/handlers/ci_run_status.ts
@@ -11,6 +11,10 @@ const inputSchema = z
   .object({
     ref: z.string().min(1, 'ref must be a non-empty string'),
     workflow_name: z.string().optional(),
+    repo: z
+      .string()
+      .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/, 'repo must be in owner/repo form')
+      .optional(),
   })
   .strict();
 
@@ -156,27 +160,38 @@ function normalizeGlConclusion(
 
 function ghQueryRuns(
   ref: string,
-  workflowName: string | undefined
+  workflowName: string | undefined,
+  repo: string | undefined,
 ): GhRun[] {
   const selector = isSha(ref)
     ? `--commit ${shellQuote(ref)}`
     : `--branch ${shellQuote(ref)}`;
   const workflow = workflowName ? ` --workflow ${shellQuote(workflowName)}` : '';
-  const cmd = `gh run list ${selector}${workflow} --limit 1 --json databaseId,name,status,conclusion,url,headBranch,headSha,createdAt,updatedAt`;
+  const repoFlag = repo ? ` --repo ${shellQuote(repo)}` : '';
+  const cmd = `gh run list ${selector}${workflow}${repoFlag} --limit 1 --json databaseId,name,status,conclusion,url,headBranch,headSha,createdAt,updatedAt`;
   const raw = exec(cmd);
   if (!raw) return [];
   return JSON.parse(raw) as GhRun[];
 }
 
+function splitRepoSlug(
+  repo: string | undefined,
+): { owner: string; repo: string } | undefined {
+  if (!repo) return undefined;
+  const [owner, name] = repo.split('/', 2);
+  return { owner, repo: name };
+}
+
 function glQueryRuns(
   ref: string,
-  workflowName: string | undefined
+  workflowName: string | undefined,
+  repo: string | undefined,
 ): GitlabPipeline[] {
   // GitLab pipelines don't carry a workflow "name" the way GitHub does; we
   // list without filter and then apply workflow_name client-side against the
   // "source" field for best-effort matching.
   const limit = workflowName ? 20 : 1;
-  const runs = gitlabApiCiList({ ref, limit });
+  const runs = gitlabApiCiList({ ref, limit }, splitRepoSlug(repo));
   if (!workflowName) return runs;
   return runs.filter((r) => {
     const source = r.source ?? '';
@@ -240,12 +255,12 @@ const ciRunStatusHandler: HandlerDef = {
       let normalized: NormalizedRun | null = null;
 
       if (platform === 'github') {
-        const runs = ghQueryRuns(args.ref, args.workflow_name);
+        const runs = ghQueryRuns(args.ref, args.workflow_name, args.repo);
         if (runs.length > 0) {
           normalized = normalizeGh(runs[0]);
         }
       } else {
-        const runs = glQueryRuns(args.ref, args.workflow_name);
+        const runs = glQueryRuns(args.ref, args.workflow_name, args.repo);
         if (runs.length > 0) {
           normalized = normalizeGl(runs[0]);
         }

--- a/handlers/ci_runs_for_branch.ts
+++ b/handlers/ci_runs_for_branch.ts
@@ -11,6 +11,10 @@ const inputSchema = z.object({
   branch: z.string().min(1, 'branch must be a non-empty string'),
   limit: z.number().int().positive().optional().default(10),
   status: z.enum(['success', 'failure', 'in_progress', 'all']).optional().default('all'),
+  repo: z
+    .string()
+    .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/, 'repo must be in owner/repo form')
+    .optional(),
 });
 
 type Input = z.infer<typeof inputSchema>;
@@ -65,11 +69,17 @@ interface GithubRun {
   createdAt: string;
 }
 
-function fetchGithubRuns(branch: string, limit: number, status: Input['status']): RunRecord[] {
+function fetchGithubRuns(
+  branch: string,
+  limit: number,
+  status: Input['status'],
+  repo: string | undefined,
+): RunRecord[] {
   const statusFlag = githubStatusFlag(status);
   const statusArg = statusFlag ? ` --status ${statusFlag}` : '';
+  const repoArg = repo ? ` --repo ${repo}` : '';
   const cmd =
-    `gh run list --branch ${JSON.stringify(branch)} --limit ${limit}${statusArg}` +
+    `gh run list --branch ${JSON.stringify(branch)} --limit ${limit}${statusArg}${repoArg}` +
     ` --json databaseId,name,status,conclusion,headSha,url,createdAt`;
   const raw = execSync(cmd, { encoding: 'utf8' });
   const runs = JSON.parse(raw) as GithubRun[];
@@ -84,10 +94,23 @@ function fetchGithubRuns(branch: string, limit: number, status: Input['status'])
   }));
 }
 
-function fetchGitlabRuns(branch: string, limit: number, status: Input['status']): RunRecord[] {
+function splitRepoSlug(
+  repo: string | undefined,
+): { owner: string; repo: string } | undefined {
+  if (!repo) return undefined;
+  const [owner, name] = repo.split('/', 2);
+  return { owner, repo: name };
+}
+
+function fetchGitlabRuns(
+  branch: string,
+  limit: number,
+  status: Input['status'],
+  repo: string | undefined,
+): RunRecord[] {
   // GitLab API doesn't support status filtering, so we fetch more and filter client-side.
   const fetchLimit = status === 'all' ? limit : limit * 3;
-  const pipelines = gitlabApiCiList({ ref: branch, limit: fetchLimit });
+  const pipelines = gitlabApiCiList({ ref: branch, limit: fetchLimit }, splitRepoSlug(repo));
 
   const targetStatus = gitlabStatusFlag(status);
   const filtered = targetStatus
@@ -132,8 +155,8 @@ const ciRunsForBranchHandler: HandlerDef = {
       const platform = detectPlatform();
       const runs =
         platform === 'github'
-          ? fetchGithubRuns(args.branch, args.limit, args.status)
-          : fetchGitlabRuns(args.branch, args.limit, args.status);
+          ? fetchGithubRuns(args.branch, args.limit, args.status, args.repo)
+          : fetchGitlabRuns(args.branch, args.limit, args.status, args.repo);
 
       return {
         content: [

--- a/handlers/ci_wait_run.ts
+++ b/handlers/ci_wait_run.ts
@@ -19,6 +19,10 @@ const inputSchema = z
     workflow_name: z.string().optional(),
     poll_interval_sec: z.number().int().positive().optional(),
     timeout_sec: z.number().int().positive().optional(),
+    repo: z
+      .string()
+      .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/, 'repo must be in owner/repo form')
+      .optional(),
   })
   .strict();
 
@@ -87,6 +91,17 @@ function shellQuote(value: string): string {
   return value.replace(/(["\\$`])/g, '\\$1');
 }
 
+// Split a validated `owner/repo` slug into the opts shape expected by
+// lib/glab.ts wrappers. Returns undefined when repo is not provided so
+// callers fall back to cwd resolution.
+function splitRepoSlug(
+  repo: string | undefined,
+): { owner: string; repo: string } | undefined {
+  if (!repo) return undefined;
+  const [owner, name] = repo.split('/', 2);
+  return { owner, repo: name };
+}
+
 // Resolve a branch ref to its HEAD commit SHA via `gh api`.
 // Only invoked when we need to compare a branch ref against a run.headSha
 // (e.g. merge-queue fallback). Uses the same authenticated gh subprocess
@@ -106,14 +121,19 @@ function resolveBranchToSha(slug: string, branch: string): string | null {
 
 // --- GitHub polling ---
 
-function githubListCmd(ref: string, workflowName: string | undefined): string {
+function githubListCmd(
+  ref: string,
+  workflowName: string | undefined,
+  repo: string | undefined,
+): string {
   const quotedRef = shellQuote(ref);
   const refFlag = isSha(ref) ? `--commit "${quotedRef}"` : `--branch "${quotedRef}"`;
   const workflowFlag = workflowName
     ? ` --workflow "${shellQuote(workflowName)}"`
     : '';
+  const repoFlag = repo ? ` --repo "${shellQuote(repo)}"` : '';
   // Pull a generous set of fields so we can surface good error messages.
-  return `gh run list ${refFlag}${workflowFlag} --limit 20 --json databaseId,name,status,conclusion,url,headSha,headBranch,workflowName,createdAt,event`;
+  return `gh run list ${refFlag}${workflowFlag}${repoFlag} --limit 20 --json databaseId,name,status,conclusion,url,headSha,headBranch,workflowName,createdAt,event`;
 }
 
 interface GithubRun {
@@ -131,9 +151,10 @@ interface GithubRun {
 
 function fetchGithubRuns(
   ref: string,
-  workflowName: string | undefined
+  workflowName: string | undefined,
+  repo: string | undefined,
 ): GithubRun[] {
-  const cmd = githubListCmd(ref, workflowName);
+  const cmd = githubListCmd(ref, workflowName, repo);
   let raw: string;
   try {
     raw = exec(cmd);
@@ -192,9 +213,13 @@ function githubSnapshot(run: GithubRun): RunSnapshot {
 
 // --- GitLab polling ---
 
-function fetchGitlabPipelines(ref: string): GitlabPipeline[] {
+function fetchGitlabPipelines(
+  ref: string,
+  repo: string | undefined,
+): GitlabPipeline[] {
   try {
-    return gitlabApiCiList({ ref, limit: 20 });
+    const opts = splitRepoSlug(repo);
+    return gitlabApiCiList({ ref, limit: 20 }, opts);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(
@@ -272,14 +297,15 @@ function gitlabSnapshot(pipeline: GitlabPipeline): RunSnapshot {
 function fetchSnapshot(
   platform: 'github' | 'gitlab',
   ref: string,
-  workflowName: string | undefined
+  workflowName: string | undefined,
+  repo: string | undefined,
 ): RunSnapshot | null {
   if (platform === 'github') {
-    const runs = fetchGithubRuns(ref, workflowName);
+    const runs = fetchGithubRuns(ref, workflowName, repo);
     const picked = pickGithubRun(runs, workflowName);
     return picked ? githubSnapshot(picked) : null;
   }
-  const pipelines = fetchGitlabPipelines(ref);
+  const pipelines = fetchGitlabPipelines(ref, repo);
   const picked = pickGitlabPipeline(pipelines, workflowName);
   return picked ? gitlabSnapshot(picked) : null;
 }
@@ -333,6 +359,7 @@ const ciWaitRunHandler: HandlerDef = {
     const timeoutSec = args.timeout_sec ?? DEFAULT_TIMEOUT_SEC;
     const ref = args.ref;
     const workflowName = args.workflow_name;
+    const repo = args.repo;
 
     const platform = detectPlatform();
     const startMs = Date.now();
@@ -345,14 +372,16 @@ const ciWaitRunHandler: HandlerDef = {
       // matching its HEAD SHA, treat that as validation — don't wait for a
       // push-triggered run that will never arrive.
       if (platform === 'github') {
-        const initialRuns = fetchGithubRuns(ref, workflowName);
+        const initialRuns = fetchGithubRuns(ref, workflowName, repo);
         if (initialRuns.length > 0) {
           const anyPush = initialRuns.some((r) => r.event === 'push');
           if (!anyPush) {
             // Resolve ref to a HEAD SHA for comparison against run.headSha.
             let headSha: string | null = isSha(ref) ? ref.toLowerCase() : null;
             if (!headSha) {
-              const slug = parseRepoSlug();
+              // When `repo` is explicitly provided, skip cwd-based slug
+              // parsing and pass the caller's slug directly.
+              const slug = repo ?? parseRepoSlug();
               if (slug) headSha = resolveBranchToSha(slug, ref);
             }
             const mergeGroupMatch = initialRuns.find(
@@ -411,7 +440,7 @@ const ciWaitRunHandler: HandlerDef = {
       // --- Phase 1: wait for a run to appear (no-run-yet window) ---
       let snapshot: RunSnapshot | null = null;
       while (elapsedSec() < NO_RUN_YET_WINDOW_SEC) {
-        snapshot = fetchSnapshot(platform, ref, workflowName);
+        snapshot = fetchSnapshot(platform, ref, workflowName, repo);
         if (snapshot) break;
         logPoll(ref, elapsedSec(), 'no_run_yet');
         // Also honor the overall timeout — don't exceed it here.
@@ -468,7 +497,7 @@ const ciWaitRunHandler: HandlerDef = {
         }
         await sleepFn(pollIntervalSec * 1000);
         // Refresh snapshot.
-        const next = fetchSnapshot(platform, ref, workflowName);
+        const next = fetchSnapshot(platform, ref, workflowName, repo);
         if (!next) {
           // Unusual — the run vanished between polls. Keep the previous snapshot and log.
           logPoll(ref, elapsedSec(), `${snapshot.status}(stale,no_run_returned)`);

--- a/lib/glab.ts
+++ b/lib/glab.ts
@@ -308,11 +308,14 @@ export function gitlabApiMrList(params: {
  *
  * Endpoint: `GET /projects/:id/pipelines?<query>`
  */
-export function gitlabApiCiList(params: {
-  ref?: string;
-  limit?: number;
-}): GitlabPipeline[] {
-  const path = projectPath();
+export function gitlabApiCiList(
+  params: {
+    ref?: string;
+    limit?: number;
+  },
+  opts?: { owner?: string; repo?: string },
+): GitlabPipeline[] {
+  const path = projectPath(opts);
   const queryParts: string[] = [];
 
   if (params.ref !== undefined) {

--- a/tests/ci_failed_jobs.test.ts
+++ b/tests/ci_failed_jobs.test.ts
@@ -376,6 +376,96 @@ describe('ci_failed_jobs handler', () => {
     expect(jobs[0].finished_at).toBeNull();
   });
 
+  // --- Issue #197: cross-repo orchestration via explicit `repo` ---
+
+  test('github_explicit_repo — appends --repo flag to gh run view', async () => {
+    let sawRepoFlag = false;
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote'))
+        return 'https://github.com/cwd-org/cwd-repo.git\n';
+      if (cmd.startsWith('gh run view 777 --json jobs')) {
+        if (cmd.includes('--repo other-org/other-repo')) sawRepoFlag = true;
+        return JSON.stringify({
+          jobs: [
+            {
+              databaseId: 1,
+              name: 'unit',
+              status: 'completed',
+              conclusion: 'failure',
+              startedAt: '2025-01-01T00:00:00Z',
+              completedAt: '2025-01-01T00:01:00Z',
+              url: 'https://github.com/other-org/other-repo/actions/runs/777/job/1',
+            },
+          ],
+        });
+      }
+      throw new Error(`Unexpected exec: ${cmd}`);
+    };
+
+    const result = await ciFailedJobsHandler.execute({
+      run_id: 777,
+      repo: 'other-org/other-repo',
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(sawRepoFlag).toBe(true);
+  });
+
+  test('gitlab_explicit_repo — replaces :id with encoded explicit slug', async () => {
+    let sawExplicitPath = false;
+    let sawColonId = false;
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote'))
+        return 'https://gitlab.com/cwd-org/cwd-repo.git\n';
+      if (cmd.startsWith('glab api')) {
+        if (cmd.includes('projects/other-org%2Fother-repo/pipelines/101/jobs'))
+          sawExplicitPath = true;
+        if (cmd.includes('projects/:id/pipelines/101/jobs'))
+          sawColonId = true;
+        return JSON.stringify([
+          {
+            id: 501,
+            name: 'unit',
+            status: 'failed',
+            stage: 'test',
+            started_at: null,
+            finished_at: null,
+            web_url: 'https://gitlab.com/other-org/other-repo/-/jobs/501',
+          },
+        ]);
+      }
+      throw new Error(`Unexpected exec: ${cmd}`);
+    };
+
+    const result = await ciFailedJobsHandler.execute({
+      run_id: 101,
+      repo: 'other-org/other-repo',
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(sawExplicitPath).toBe(true);
+    expect(sawColonId).toBe(false);
+  });
+
+  test('regression_no_repo — preserves :id shorthand when repo not provided', async () => {
+    let sawColonId = false;
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote'))
+        return 'https://gitlab.com/org/repo.git\n';
+      if (cmd.startsWith('glab api')) {
+        if (cmd.includes('projects/:id/pipelines/202/jobs'))
+          sawColonId = true;
+        return JSON.stringify([]);
+      }
+      throw new Error(`Unexpected exec: ${cmd}`);
+    };
+
+    const result = await ciFailedJobsHandler.execute({ run_id: 202 });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(sawColonId).toBe(true);
+  });
+
   // --- exec error surfaces as ok:false ---
   test('exec_error — surfaces platform command failure as ok:false', async () => {
     execMockFn = (cmd: string) => {

--- a/tests/ci_run_logs.test.ts
+++ b/tests/ci_run_logs.test.ts
@@ -216,6 +216,82 @@ describe('ci_run_logs handler', () => {
     expect((parsed.error as string)).toContain('no failed job');
   });
 
+  // --- Issue #197: cross-repo orchestration via explicit `repo` ---
+
+  test('github_explicit_repo — appends --repo flag to gh run view', async () => {
+    let sawRepoFlag = false;
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote'))
+        return 'https://github.com/cwd-org/cwd-repo.git\n';
+      if (cmd.includes('gh run view')) {
+        if (cmd.includes('--repo other-org/other-repo')) sawRepoFlag = true;
+        return 'logline\n';
+      }
+      throw new Error(`unexpected cmd: ${cmd}`);
+    };
+
+    const result = await handler.execute({
+      run_id: 321,
+      repo: 'other-org/other-repo',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(sawRepoFlag).toBe(true);
+  });
+
+  test('github_explicit_repo — URL construction uses explicit slug not cwd', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote'))
+        return 'https://github.com/cwd-org/cwd-repo.git\n';
+      if (cmd.includes('gh run view')) return 'logline\n';
+      throw new Error(`unexpected cmd: ${cmd}`);
+    };
+
+    const result = await handler.execute({
+      run_id: 654,
+      repo: 'explicit-org/explicit-repo',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    const url = parsed.url as string;
+    expect(url).toContain('explicit-org/explicit-repo');
+    expect(url).not.toContain('cwd-org/cwd-repo');
+  });
+
+  test('gitlab_explicit_repo — pipelines URL + trace use explicit slug', async () => {
+    let sawExplicitPipelinesPath = false;
+    let sawTraceRepoFlag = false;
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote'))
+        return 'https://gitlab.com/cwd-org/cwd-repo.git\n';
+      if (
+        cmd.includes('glab api') &&
+        cmd.includes(
+          'projects/other-org%2Fother-repo/pipelines/99/jobs',
+        )
+      ) {
+        sawExplicitPipelinesPath = true;
+        return JSON.stringify([{ id: 701, status: 'failed' }]);
+      }
+      if (cmd.startsWith('glab ci trace 701')) {
+        if (cmd.includes('-R other-org/other-repo')) sawTraceRepoFlag = true;
+        return 'failing log\n';
+      }
+      throw new Error(`unexpected cmd: ${cmd}`);
+    };
+
+    const result = await handler.execute({
+      run_id: 99,
+      repo: 'other-org/other-repo',
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(sawExplicitPipelinesPath).toBe(true);
+    expect(sawTraceRepoFlag).toBe(true);
+    const url = parsed.url as string;
+    expect(url).toContain('other-org/other-repo');
+  });
+
   test('gitlab — long log triggers truncation', async () => {
     const longLog = makeLines(1200);
     execMockFn = (cmd: string) => {

--- a/tests/ci_run_status.test.ts
+++ b/tests/ci_run_status.test.ts
@@ -316,6 +316,89 @@ describe('ci_run_status handler', () => {
     expect(typeof data.error).toBe('string');
   });
 
+  // --- Issue #197: cross-repo orchestration via explicit `repo` ---
+
+  test('github_explicit_repo — appends --repo flag to gh run list', async () => {
+    execRegistry['git remote get-url origin'] =
+      'https://github.com/cwd-org/cwd-repo.git';
+    execRegistry['gh run list --branch'] = JSON.stringify([
+      {
+        databaseId: 9001,
+        name: 'CI',
+        status: 'completed',
+        conclusion: 'success',
+        url: 'https://github.com/other-org/other-repo/actions/runs/9001',
+        headBranch: 'main',
+        headSha: '1111111111111111111111111111111111111111',
+        createdAt: '2026-04-07T12:00:00Z',
+        updatedAt: '2026-04-07T12:05:00Z',
+      },
+    ]);
+
+    const result = await ciRunStatusHandler.execute({
+      ref: 'main',
+      repo: 'other-org/other-repo',
+    });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    const runListCall = execCalls.find((c) => c.includes('gh run list')) ?? '';
+    expect(runListCall).toContain('--repo');
+    expect(runListCall).toContain('other-org/other-repo');
+  });
+
+  test('gitlab_explicit_repo — targets encoded explicit slug', async () => {
+    execRegistry['git remote get-url origin'] =
+      'https://gitlab.com/cwd-org/cwd-repo.git';
+    execRegistry['glab api projects/other-org%2Fother-repo/pipelines?ref='] =
+      JSON.stringify([
+        {
+          id: 9002,
+          status: 'success',
+          web_url: 'https://gitlab.com/other-org/other-repo/-/pipelines/9002',
+          ref: 'main',
+          sha: '2222222222222222222222222222222222222222',
+          created_at: '2026-04-07T12:00:00Z',
+          updated_at: '2026-04-07T12:05:00Z',
+          finished_at: '2026-04-07T12:05:00Z',
+          source: 'push',
+        },
+      ]);
+
+    const result = await ciRunStatusHandler.execute({
+      ref: 'main',
+      repo: 'other-org/other-repo',
+    });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    const glabCall = execCalls.find((c) => c.startsWith('glab api')) ?? '';
+    expect(glabCall).toContain('projects/other-org%2Fother-repo/pipelines');
+    expect(glabCall).not.toContain('projects/cwd-org%2Fcwd-repo/pipelines');
+  });
+
+  test('regression_no_repo — omits --repo and uses cwd slug when repo not set', async () => {
+    execRegistry['git remote get-url origin'] =
+      'https://github.com/org/repo.git';
+    execRegistry['gh run list --branch'] = JSON.stringify([
+      {
+        databaseId: 4242,
+        name: 'CI',
+        status: 'completed',
+        conclusion: 'success',
+        url: 'https://github.com/org/repo/actions/runs/4242',
+        headBranch: 'main',
+        headSha: 'abc0000000000000000000000000000000000000',
+        createdAt: '2026-04-07T12:00:00Z',
+        updatedAt: '2026-04-07T12:05:00Z',
+      },
+    ]);
+
+    const result = await ciRunStatusHandler.execute({ ref: 'main' });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    const runListCall = execCalls.find((c) => c.includes('gh run list')) ?? '';
+    expect(runListCall).not.toContain('--repo');
+  });
+
   // --- Input validation: unsafe ref characters ---
   test('validation — shell-unsafe ref characters surface as error', async () => {
     execRegistry['git remote get-url origin'] =

--- a/tests/ci_runs_for_branch.test.ts
+++ b/tests/ci_runs_for_branch.test.ts
@@ -265,6 +265,69 @@ describe('ci_runs_for_branch handler', () => {
 
   });
 
+  // --- Issue #197: cross-repo orchestration via explicit `repo` ---
+
+  test('github_explicit_repo — appends --repo flag to gh run list', async () => {
+    execRegistry['git remote get-url origin'] = 'https://github.com/cwd-org/cwd-repo.git';
+    execRegistry['gh run list'] = JSON.stringify([
+      {
+        databaseId: 8001,
+        name: 'ci',
+        status: 'completed',
+        conclusion: 'success',
+        headSha: 'ff',
+        url: 'https://github.com/other-org/other-repo/actions/runs/8001',
+        createdAt: '2026-04-07T12:00:00Z',
+      },
+    ]);
+
+    const result = await handler.execute({
+      branch: 'feature/88-ci',
+      repo: 'other-org/other-repo',
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+
+    const runListCall = execCalls.find((c) => c.includes('gh run list'));
+    expect(runListCall).toBeDefined();
+    expect(runListCall).toContain('--repo other-org/other-repo');
+  });
+
+  test('gitlab_explicit_repo — routes to encoded explicit slug', async () => {
+    execRegistry['git remote get-url origin'] = 'https://gitlab.com/cwd-org/cwd-repo.git';
+    execRegistry['glab api projects/other-org%2Fother-repo/pipelines?ref='] = JSON.stringify([
+      {
+        id: 8100,
+        status: 'success',
+        sha: 'gsha',
+        web_url: 'https://gitlab.com/other-org/other-repo/-/pipelines/8100',
+        created_at: '2026-04-07T12:00:00Z',
+        source: 'push',
+      },
+    ]);
+
+    const result = await handler.execute({
+      branch: 'feature/88-ci',
+      repo: 'other-org/other-repo',
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+
+    const glabCall = execCalls.find((c) => c.startsWith('glab api')) ?? '';
+    expect(glabCall).toContain('projects/other-org%2Fother-repo/pipelines');
+    expect(glabCall).not.toContain('projects/cwd-org%2Fcwd-repo/pipelines');
+  });
+
+  test('regression_no_repo — omits --repo flag when repo not provided', async () => {
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    execRegistry['gh run list'] = '[]';
+
+    await handler.execute({ branch: 'feature/88-ci' });
+
+    const runListCall = execCalls.find((c) => c.includes('gh run list')) ?? '';
+    expect(runListCall).not.toContain('--repo');
+  });
+
   test('gitlab_empty_branch — empty pipeline list returns ok with runs=[]', async () => {
     execRegistry['git remote get-url origin'] = 'https://gitlab.com/org/repo.git';
     execRegistry['glab api projects/org%2Frepo/pipelines?ref='] = '[]';

--- a/tests/ci_wait_run.test.ts
+++ b/tests/ci_wait_run.test.ts
@@ -469,6 +469,138 @@ describe('ci_wait_run handler', () => {
     }
   });
 
+  // --- Issue #197: cross-repo orchestration via explicit `repo` ---
+
+  // GitHub with explicit repo → gh run list gets --repo flag.
+  test('github_explicit_repo — appends --repo flag and routes to the specified slug', async () => {
+    // Intentionally do NOT register `git remote get-url origin` — the handler
+    // must not depend on cwd when `repo` is provided. (detectPlatform still
+    // runs, but falls back to 'github' on exec failure.)
+    execRegistry['gh run list'] = JSON.stringify([
+      ghRun({ status: 'completed', conclusion: 'success' }),
+    ]);
+
+    const result = await ciWaitRunHandler.execute({
+      ref: 'main',
+      repo: 'other-org/other-repo',
+    });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    expect(data.final_status).toBe('success');
+    const ghCalls = execCallLog.filter((c) => c.startsWith('gh run list'));
+    expect(ghCalls.length).toBeGreaterThan(0);
+    expect(ghCalls[0]).toContain('--repo "other-org/other-repo"');
+  });
+
+  // GitHub merge-queue fallback with explicit repo → must skip parseRepoSlug()
+  // (git remote get-url origin) and use `repo` directly when resolving branch
+  // → SHA. Assert via the call log that only the allowed gh-subprocess calls
+  // occur for SHA resolution.
+  test('github_explicit_repo_merge_queue_branch — SHA resolution uses explicit slug', async () => {
+    const targetSha = 'e'.repeat(40);
+    // Register the cwd remote URL (detectPlatform still reads it) AND the
+    // explicit-slug `gh api` endpoint. The key assertion below is that the
+    // SHA-resolution hit `gh api repos/other-org/other-repo/...`, NOT
+    // `gh api repos/cwd-org/cwd-repo/...`.
+    execRegistry['git remote get-url origin'] =
+      'https://github.com/cwd-org/cwd-repo.git';
+    execRegistry['gh api repos/other-org/other-repo/git/refs/heads/main'] =
+      targetSha;
+    execRegistry['gh run list'] = JSON.stringify([
+      ghRun({
+        databaseId: 888,
+        status: 'completed',
+        conclusion: 'success',
+        event: 'merge_group',
+        headSha: targetSha,
+        url: 'https://github.com/other-org/other-repo/actions/runs/888',
+      }),
+    ]);
+
+    const result = await ciWaitRunHandler.execute({
+      ref: 'main',
+      repo: 'other-org/other-repo',
+    });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    expect(data.final_status).toBe('not_applicable');
+    expect(data.reason).toBe('merge_group_validated');
+    expect(data.run_id).toBe(888);
+
+    // Verify the branch-to-SHA resolution hit the EXPLICIT slug, NOT the cwd
+    // slug — the handler must have skipped `parseRepoSlug()` (which would
+    // have returned `cwd-org/cwd-repo`) and used the caller's `repo` directly.
+    const apiCalls = execCallLog.filter((c) =>
+      c.includes('gh api repos/other-org/other-repo/git/refs/heads/main'),
+    );
+    expect(apiCalls.length).toBe(1);
+    const wrongApiCalls = execCallLog.filter((c) =>
+      c.includes('gh api repos/cwd-org/cwd-repo/git/refs/'),
+    );
+    expect(wrongApiCalls.length).toBe(0);
+  });
+
+  // GitLab with explicit repo → gitlabApiCiList uses encoded explicit slug.
+  test('gitlab_explicit_repo — uses encoded owner/repo path, not cwd', async () => {
+    // Register BOTH a failing cwd entry AND the explicit-path entry; the
+    // handler must hit the explicit-path entry. (Intentionally register the
+    // cwd lookup to show it's never hit: if hit, the test would still pass
+    // because the handler's detectPlatform reads cwd first — we still allow it.)
+    execRegistry['git remote get-url origin'] =
+      'https://gitlab.com/cwd-org/cwd-repo.git';
+    execRegistry['glab api projects/other-org%2Fother-repo/pipelines?ref='] =
+      JSON.stringify([glabPipeline({ status: 'success' })]);
+
+    const result = await ciWaitRunHandler.execute({
+      ref: 'main',
+      repo: 'other-org/other-repo',
+    });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    expect(data.final_status).toBe('success');
+
+    const glabCalls = execCallLog.filter((c) => c.startsWith('glab api'));
+    expect(glabCalls.length).toBeGreaterThan(0);
+    // Every glab call must target the explicit encoded slug.
+    for (const c of glabCalls) {
+      expect(c).toContain('projects/other-org%2Fother-repo/pipelines');
+      expect(c).not.toContain('projects/cwd-org%2Fcwd-repo/pipelines');
+    }
+  });
+
+  // Branch ref with explicit repo → merge-queue SHA resolution uses the
+  // explicit slug (NOT the cwd slug).
+  test('merge_group_branch_with_explicit_repo — resolves SHA via explicit slug', async () => {
+    const targetSha = 'f'.repeat(40);
+    execRegistry['git remote get-url origin'] =
+      'https://github.com/cwd-org/cwd-repo.git';
+    execRegistry['gh api repos/explicit-org/explicit-repo/git/refs/heads/feature/1-demo'] =
+      targetSha;
+    execRegistry['gh run list'] = JSON.stringify([
+      ghRun({
+        databaseId: 2222,
+        status: 'completed',
+        conclusion: 'success',
+        event: 'merge_group',
+        headSha: targetSha,
+      }),
+    ]);
+
+    const result = await ciWaitRunHandler.execute({
+      ref: 'feature/1-demo',
+      repo: 'explicit-org/explicit-repo',
+    });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    expect(data.final_status).toBe('not_applicable');
+    expect(data.reason).toBe('merge_group_validated');
+    // Must not have asked the cwd for a SHA.
+    const wrongApiCalls = execCallLog.filter((c) =>
+      c.includes('gh api repos/cwd-org/cwd-repo/git/refs/'),
+    );
+    expect(wrongApiCalls.length).toBe(0);
+  });
+
   // Timeout still fires for push-triggered runs that never complete.
   // Verifies the pre-flight doesn't swallow the existing timeout path.
   test('timeout_still_fires_for_push_triggered — push run stays in_progress, times out', async () => {


### PR DESCRIPTION
## Summary

Adds optional `repo: string` input to all 5 `ci_*` handlers (`ci_wait_run`, `ci_run_status`, `ci_failed_jobs`, `ci_run_logs`, `ci_runs_for_branch`). Sibling of #196 (pr_* tools) — same pattern, fewer handlers, one extra wrinkle: `ci_wait_run`'s merge-queue fallback (recently added via #193) needs the explicit slug threaded through `resolveBranchToSha`. Part of round-2 epic #199.

## Changes

- **All 5 handlers:** schemas gain `repo: z.string().regex(...).optional()`; subprocess calls thread `--repo <slug>` (gh) / `-R <slug>` (`glab ci trace`) / `encodeURIComponent(repo)` (`glab api projects/<slug>/…` replacing the `:id` shorthand) / `{owner, repo}` opts (`gitlabApiCiList`).
- **`lib/glab.ts`:** `gitlabApiCiList` gained `opts?: {owner?, repo?}` second param. Non-adjacent to `#196`'s `gitlabApiMrList` change; both branches auto-merge cleanly.
- **`ci_wait_run` merge-queue fallback:** `const slug = repo ?? parseRepoSlug()` — explicit `repo` bypasses cwd entirely for SHA resolution.
- **Regex tightened** to `/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/` (same as #196) — closes shell-injection hole.
- **`glab ci trace -R`** verified supported via glab's global flag set; no error-fast path needed for GitLab cross-repo logs.

## Test Plan

- 5 handler test files extended with 3–4 new cases each — **16 new tests total**
- `ci_wait_run`: 4 new cases including `merge_group_branch_with_explicit_repo` (asserts cwd slug not hit)
- `ci_failed_jobs`: regression test asserts `:id` preserved when `repo` unset
- Full suite: **1116/0 pass**
- `./scripts/ci/validate.sh` 69/69
- `bun run lint` clean

## Code review findings (pre-commit, fixed in-branch)

- **CRITICAL** — Same unquoted-`--repo` shell-injection risk as #196. Fixed via regex tighten across all 5 handlers.

## Deferred (post-merge follow-up)

- HIGH coverage gap: no test for branch-ref + no-repo + merge_group pattern (the `parseRepoSlug()` fallback path in `resolveBranchToSha`). Low priority; existing merge_group tests use explicit-repo or SHA-ref.

## Linked Issues

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)