### PR TITLE
feat(wave-state): kahuna_branch field + kahuna_branches history + gate actions

### DIFF
--- a/lib/wave_state.ts
+++ b/lib/wave_state.ts
@@ -1,0 +1,125 @@
+/**
+ * Canonical wave-state schema.
+ *
+ * Wave state lives at `.claude/status/state.json` and is written by the Python
+ * `wave_status` CLI in the claudecode-workflow repo; sdlc-server handlers
+ * read it. The schema here is the authoritative contract shared between the
+ * two processes.
+ *
+ * Backward compat: all new fields (`kahuna_branch`, `kahuna_branches`, and
+ * the `gate_evaluating`/`gate_blocked` action values) are additive. Legacy
+ * state files that pre-date KAHUNA parse cleanly against this schema — the
+ * optional fields are simply absent.
+ *
+ * See claudecode-workflow:docs/kahuna-devspec.md §5.1.4 for the authoritative
+ * field definitions.
+ */
+
+import { z } from 'zod';
+
+/**
+ * Enumeration of action values known to this schema version. Callers who
+ * want strict validation of an action value can call
+ * `WaveStateActionSchema.parse(value)` directly.
+ *
+ * **Not enforced at parse time by `CurrentActionSchema`.** The Python
+ * `wave_status` CLI is the authoritative writer and may introduce new action
+ * values ahead of a coordinated schema bump. To keep state-file reads
+ * forward-compatible, `CurrentActionSchema.action` is typed as `z.string()`.
+ * This enum exists as documentation + an opt-in validator, not a gate.
+ */
+export const WaveStateActionSchema = z.enum([
+  'idle',
+  'planning',
+  'preflight',
+  'in-flight',
+  'flight-done',
+  'review',
+  'merging',
+  'waiting',
+  'waiting-ci',
+  'complete',
+  'gate_evaluating',
+  'gate_blocked',
+]);
+
+export type WaveStateAction = z.infer<typeof WaveStateActionSchema>;
+
+/**
+ * Current-action sub-schema. `action` is deliberately `z.string()` rather
+ * than `WaveStateActionSchema` — see the docstring on `WaveStateActionSchema`
+ * for the forward-compat rationale.
+ */
+export const CurrentActionSchema = z
+  .object({
+    action: z.string(),
+    label: z.string().optional(),
+    detail: z.string().optional(),
+  })
+  .passthrough();
+
+export type CurrentAction = z.infer<typeof CurrentActionSchema>;
+
+export const WaveEntrySchema = z
+  .object({
+    status: z.string().optional(),
+    mr_urls: z.record(z.string(), z.string()).optional(),
+  })
+  .passthrough();
+
+export type WaveEntry = z.infer<typeof WaveEntrySchema>;
+
+export const IssueEntrySchema = z
+  .object({
+    status: z.string().optional(),
+  })
+  .passthrough();
+
+export type IssueEntry = z.infer<typeof IssueEntrySchema>;
+
+export const KahunaDispositionSchema = z.enum(['merged', 'aborted']);
+
+export type KahunaDisposition = z.infer<typeof KahunaDispositionSchema>;
+
+/**
+ * One historical kahuna branch. `main_merge_sha` is populated when
+ * disposition === "merged"; `abort_reason` when disposition === "aborted".
+ * Neither field is required at the schema level — callers may populate
+ * whichever is relevant and omit the other.
+ */
+export const KahunaBranchHistoryEntrySchema = z
+  .object({
+    branch: z.string().min(1),
+    epic_id: z.number().int().positive(),
+    created_at: z.string().min(1),
+    resolved_at: z.string().min(1),
+    disposition: KahunaDispositionSchema,
+    main_merge_sha: z.string().optional(),
+    abort_reason: z.string().optional(),
+  })
+  .passthrough();
+
+export type KahunaBranchHistoryEntry = z.infer<typeof KahunaBranchHistoryEntrySchema>;
+
+/**
+ * Full wave-state shape. All fields are optional at the top level so that
+ * partial state files (e.g. freshly initialized, or legacy pre-KAHUNA) parse
+ * cleanly. Unknown top-level fields pass through via `.passthrough()` — we
+ * never want schema enforcement to drop data written by another process.
+ */
+export const WaveStateSchema = z
+  .object({
+    current_wave: z.string().nullable().optional(),
+    current_action: CurrentActionSchema.optional(),
+    waves: z.record(z.string(), WaveEntrySchema).optional(),
+    issues: z.record(z.string(), IssueEntrySchema).optional(),
+    deferrals: z.array(z.unknown()).optional(),
+    last_updated: z.string().optional(),
+    wavemachine_active: z.boolean().optional(),
+    // KAHUNA additions (Story 1.4 / issue #207)
+    kahuna_branch: z.string().nullable().optional(),
+    kahuna_branches: z.array(KahunaBranchHistoryEntrySchema).optional(),
+  })
+  .passthrough();
+
+export type WaveState = z.infer<typeof WaveStateSchema>;

--- a/tests/wave_state.test.ts
+++ b/tests/wave_state.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  WaveStateSchema,
+  WaveStateActionSchema,
+  KahunaBranchHistoryEntrySchema,
+  type WaveState,
+} from '../lib/wave_state';
+
+describe('WaveStateSchema — legacy state files (pre-KAHUNA)', () => {
+  test('parses a minimal legacy state file without kahuna fields', () => {
+    const legacy = {
+      current_wave: null,
+      current_action: { action: 'idle', label: 'idle', detail: '' },
+      waves: {
+        'wave-1a': { status: 'completed', mr_urls: { '1': 'https://example/pr/1' } },
+      },
+      issues: { '1': { status: 'closed' } },
+      deferrals: [],
+      last_updated: '2026-04-13T07:26:28Z',
+      wavemachine_active: false,
+    };
+    const parsed = WaveStateSchema.parse(legacy);
+    expect(parsed.kahuna_branch).toBeUndefined();
+    expect(parsed.kahuna_branches).toBeUndefined();
+    expect(parsed.current_wave).toBeNull();
+    expect(parsed.waves?.['wave-1a']?.status).toBe('completed');
+  });
+
+  test('parses an empty object as a valid (empty) state', () => {
+    const parsed = WaveStateSchema.parse({});
+    expect(parsed).toEqual({});
+  });
+
+  test('preserves unknown top-level fields via passthrough', () => {
+    const withExtra = { last_updated: '2026-04-24T00:00:00Z', future_field: { nested: true } };
+    const parsed = WaveStateSchema.parse(withExtra) as WaveState & { future_field?: unknown };
+    expect(parsed.future_field).toEqual({ nested: true });
+  });
+});
+
+describe('WaveStateSchema — kahuna fields', () => {
+  test('round-trips a state file populated with kahuna_branch + kahuna_branches history', () => {
+    const populated = {
+      current_wave: 'wave-1a',
+      current_action: { action: 'gate_evaluating', label: 'gate_evaluating', detail: '4/4 signals' },
+      kahuna_branch: 'kahuna/42-wave-status-cli',
+      kahuna_branches: [
+        {
+          branch: 'kahuna/41-prior-epic',
+          epic_id: 41,
+          created_at: '2026-04-23T10:00:00Z',
+          resolved_at: '2026-04-24T02:15:00Z',
+          disposition: 'merged' as const,
+          main_merge_sha: 'abc123def456',
+        },
+        {
+          branch: 'kahuna/40-aborted-epic',
+          epic_id: 40,
+          created_at: '2026-04-22T08:00:00Z',
+          resolved_at: '2026-04-22T09:30:00Z',
+          disposition: 'aborted' as const,
+          abort_reason: 'code_reviewer_critical_findings',
+        },
+      ],
+      last_updated: '2026-04-24T02:16:00Z',
+    };
+    const parsed = WaveStateSchema.parse(populated);
+    const roundTripped = WaveStateSchema.parse(JSON.parse(JSON.stringify(parsed)));
+    expect(roundTripped).toEqual(parsed);
+  });
+
+  test('accepts null kahuna_branch (epic closed, no current sandbox)', () => {
+    const parsed = WaveStateSchema.parse({ kahuna_branch: null });
+    expect(parsed.kahuna_branch).toBeNull();
+  });
+
+  test('accepts empty kahuna_branches array', () => {
+    const parsed = WaveStateSchema.parse({ kahuna_branches: [] });
+    expect(parsed.kahuna_branches).toEqual([]);
+  });
+
+  test('rejects kahuna_branches entry with an invalid disposition', () => {
+    const bad = {
+      kahuna_branches: [
+        {
+          branch: 'kahuna/1-foo',
+          epic_id: 1,
+          created_at: '2026-04-23T00:00:00Z',
+          resolved_at: '2026-04-24T00:00:00Z',
+          disposition: 'bogus',
+        },
+      ],
+    };
+    expect(() => WaveStateSchema.parse(bad)).toThrow();
+  });
+
+  test('rejects kahuna_branches entry missing required fields', () => {
+    const bad = {
+      kahuna_branches: [{ branch: 'kahuna/1-foo', epic_id: 1 }],
+    };
+    expect(() => WaveStateSchema.parse(bad)).toThrow();
+  });
+});
+
+describe('KahunaBranchHistoryEntrySchema', () => {
+  test('merged disposition with main_merge_sha is valid', () => {
+    const entry = {
+      branch: 'kahuna/1-foo',
+      epic_id: 1,
+      created_at: '2026-04-23T00:00:00Z',
+      resolved_at: '2026-04-24T00:00:00Z',
+      disposition: 'merged' as const,
+      main_merge_sha: 'deadbeef',
+    };
+    expect(() => KahunaBranchHistoryEntrySchema.parse(entry)).not.toThrow();
+  });
+
+  test('aborted disposition with abort_reason is valid', () => {
+    const entry = {
+      branch: 'kahuna/2-bar',
+      epic_id: 2,
+      created_at: '2026-04-23T00:00:00Z',
+      resolved_at: '2026-04-24T00:00:00Z',
+      disposition: 'aborted' as const,
+      abort_reason: 'ci_timeout',
+    };
+    expect(() => KahunaBranchHistoryEntrySchema.parse(entry)).not.toThrow();
+  });
+
+  test('merged disposition without main_merge_sha is accepted (permissive by design)', () => {
+    const entry = {
+      branch: 'kahuna/3-permissive-merged',
+      epic_id: 3,
+      created_at: '2026-04-23T00:00:00Z',
+      resolved_at: '2026-04-24T00:00:00Z',
+      disposition: 'merged' as const,
+    };
+    expect(() => KahunaBranchHistoryEntrySchema.parse(entry)).not.toThrow();
+  });
+
+  test('aborted disposition without abort_reason is accepted (permissive by design)', () => {
+    const entry = {
+      branch: 'kahuna/4-permissive-aborted',
+      epic_id: 4,
+      created_at: '2026-04-23T00:00:00Z',
+      resolved_at: '2026-04-24T00:00:00Z',
+      disposition: 'aborted' as const,
+    };
+    expect(() => KahunaBranchHistoryEntrySchema.parse(entry)).not.toThrow();
+  });
+
+  test('rejects non-positive epic_id', () => {
+    const entry = {
+      branch: 'kahuna/0-zero',
+      epic_id: 0,
+      created_at: '2026-04-23T00:00:00Z',
+      resolved_at: '2026-04-24T00:00:00Z',
+      disposition: 'merged' as const,
+    };
+    expect(() => KahunaBranchHistoryEntrySchema.parse(entry)).toThrow();
+  });
+});
+
+describe('WaveStateActionSchema — gate_evaluating and gate_blocked', () => {
+  test('accepts the new KAHUNA action values', () => {
+    expect(() => WaveStateActionSchema.parse('gate_evaluating')).not.toThrow();
+    expect(() => WaveStateActionSchema.parse('gate_blocked')).not.toThrow();
+  });
+
+  test('still accepts all pre-existing action values', () => {
+    const existing = [
+      'idle',
+      'planning',
+      'preflight',
+      'in-flight',
+      'flight-done',
+      'review',
+      'merging',
+      'waiting',
+      'waiting-ci',
+      'complete',
+    ];
+    for (const v of existing) {
+      expect(() => WaveStateActionSchema.parse(v)).not.toThrow();
+    }
+  });
+
+  test('rejects unknown action values', () => {
+    expect(() => WaveStateActionSchema.parse('bogus_action')).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Adds the canonical wave-state schema in `lib/wave_state.ts` and formalizes the KAHUNA additions: optional `kahuna_branch` (string | null), `kahuna_branches[]` (resolved-branch history with `disposition: "merged" | "aborted"`), and the two new action-label values `gate_evaluating` / `gate_blocked`.

Backward-compatible: legacy state files with no kahuna fields parse cleanly. The existing handlers (`wave_init`, `wave_show`, `wave_reconcile_mrs`, etc.) already use narrow optional interfaces and are untouched — the new schema is the reader contract for future handlers and for cross-process coordination with the Python `wave_status` CLI (which owns writes).

## Changes

- `lib/wave_state.ts` — NEW. Zod schemas + inferred types: `WaveStateSchema`, `CurrentActionSchema`, `WaveEntrySchema`, `KahunaBranchHistoryEntrySchema`, `WaveStateActionSchema` (enum of known action values). Top-level `.passthrough()` preserves unknown fields — we never drop data written by another process.
- `tests/wave_state.test.ts` — NEW. 16 tests: legacy parse, populated round-trip, null kahuna_branch, empty kahuna_branches, permissive merged/aborted entries, invalid disposition rejected, missing required fields rejected, action enum contents.

## Linked Issues

Closes #207

## Test Plan

- [x] `bun test tests/wave_state.test.ts` — 16/16 pass
- [x] `bun test` full suite — 1187/1187 pass, 2904 expect() calls
- [x] `./scripts/ci/validate.sh` — 69/69 handler assertions, typecheck clean
- [x] `trivy fs --severity HIGH,CRITICAL` — 0 findings
- [x] `feature-dev:code-reviewer` — 2 important findings (false-confidence enum trap, missing permissive-case tests), both fixed before gate

## Notes

Canonical contract: claudecode-workflow:docs/kahuna-devspec.md §5.1.4. No existing handlers refactored — they use narrow `?`-typed interfaces and already tolerate unknown fields in `state.json`. The Zod schema is intentionally advisory on the `action` field (`z.string()` at parse time) because the Python writer is authoritative and may add values ahead of coordinated schema bumps; `WaveStateActionSchema` is the enum consumers opt into for strict validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)