### PR TITLE
feat(wave_finalize): new handler for kahuna→main MR assembly

### DIFF
--- a/handlers/wave_finalize.ts
+++ b/handlers/wave_finalize.ts
@@ -158,7 +158,7 @@ interface AssembleResult {
  * `flight-M/results.md` with no issue-X sub-directory — keeps the handler
  * resilient to artifact-layout drift.
  */
-function assembleBody(
+export function assembleBody(
   artifactsDir: string,
   epicId: number,
   kahunaBranch: string,

--- a/handlers/wave_finalize.ts
+++ b/handlers/wave_finalize.ts
@@ -7,12 +7,13 @@
 // contract.
 
 import { execSync } from 'child_process';
-// Imported via `node:fs` (not `'fs'`) so the partial `mock.module('fs', ...)`
-// in sibling test files (e.g. wave_init.test.ts, work_item.test.ts) does not
-// shadow these symbols as `undefined`. See lesson_mcp_gotchas.md §6.
-import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { createHash } from 'crypto';
 import { join, resolve } from 'path';
+// File reads + directory walks use Bun native APIs (Bun.Glob + Bun.file)
+// instead of node:fs. Sibling test files partially mock 'fs' (only
+// writeFileSync), and Bun's mock.module leaks across the entire suite —
+// any handler importing readFileSync/readdirSync from 'fs' or 'node:fs' gets
+// `undefined` if the offending test runs first. See lesson_mcp_gotchas.md §6.
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
 import { detectPlatform } from '../lib/glab.js';
@@ -106,23 +107,11 @@ function run(cmd: string, cwd: string): RunResult {
   }
 }
 
-function listDirs(path: string): string[] {
+async function readIfExists(path: string): Promise<string | null> {
+  const file = Bun.file(path);
+  if (!(await file.exists())) return null;
   try {
-    return readdirSync(path).filter((name) => {
-      try {
-        return statSync(join(path, name)).isDirectory();
-      } catch {
-        return false;
-      }
-    });
-  } catch {
-    return [];
-  }
-}
-
-function readIfExists(path: string): string | null {
-  try {
-    return readFileSync(path, 'utf8');
+    return await file.text();
   } catch {
     return null;
   }
@@ -161,70 +150,133 @@ interface AssembleResult {
  * `flight-M/results.md` with no issue-X sub-directory — keeps the handler
  * resilient to artifact-layout drift.
  */
-export function assembleBody(
+interface ResolvedEntry {
+  wave: string;
+  flight: string;
+  issueId?: string;
+  resultsRel: string; // path relative to artifactsDir
+}
+
+/** Sort `wave-N` / `flight-N` / `issue-N` lexicographically with numeric awareness. */
+function naturalCompare(a: string, b: string): number {
+  return a.localeCompare(b, undefined, { numeric: true });
+}
+
+export async function assembleBody(
   artifactsDir: string,
   epicId: number,
   kahunaBranch: string,
   targetBranch: string,
-): AssembleResult {
-  const waves = listDirs(artifactsDir)
-    .filter((d) => d.startsWith('wave-'))
-    .sort();
+): Promise<AssembleResult> {
+  // Bun.Glob.scanSync walks the tree without going through `'fs'`, so it is
+  // immune to the partial `mock.module('fs', ...)` leakage.
+  const issueGlob = new Bun.Glob('wave-*/flight-*/issue-*/results.md');
+  const flatGlob = new Bun.Glob('wave-*/flight-*/results.md');
+
+  // Bun.Glob.scanSync throws ENOENT when the cwd doesn't exist (legitimate
+  // case — e.g. the default `/tmp/wavemachine/<slug>/` may never have been
+  // created if the wave was run elsewhere). Treat as "no entries".
+  function safeScan(glob: Bun.Glob): string[] {
+    try {
+      return Array.from(glob.scanSync({ cwd: artifactsDir, onlyFiles: true }));
+    } catch {
+      return [];
+    }
+  }
+
+  const entries: ResolvedEntry[] = [];
+  for (const rel of safeScan(issueGlob)) {
+    const parts = rel.split('/');
+    if (parts.length === 4) {
+      entries.push({
+        wave: parts[0],
+        flight: parts[1],
+        issueId: parts[2].replace(/^issue-/, ''),
+        resultsRel: rel,
+      });
+    }
+  }
+  // Only consider the flat layout when no issue-* entries are found at all
+  // — mixing the two would produce confusing output.
+  if (entries.length === 0) {
+    for (const rel of safeScan(flatGlob)) {
+      const parts = rel.split('/');
+      if (parts.length === 3) {
+        entries.push({ wave: parts[0], flight: parts[1], resultsRel: rel });
+      }
+    }
+  }
+
+  entries.sort((a, b) => {
+    const w = naturalCompare(a.wave, b.wave);
+    if (w !== 0) return w;
+    const f = naturalCompare(a.flight, b.flight);
+    if (f !== 0) return f;
+    if (a.issueId !== undefined && b.issueId !== undefined) {
+      return naturalCompare(a.issueId, b.issueId);
+    }
+    return 0;
+  });
 
   const lines: string[] = [];
   lines.push(`Epic #${epicId} — integration branch \`${kahunaBranch}\` ready for merge into \`${targetBranch}\`.`);
   lines.push('');
   lines.push('## Waves');
 
-  let flightCount = 0;
+  // Cache merge-report.md URL maps per (wave, flight) so we don't reread them
+  // for each issue in the same flight.
+  const mergeReportCache = new Map<string, Map<string, string>>();
+  async function urlsForFlight(wave: string, flight: string): Promise<Map<string, string>> {
+    const key = `${wave}/${flight}`;
+    const cached = mergeReportCache.get(key);
+    if (cached !== undefined) return cached;
+    const content = (await readIfExists(join(artifactsDir, wave, flight, 'merge-report.md'))) ?? '';
+    const urls = new Map<string, string>();
+    for (const m of content.matchAll(/issue[-_ ]*#?(\d+)[^\n]*?(https?:\/\/\S+?\/(?:pull|merge_requests)\/\d+)/gi)) {
+      urls.set(m[1], m[2]);
+    }
+    mergeReportCache.set(key, urls);
+    return urls;
+  }
+
+  let currentWave = '';
+  let currentFlight = '';
+  const flightSet = new Set<string>();
   let issueCount = 0;
 
-  for (const wave of waves) {
-    const wavePath = join(artifactsDir, wave);
-    const flights = listDirs(wavePath).filter((d) => d.startsWith('flight-')).sort();
-    if (flights.length === 0) continue;
-    lines.push('');
-    lines.push(`### ${wave}`);
-
-    for (const flight of flights) {
-      flightCount++;
-      const flightPath = join(wavePath, flight);
+  for (const entry of entries) {
+    if (entry.wave !== currentWave) {
       lines.push('');
-      lines.push(`#### ${flight}`);
+      lines.push(`### ${entry.wave}`);
+      currentWave = entry.wave;
+      currentFlight = '';
+    }
+    if (entry.flight !== currentFlight) {
+      lines.push('');
+      lines.push(`#### ${entry.flight}`);
+      currentFlight = entry.flight;
+      flightSet.add(`${entry.wave}/${entry.flight}`);
+    }
 
-      const issues = listDirs(flightPath).filter((d) => d.startsWith('issue-')).sort();
-      if (issues.length > 0) {
-        const mergeReport = readIfExists(join(flightPath, 'merge-report.md')) ?? '';
-        const mergeReportUrls = new Map<string, string>();
-        // Best-effort correlation: line-level scan for "issue-X" paired with a PR/MR URL.
-        for (const m of mergeReport.matchAll(/issue[-_ ]*#?(\d+)[^\n]*?(https?:\/\/\S+?\/(?:pull|merge_requests)\/\d+)/gi)) {
-          mergeReportUrls.set(m[1], m[2]);
-        }
-        for (const issueDir of issues) {
-          issueCount++;
-          const issueId = issueDir.replace(/^issue-/, '');
-          const results = readIfExists(join(flightPath, issueDir, 'results.md')) ?? '';
-          const mrUrl = extractMrUrl(results) ?? mergeReportUrls.get(issueId);
-          const summary = extractSummary(results);
-          const mrLink = mrUrl !== undefined ? `[PR](${mrUrl}) — ` : '';
-          const bullet = summary.length > 0 ? `${mrLink}${summary}` : mrLink.replace(/ — $/, '');
-          lines.push(`- Issue #${issueId}: ${bullet}`.trimEnd());
-        }
-      } else {
-        // Flatter shape: flight-*/results.md directly (per devspec wording).
-        const results = readIfExists(join(flightPath, 'results.md'));
-        if (results !== null) {
-          issueCount++;
-          const mrUrl = extractMrUrl(results);
-          const summary = extractSummary(results);
-          const mrLink = mrUrl !== undefined ? `[PR](${mrUrl}) — ` : '';
-          lines.push(`- ${mrLink}${summary}`.trimEnd());
-        }
-      }
+    const content = (await readIfExists(join(artifactsDir, entry.resultsRel))) ?? '';
+    let mrUrl = extractMrUrl(content);
+    if (mrUrl === undefined && entry.issueId !== undefined) {
+      mrUrl = (await urlsForFlight(entry.wave, entry.flight)).get(entry.issueId);
+    }
+    const summary = extractSummary(content);
+    const mrLink = mrUrl !== undefined ? `[PR](${mrUrl}) — ` : '';
+
+    if (entry.issueId !== undefined) {
+      issueCount++;
+      const bullet = summary.length > 0 ? `${mrLink}${summary}` : mrLink.replace(/ — $/, '');
+      lines.push(`- Issue #${entry.issueId}: ${bullet}`.trimEnd());
+    } else {
+      issueCount++;
+      lines.push(`- ${mrLink}${summary}`.trimEnd());
     }
   }
 
-  return { body: lines.join('\n'), issueCount, flightCount };
+  return { body: lines.join('\n'), issueCount, flightCount: flightSet.size };
 }
 
 interface NormalizedMr {
@@ -393,7 +445,7 @@ const waveFinalizeHandler: HandlerDef = {
       if (existing !== null) {
         // Compute body_sha from current artifacts for drift detection. Empty
         // sha when artifacts are absent — a legitimate post-cleanup state.
-        const { body, issueCount } = assembleBody(artifactsDir, args.epic_id, args.kahuna_branch, args.target_branch);
+        const { body, issueCount } = await assembleBody(artifactsDir, args.epic_id, args.kahuna_branch, args.target_branch);
         const bodySha = issueCount > 0 ? createHash('sha256').update(body).digest('hex') : '';
         return {
           content: [{
@@ -416,7 +468,7 @@ const waveFinalizeHandler: HandlerDef = {
         };
       }
 
-      const { body, issueCount } = assembleBody(artifactsDir, args.epic_id, args.kahuna_branch, args.target_branch);
+      const { body, issueCount } = await assembleBody(artifactsDir, args.epic_id, args.kahuna_branch, args.target_branch);
       if (issueCount === 0) {
         return {
           content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error: 'no_artifacts' }) }],

--- a/handlers/wave_finalize.ts
+++ b/handlers/wave_finalize.ts
@@ -7,7 +7,10 @@
 // contract.
 
 import { execSync } from 'child_process';
-import { readFileSync, readdirSync, statSync } from 'fs';
+// Imported via `node:fs` (not `'fs'`) so the partial `mock.module('fs', ...)`
+// in sibling test files (e.g. wave_init.test.ts, work_item.test.ts) does not
+// shadow these symbols as `undefined`. See lesson_mcp_gotchas.md §6.
+import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { createHash } from 'crypto';
 import { join, resolve } from 'path';
 import { z } from 'zod';

--- a/handlers/wave_finalize.ts
+++ b/handlers/wave_finalize.ts
@@ -1,0 +1,454 @@
+// KAHUNA epic-final gate: opens the kahuna → main MR once all waves of an
+// epic have landed in the kahuna integration branch. Idempotent — a second
+// call for the same (kahuna_branch, target_branch) pair returns the existing
+// open MR rather than creating a duplicate.
+//
+// See claudecode-workflow:docs/kahuna-devspec.md §5.1.1 for the authoritative
+// contract.
+
+import { execSync } from 'child_process';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { createHash } from 'crypto';
+import { join, resolve } from 'path';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+import { detectPlatform } from '../lib/glab.js';
+
+const inputSchema = z.object({
+  root: z.string().optional(),
+  epic_id: z.number().int().positive(),
+  kahuna_branch: z.string().min(1),
+  target_branch: z.string().min(1).default('main'),
+  body_artifacts_dir: z.string().optional(),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+function projectDir(override?: string): string {
+  if (override !== undefined && override.length > 0) return override;
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+/**
+ * Default wavebus artifact dir. The wavebus skill writes to
+ * `/tmp/wavemachine/<repo-slug>/` — we approximate with the epic slug
+ * extracted from the kahuna branch name. Callers can pass an explicit
+ * `body_artifacts_dir` to override.
+ */
+function defaultArtifactsDir(kahunaBranch: string): string {
+  const m = /^kahuna\/(.+)$/.exec(kahunaBranch);
+  const slug = m !== null ? m[1] : kahunaBranch.replace(/\//g, '-');
+  return `/tmp/wavemachine/${slug}`;
+}
+
+/**
+ * Contain `body_artifacts_dir` to safe locations. The handler reads every
+ * results.md and merge-report.md under this directory into the MR body, so an
+ * unchecked path would let a caller exfiltrate arbitrary file contents into a
+ * PR description (and its SHA). Resolution rules:
+ *   - If not explicitly supplied, the default `/tmp/wavemachine/<slug>/` is
+ *     trusted unconditionally.
+ *   - If explicit, the resolved absolute path must be under `/tmp/` or under
+ *     the caller's project directory. Anything else is rejected.
+ */
+function resolveArtifactsDir(
+  explicit: string | undefined,
+  defaultPath: string,
+  projectRoot: string,
+): { ok: true; path: string } | { ok: false; error: string } {
+  if (explicit === undefined || explicit.length === 0) {
+    return { ok: true, path: defaultPath };
+  }
+  const absolute = resolve(explicit);
+  const projectAbs = resolve(projectRoot);
+  if (
+    absolute.startsWith('/tmp/') ||
+    absolute === '/tmp' ||
+    absolute === projectAbs ||
+    absolute.startsWith(`${projectAbs}/`)
+  ) {
+    return { ok: true, path: absolute };
+  }
+  return {
+    ok: false,
+    error: `body_artifacts_dir '${explicit}' resolves outside allowed roots (/tmp or project directory)`,
+  };
+}
+
+/** Extract the free-text slug suffix from `kahuna/<epic_id>-<slug>`. */
+function epicSlugFromBranch(kahunaBranch: string): string {
+  const m = /^kahuna\/\d+-(.+)$/.exec(kahunaBranch);
+  return m !== null ? m[1] : '';
+}
+
+function shellEscape(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+interface RunResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+function run(cmd: string, cwd: string): RunResult {
+  try {
+    const out = execSync(cmd, { encoding: 'utf8', cwd });
+    return { ok: true, stdout: out.trim(), stderr: '' };
+  } catch (err) {
+    const e = err as { stderr?: Buffer | string; stdout?: Buffer | string; message?: string };
+    const stderr = (typeof e.stderr === 'string' ? e.stderr : e.stderr?.toString() ?? '') ?? '';
+    const stdout = (typeof e.stdout === 'string' ? e.stdout : e.stdout?.toString() ?? '') ?? '';
+    return { ok: false, stdout: stdout.trim(), stderr: stderr.trim() || e.message || '' };
+  }
+}
+
+function listDirs(path: string): string[] {
+  try {
+    return readdirSync(path).filter((name) => {
+      try {
+        return statSync(join(path, name)).isDirectory();
+      } catch {
+        return false;
+      }
+    });
+  } catch {
+    return [];
+  }
+}
+
+function readIfExists(path: string): string | null {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function extractMrUrl(content: string): string | undefined {
+  const m = /https?:\/\/[^\s)"']+\/(?:pull|merge_requests)\/\d+/.exec(content);
+  return m !== null ? m[0] : undefined;
+}
+
+function extractSummary(content: string): string {
+  for (const raw of content.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line.length === 0) continue;
+    if (line.startsWith('#')) continue;
+    return line.replace(/^[-*]\s*/, '').slice(0, 240);
+  }
+  return '';
+}
+
+interface AssembleResult {
+  body: string;
+  issueCount: number;
+  flightCount: number;
+}
+
+/**
+ * Walks the canonical wavebus layout:
+ *   artifactsDir / wave-N / flight-M / issue-X / results.md
+ * and composes a markdown body grouping entries by wave and flight. Each
+ * per-issue bullet links to the flight's PR/MR when the URL is recoverable
+ * from the artifact (from results.md directly or from the flight's
+ * `merge-report.md`).
+ *
+ * Silently falls back to a flatter layout where the devspec describes
+ * `flight-M/results.md` with no issue-X sub-directory — keeps the handler
+ * resilient to artifact-layout drift.
+ */
+function assembleBody(
+  artifactsDir: string,
+  epicId: number,
+  kahunaBranch: string,
+  targetBranch: string,
+): AssembleResult {
+  const waves = listDirs(artifactsDir)
+    .filter((d) => d.startsWith('wave-'))
+    .sort();
+
+  const lines: string[] = [];
+  lines.push(`Epic #${epicId} — integration branch \`${kahunaBranch}\` ready for merge into \`${targetBranch}\`.`);
+  lines.push('');
+  lines.push('## Waves');
+
+  let flightCount = 0;
+  let issueCount = 0;
+
+  for (const wave of waves) {
+    const wavePath = join(artifactsDir, wave);
+    const flights = listDirs(wavePath).filter((d) => d.startsWith('flight-')).sort();
+    if (flights.length === 0) continue;
+    lines.push('');
+    lines.push(`### ${wave}`);
+
+    for (const flight of flights) {
+      flightCount++;
+      const flightPath = join(wavePath, flight);
+      lines.push('');
+      lines.push(`#### ${flight}`);
+
+      const issues = listDirs(flightPath).filter((d) => d.startsWith('issue-')).sort();
+      if (issues.length > 0) {
+        const mergeReport = readIfExists(join(flightPath, 'merge-report.md')) ?? '';
+        const mergeReportUrls = new Map<string, string>();
+        // Best-effort correlation: line-level scan for "issue-X" paired with a PR/MR URL.
+        for (const m of mergeReport.matchAll(/issue[-_ ]*#?(\d+)[^\n]*?(https?:\/\/\S+?\/(?:pull|merge_requests)\/\d+)/gi)) {
+          mergeReportUrls.set(m[1], m[2]);
+        }
+        for (const issueDir of issues) {
+          issueCount++;
+          const issueId = issueDir.replace(/^issue-/, '');
+          const results = readIfExists(join(flightPath, issueDir, 'results.md')) ?? '';
+          const mrUrl = extractMrUrl(results) ?? mergeReportUrls.get(issueId);
+          const summary = extractSummary(results);
+          const mrLink = mrUrl !== undefined ? `[PR](${mrUrl}) — ` : '';
+          const bullet = summary.length > 0 ? `${mrLink}${summary}` : mrLink.replace(/ — $/, '');
+          lines.push(`- Issue #${issueId}: ${bullet}`.trimEnd());
+        }
+      } else {
+        // Flatter shape: flight-*/results.md directly (per devspec wording).
+        const results = readIfExists(join(flightPath, 'results.md'));
+        if (results !== null) {
+          issueCount++;
+          const mrUrl = extractMrUrl(results);
+          const summary = extractSummary(results);
+          const mrLink = mrUrl !== undefined ? `[PR](${mrUrl}) — ` : '';
+          lines.push(`- ${mrLink}${summary}`.trimEnd());
+        }
+      }
+    }
+  }
+
+  return { body: lines.join('\n'), issueCount, flightCount };
+}
+
+interface NormalizedMr {
+  number: number;
+  url: string;
+  state: 'open';
+  head: string;
+  base: string;
+}
+
+function branchExistsOnRemote(cwd: string, branch: string): boolean {
+  const out = run(`git ls-remote --heads origin ${shellEscape(branch)}`, cwd);
+  if (!out.ok) return false;
+  return out.stdout.length > 0;
+}
+
+function findExistingGithubPr(head: string, base: string, cwd: string): NormalizedMr | null {
+  const cmd =
+    `gh pr list --head ${shellEscape(head)} --base ${shellEscape(base)} ` +
+    `--state open --json number,url,state,headRefName,baseRefName --limit 1`;
+  const result = run(cmd, cwd);
+  if (!result.ok) return null;
+  try {
+    const prs = JSON.parse(result.stdout) as Array<{
+      number: number;
+      url: string;
+      state: string;
+      headRefName: string;
+      baseRefName: string;
+    }>;
+    if (prs.length === 0) return null;
+    const pr = prs[0];
+    return { number: pr.number, url: pr.url, state: 'open', head: pr.headRefName, base: pr.baseRefName };
+  } catch {
+    return null;
+  }
+}
+
+function findExistingGitlabMr(head: string, base: string, cwd: string): NormalizedMr | null {
+  const cmd =
+    `glab mr list --source-branch ${shellEscape(head)} --target-branch ${shellEscape(base)} ` +
+    `--state opened -F json -P 1`;
+  const result = run(cmd, cwd);
+  if (!result.ok) return null;
+  try {
+    const mrs = JSON.parse(result.stdout) as Array<{
+      iid: number;
+      web_url: string;
+      state: string;
+      source_branch: string;
+      target_branch: string;
+    }>;
+    if (mrs.length === 0) return null;
+    const mr = mrs[0];
+    return { number: mr.iid, url: mr.web_url, state: 'open', head: mr.source_branch, base: mr.target_branch };
+  } catch {
+    return null;
+  }
+}
+
+interface CreateArgs {
+  title: string;
+  body: string;
+  base: string;
+  head: string;
+}
+
+function createGithubPr(args: CreateArgs, cwd: string): NormalizedMr {
+  const cmd =
+    `gh pr create --title ${shellEscape(args.title)} --body ${shellEscape(args.body)} ` +
+    `--base ${shellEscape(args.base)} --head ${shellEscape(args.head)}`;
+  const result = run(cmd, cwd);
+  if (!result.ok) {
+    throw new Error(`gh pr create failed: ${result.stderr || result.stdout}`);
+  }
+  const url = result.stdout.split('\n').pop() ?? '';
+  const numMatch = /\/pull\/(\d+)/.exec(url);
+  if (numMatch === null) {
+    throw new Error(`gh pr create: could not parse PR number from output: ${url}`);
+  }
+  return {
+    number: parseInt(numMatch[1], 10),
+    url: url.trim(),
+    state: 'open',
+    head: args.head,
+    base: args.base,
+  };
+}
+
+function createGitlabMr(args: CreateArgs, cwd: string): NormalizedMr {
+  const cmd =
+    `glab mr create --title ${shellEscape(args.title)} --description ${shellEscape(args.body)} ` +
+    `--target-branch ${shellEscape(args.base)} --source-branch ${shellEscape(args.head)} --yes`;
+  const result = run(cmd, cwd);
+  if (!result.ok) {
+    throw new Error(`glab mr create failed: ${result.stderr || result.stdout}`);
+  }
+  // Normalize by fetching the MR we just created.
+  const view = run(`glab mr view ${shellEscape(args.head)} -F json`, cwd);
+  if (!view.ok) {
+    throw new Error(`glab mr view failed: ${view.stderr || view.stdout}`);
+  }
+  const parsed = JSON.parse(view.stdout) as {
+    iid: number;
+    web_url: string;
+    source_branch: string;
+    target_branch: string;
+  };
+  return {
+    number: parsed.iid,
+    url: parsed.web_url,
+    state: 'open',
+    head: parsed.source_branch,
+    base: parsed.target_branch,
+  };
+}
+
+const waveFinalizeHandler: HandlerDef = {
+  name: 'wave_finalize',
+  description:
+    'Open (or return the existing) kahuna→target_branch MR for a KAHUNA epic. ' +
+    'Idempotent on (kahuna_branch, target_branch). The MR body is assembled from wavebus artifacts under `body_artifacts_dir` (default: /tmp/wavemachine/<slug>/). ' +
+    'Returns kahuna_branch_not_found if the branch is absent on the remote; no_artifacts if the artifact tree contains no flight results. ' +
+    'body_sha is a SHA-256 digest of the assembled body for drift detection.',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: Input;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const cwd = projectDir(args.root);
+      // NOTE: detectPlatform() runs `git remote get-url origin` from the
+      // sdlc-server's own cwd — not necessarily `cwd` resolved from args.root.
+      // For single-repo usage this is fine; for cross-repo KAHUNA workflows
+      // where root points elsewhere, the server's launch directory and the
+      // target project must be on the same platform. Matches the codebase
+      // pattern (pr_create/pr_merge/ci_*).
+      const platform = detectPlatform();
+      const resolved = resolveArtifactsDir(
+        args.body_artifacts_dir,
+        defaultArtifactsDir(args.kahuna_branch),
+        cwd,
+      );
+      if (!resolved.ok) {
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error: resolved.error }) }],
+        };
+      }
+      const artifactsDir = resolved.path;
+
+      // Idempotency first (per devspec §5.1.1 step 1). Cover the edge case
+      // where the kahuna branch was deleted after the MR was opened — we
+      // still want to return the existing open MR rather than failing on a
+      // missing branch.
+      const existing =
+        platform === 'github'
+          ? findExistingGithubPr(args.kahuna_branch, args.target_branch, cwd)
+          : findExistingGitlabMr(args.kahuna_branch, args.target_branch, cwd);
+      if (existing !== null) {
+        // Compute body_sha from current artifacts for drift detection. Empty
+        // sha when artifacts are absent — a legitimate post-cleanup state.
+        const { body, issueCount } = assembleBody(artifactsDir, args.epic_id, args.kahuna_branch, args.target_branch);
+        const bodySha = issueCount > 0 ? createHash('sha256').update(body).digest('hex') : '';
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              number: existing.number,
+              url: existing.url,
+              state: existing.state,
+              created: false,
+              body_sha: bodySha,
+            }),
+          }],
+        };
+      }
+
+      if (!branchExistsOnRemote(cwd, args.kahuna_branch)) {
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error: 'kahuna_branch_not_found' }) }],
+        };
+      }
+
+      const { body, issueCount } = assembleBody(artifactsDir, args.epic_id, args.kahuna_branch, args.target_branch);
+      if (issueCount === 0) {
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error: 'no_artifacts' }) }],
+        };
+      }
+
+      const slug = epicSlugFromBranch(args.kahuna_branch);
+      const title = `epic(#${args.epic_id}): ${slug} — kahuna to ${args.target_branch}`;
+      const bodySha = createHash('sha256').update(body).digest('hex');
+
+      const created =
+        platform === 'github'
+          ? createGithubPr({ title, body, base: args.target_branch, head: args.kahuna_branch }, cwd)
+          : createGitlabMr({ title, body, base: args.target_branch, head: args.kahuna_branch }, cwd);
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify({
+            ok: true,
+            number: created.number,
+            url: created.url,
+            state: 'open',
+            created: true,
+            body_sha: bodySha,
+          }),
+        }],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default waveFinalizeHandler;

--- a/tests/wave_finalize.test.ts
+++ b/tests/wave_finalize.test.ts
@@ -23,7 +23,7 @@ mock.module('child_process', () => ({
 
 let currentPlatform: 'github' | 'gitlab' = 'github';
 
-const { default: handler } = await import('../handlers/wave_finalize.ts');
+const { default: handler, assembleBody } = await import('../handlers/wave_finalize.ts');
 
 function parseResult(result: { content: Array<{ type: string; text: string }> }) {
   return JSON.parse(result.content[0].text) as Record<string, unknown>;
@@ -302,88 +302,58 @@ describe('wave_finalize handler', () => {
     expect(createCall).toContain("--base 'release/v2'");
   });
 
-  // --- body assembly ---
-  test('body assembles per-flight bullets with issue IDs and PR links from results.md', async () => {
+  // --- body assembly (tests the exported assembleBody directly) ---
+  test('body assembles per-flight bullets with issue IDs and PR links from results.md', () => {
     writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md',
       'Adds widget component.\nPR: https://github.com/o/r/pull/100\n');
     writeArtifact(tmpRoot, 'wave-1/flight-2/issue-6/results.md',
       'Fixes navigation crash.\nhttps://github.com/o/r/pull/101\n');
 
-    let capturedBody = '';
-    onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
-    onExec('gh pr list', '[]');
-    onExec('gh pr create', () => {
-      const createCall = execCalls[execCalls.length - 1];
-      const bodyMatch = /--body '((?:[^'\\]|\\.|'\\'')*)'/s.exec(createCall);
-      if (bodyMatch !== null) capturedBody = bodyMatch[1].replace(/'\\''/g, "'");
-      return 'https://github.com/o/r/pull/555';
-    });
+    const result = assembleBody(tmpRoot, 42, 'kahuna/42-foo', 'main');
 
-    await handler.execute({
-      epic_id: 42,
-      kahuna_branch: 'kahuna/42-foo',
-      body_artifacts_dir: tmpRoot,
-    });
-
-    expect(capturedBody).toContain('Epic #42');
-    expect(capturedBody).toContain('wave-1');
-    expect(capturedBody).toContain('flight-1');
-    expect(capturedBody).toContain('flight-2');
-    expect(capturedBody).toContain('Issue #5');
-    expect(capturedBody).toContain('Issue #6');
-    expect(capturedBody).toContain('https://github.com/o/r/pull/100');
-    expect(capturedBody).toContain('https://github.com/o/r/pull/101');
-    expect(capturedBody).toContain('Adds widget component');
-    expect(capturedBody).toContain('Fixes navigation crash');
+    expect(result.flightCount).toBe(2);
+    expect(result.issueCount).toBe(2);
+    expect(result.body).toContain('Epic #42');
+    expect(result.body).toContain('wave-1');
+    expect(result.body).toContain('flight-1');
+    expect(result.body).toContain('flight-2');
+    expect(result.body).toContain('Issue #5');
+    expect(result.body).toContain('Issue #6');
+    expect(result.body).toContain('https://github.com/o/r/pull/100');
+    expect(result.body).toContain('https://github.com/o/r/pull/101');
+    expect(result.body).toContain('Adds widget component');
+    expect(result.body).toContain('Fixes navigation crash');
   });
 
-  test('body assembly falls back to flight-level merge-report.md for MR URL when results.md lacks one', async () => {
+  test('body assembly falls back to flight-level merge-report.md for MR URL when results.md lacks one', () => {
     writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md',
       'Adds widget component.\n(no URL here)\n');
     writeArtifact(tmpRoot, 'wave-1/flight-1/merge-report.md',
       '# Merge Report\n\n- issue-5 landed: https://github.com/o/r/pull/100 (CI green, direct squash)\n');
 
-    let capturedBody = '';
-    onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
-    onExec('gh pr list', '[]');
-    onExec('gh pr create', () => {
-      const createCall = execCalls[execCalls.length - 1];
-      const bodyMatch = /--body '((?:[^'\\]|\\.|'\\'')*)'/s.exec(createCall);
-      if (bodyMatch !== null) capturedBody = bodyMatch[1].replace(/'\\''/g, "'");
-      return 'https://github.com/o/r/pull/555';
-    });
+    const result = assembleBody(tmpRoot, 42, 'kahuna/42-foo', 'main');
 
-    await handler.execute({
-      epic_id: 42,
-      kahuna_branch: 'kahuna/42-foo',
-      body_artifacts_dir: tmpRoot,
-    });
-
-    expect(capturedBody).toContain('https://github.com/o/r/pull/100');
+    expect(result.body).toContain('https://github.com/o/r/pull/100');
   });
 
-  test('body assembly supports fallback flat layout: flight-*/results.md (no issue-* dir)', async () => {
+  test('body assembly supports fallback flat layout: flight-*/results.md (no issue-* dir)', () => {
     writeArtifact(tmpRoot, 'wave-1/flight-1/results.md',
       'Combined flight summary.\nPR: https://github.com/o/r/pull/200\n');
 
-    let capturedBody = '';
-    onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
-    onExec('gh pr list', '[]');
-    onExec('gh pr create', () => {
-      const createCall = execCalls[execCalls.length - 1];
-      const bodyMatch = /--body '((?:[^'\\]|\\.|'\\'')*)'/s.exec(createCall);
-      if (bodyMatch !== null) capturedBody = bodyMatch[1].replace(/'\\''/g, "'");
-      return 'https://github.com/o/r/pull/555';
-    });
+    const result = assembleBody(tmpRoot, 42, 'kahuna/42-foo', 'main');
 
-    await handler.execute({
-      epic_id: 42,
-      kahuna_branch: 'kahuna/42-foo',
-      body_artifacts_dir: tmpRoot,
-    });
+    expect(result.issueCount).toBe(1);
+    expect(result.body).toContain('Combined flight summary');
+    expect(result.body).toContain('https://github.com/o/r/pull/200');
+  });
 
-    expect(capturedBody).toContain('Combined flight summary');
-    expect(capturedBody).toContain('https://github.com/o/r/pull/200');
+  test('body assembly returns issueCount=0 for an empty artifact tree', () => {
+    const result = assembleBody(tmpRoot, 42, 'kahuna/42-foo', 'main');
+    expect(result.issueCount).toBe(0);
+    expect(result.flightCount).toBe(0);
+    // Body still has the header — non-empty by design (issueCount is the
+    // sentinel for "had any content", not body.length).
+    expect(result.body.length).toBeGreaterThan(0);
   });
 
   // --- body_sha determinism ---

--- a/tests/wave_finalize.test.ts
+++ b/tests/wave_finalize.test.ts
@@ -1,6 +1,8 @@
 import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
-import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
+// Intentionally NOT importing from 'fs' — sibling test files partially mock
+// 'fs' (only writeFileSync exposed), and Bun's mock.module leaks across the
+// suite. Test setup uses Bun native APIs instead. See lesson_mcp_gotchas.md §6.
 
 type Responder = string | (() => string);
 
@@ -34,30 +36,25 @@ function onExec(match: string, respond: Responder) {
 }
 
 // --- tmp artifacts helpers ---
+// Each test gets a unique tmpRoot path. We do NOT pre-create the directory;
+// Bun.write creates parent dirs automatically when the first artifact lands.
+// Tests that don't write any artifacts simply leave tmpRoot non-existent —
+// the handler's safeScan path tolerates that.
 let tmpRoot: string = '';
 
-function makeTmpDir(): string {
-  const dir = `/tmp/wave-finalize-test-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
-  mkdirSync(dir, { recursive: true });
-  return dir;
+function makeTmpRoot(): string {
+  return `/tmp/wave-finalize-test-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
 }
 
-function writeArtifact(root: string, relPath: string, content: string): void {
-  const full = join(root, relPath);
-  const dir = full.substring(0, full.lastIndexOf('/'));
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(full, content);
+async function writeArtifact(root: string, relPath: string, content: string): Promise<void> {
+  await Bun.write(join(root, relPath), content);
 }
 
 beforeEach(() => {
   execRegistry = [];
   execCalls = [];
   currentPlatform = 'github';
-  tmpRoot = makeTmpDir();
-  // detectPlatform() in lib/glab reads `git remote get-url origin`. Route it
-  // through the shared exec mock so individual tests control the platform
-  // via `currentPlatform`. Registered first so later test-specific matchers
-  // (registered via onExec) take precedence for other commands.
+  tmpRoot = makeTmpRoot();
   execRegistry.push({
     match: 'git remote get-url origin',
     respond: () => currentPlatform === 'gitlab'
@@ -69,11 +66,8 @@ beforeEach(() => {
 afterEach(() => {
   execRegistry = [];
   execCalls = [];
-  try {
-    rmSync(tmpRoot, { recursive: true, force: true });
-  } catch {
-    // ignore cleanup failures
-  }
+  // Tmp files in /tmp are reaped by the OS; explicit cleanup intentionally
+  // skipped to avoid depending on fs.rmSync (mock leakage risk).
 });
 
 describe('wave_finalize handler', () => {
@@ -143,7 +137,7 @@ describe('wave_finalize handler', () => {
 
   // --- idempotency edge case: MR open but branch deleted post-merge-attempt ---
   test('returns existing open MR even when the kahuna branch has been deleted', async () => {
-    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
 
     onExec('gh pr list', JSON.stringify([{
       number: 88, url: 'https://github.com/o/r/pull/88',
@@ -178,7 +172,9 @@ describe('wave_finalize handler', () => {
   });
 
   test('no_artifacts even when wave-* dirs exist but no flights', async () => {
-    mkdirSync(join(tmpRoot, 'wave-1'), { recursive: true });
+    // Write a non-matching marker file inside wave-1/ so the directory exists
+    // without any matching flight-*/issue-*/results.md path.
+    await Bun.write(join(tmpRoot, 'wave-1', 'README.md'), 'no flights yet');
 
     onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
     onExec('gh pr list', '[]');
@@ -196,7 +192,7 @@ describe('wave_finalize handler', () => {
   // --- idempotency ---
   test('returns existing PR with created: false when one already exists', async () => {
     // Artifacts present so we can compute body_sha for drift detection.
-    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md',
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md',
       '# results\n\n- Added widget\nPR: https://github.com/o/r/pull/100\n');
 
     onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
@@ -221,7 +217,7 @@ describe('wave_finalize handler', () => {
   });
 
   test('idempotent: does not call gh pr create when an existing PR is found', async () => {
-    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
 
     onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
     onExec('gh pr list', JSON.stringify([{
@@ -240,9 +236,9 @@ describe('wave_finalize handler', () => {
 
   // --- happy path: github ---
   test('github happy path: creates PR with assembled body and returns body_sha', async () => {
-    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md',
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md',
       '# Results\n\nAdded widget.\nPR: https://github.com/o/r/pull/100\n');
-    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-6/results.md',
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-6/results.md',
       '# Results\n\nFixed bug.\nPR: https://github.com/o/r/pull/101\n');
 
     onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-wave-status-cli');
@@ -266,7 +262,7 @@ describe('wave_finalize handler', () => {
   });
 
   test('title uses epic(#N): <slug> — kahuna to <target_branch>', async () => {
-    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
 
     onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-wave-status-cli');
     onExec('gh pr list', '[]');
@@ -284,7 +280,7 @@ describe('wave_finalize handler', () => {
   });
 
   test('title uses explicit target_branch when provided', async () => {
-    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
 
     onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
     onExec('gh pr list', '[]');
@@ -304,9 +300,9 @@ describe('wave_finalize handler', () => {
 
   // --- body assembly (tests the exported assembleBody directly) ---
   test('body assembles per-flight bullets with issue IDs and PR links from results.md', async () => {
-    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md',
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md',
       'Adds widget component.\nPR: https://github.com/o/r/pull/100\n');
-    writeArtifact(tmpRoot, 'wave-1/flight-2/issue-6/results.md',
+    await writeArtifact(tmpRoot, 'wave-1/flight-2/issue-6/results.md',
       'Fixes navigation crash.\nhttps://github.com/o/r/pull/101\n');
 
     const result = await assembleBody(tmpRoot, 42, 'kahuna/42-foo', 'main');
@@ -326,9 +322,9 @@ describe('wave_finalize handler', () => {
   });
 
   test('body assembly falls back to flight-level merge-report.md for MR URL when results.md lacks one', async () => {
-    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md',
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md',
       'Adds widget component.\n(no URL here)\n');
-    writeArtifact(tmpRoot, 'wave-1/flight-1/merge-report.md',
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/merge-report.md',
       '# Merge Report\n\n- issue-5 landed: https://github.com/o/r/pull/100 (CI green, direct squash)\n');
 
     const result = await assembleBody(tmpRoot, 42, 'kahuna/42-foo', 'main');
@@ -337,7 +333,7 @@ describe('wave_finalize handler', () => {
   });
 
   test('body assembly supports fallback flat layout: flight-*/results.md (no issue-* dir)', async () => {
-    writeArtifact(tmpRoot, 'wave-1/flight-1/results.md',
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/results.md',
       'Combined flight summary.\nPR: https://github.com/o/r/pull/200\n');
 
     const result = await assembleBody(tmpRoot, 42, 'kahuna/42-foo', 'main');
@@ -358,8 +354,8 @@ describe('wave_finalize handler', () => {
 
   // --- body_sha determinism ---
   test('body_sha is deterministic — same artifacts produce the same hash', async () => {
-    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'Summary A\nPR: https://github.com/o/r/pull/100');
-    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-6/results.md', 'Summary B\nPR: https://github.com/o/r/pull/101');
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'Summary A\nPR: https://github.com/o/r/pull/100');
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-6/results.md', 'Summary B\nPR: https://github.com/o/r/pull/101');
 
     onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
     onExec('gh pr list', JSON.stringify([{
@@ -403,7 +399,7 @@ describe('wave_finalize handler', () => {
   // --- gitlab happy path ---
   test('gitlab happy path: creates MR with assembled body', async () => {
     currentPlatform = 'gitlab';
-    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md',
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md',
       'Done.\nMR: https://gitlab.com/o/r/-/merge_requests/100\n');
 
     onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
@@ -431,7 +427,7 @@ describe('wave_finalize handler', () => {
 
   test('gitlab idempotency: returns existing MR when one already exists', async () => {
     currentPlatform = 'gitlab';
-    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
 
     onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
     onExec('glab mr list', JSON.stringify([{
@@ -468,7 +464,7 @@ describe('wave_finalize handler', () => {
   });
 
   test('accepts body_artifacts_dir under /tmp', async () => {
-    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
     onExec('gh pr list', '[]');
     onExec('git ls-remote', 'abc\trefs/heads/kahuna/42-foo');
     onExec('gh pr create', 'https://github.com/o/r/pull/555');
@@ -515,7 +511,7 @@ describe('wave_finalize handler', () => {
 
   // --- shell escaping ---
   test('shell-escapes kahuna_branch and target_branch in all commands', async () => {
-    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
 
     onExec('git ls-remote', 'abc\trefs/heads/kahuna/42-foo');
     onExec('gh pr list', '[]');

--- a/tests/wave_finalize.test.ts
+++ b/tests/wave_finalize.test.ts
@@ -303,13 +303,13 @@ describe('wave_finalize handler', () => {
   });
 
   // --- body assembly (tests the exported assembleBody directly) ---
-  test('body assembles per-flight bullets with issue IDs and PR links from results.md', () => {
+  test('body assembles per-flight bullets with issue IDs and PR links from results.md', async () => {
     writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md',
       'Adds widget component.\nPR: https://github.com/o/r/pull/100\n');
     writeArtifact(tmpRoot, 'wave-1/flight-2/issue-6/results.md',
       'Fixes navigation crash.\nhttps://github.com/o/r/pull/101\n');
 
-    const result = assembleBody(tmpRoot, 42, 'kahuna/42-foo', 'main');
+    const result = await assembleBody(tmpRoot, 42, 'kahuna/42-foo', 'main');
 
     expect(result.flightCount).toBe(2);
     expect(result.issueCount).toBe(2);
@@ -325,30 +325,30 @@ describe('wave_finalize handler', () => {
     expect(result.body).toContain('Fixes navigation crash');
   });
 
-  test('body assembly falls back to flight-level merge-report.md for MR URL when results.md lacks one', () => {
+  test('body assembly falls back to flight-level merge-report.md for MR URL when results.md lacks one', async () => {
     writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md',
       'Adds widget component.\n(no URL here)\n');
     writeArtifact(tmpRoot, 'wave-1/flight-1/merge-report.md',
       '# Merge Report\n\n- issue-5 landed: https://github.com/o/r/pull/100 (CI green, direct squash)\n');
 
-    const result = assembleBody(tmpRoot, 42, 'kahuna/42-foo', 'main');
+    const result = await assembleBody(tmpRoot, 42, 'kahuna/42-foo', 'main');
 
     expect(result.body).toContain('https://github.com/o/r/pull/100');
   });
 
-  test('body assembly supports fallback flat layout: flight-*/results.md (no issue-* dir)', () => {
+  test('body assembly supports fallback flat layout: flight-*/results.md (no issue-* dir)', async () => {
     writeArtifact(tmpRoot, 'wave-1/flight-1/results.md',
       'Combined flight summary.\nPR: https://github.com/o/r/pull/200\n');
 
-    const result = assembleBody(tmpRoot, 42, 'kahuna/42-foo', 'main');
+    const result = await assembleBody(tmpRoot, 42, 'kahuna/42-foo', 'main');
 
     expect(result.issueCount).toBe(1);
     expect(result.body).toContain('Combined flight summary');
     expect(result.body).toContain('https://github.com/o/r/pull/200');
   });
 
-  test('body assembly returns issueCount=0 for an empty artifact tree', () => {
-    const result = assembleBody(tmpRoot, 42, 'kahuna/42-foo', 'main');
+  test('body assembly returns issueCount=0 for an empty artifact tree', async () => {
+    const result = await assembleBody(tmpRoot, 42, 'kahuna/42-foo', 'main');
     expect(result.issueCount).toBe(0);
     expect(result.flightCount).toBe(0);
     // Body still has the header — non-empty by design (issueCount is the

--- a/tests/wave_finalize.test.ts
+++ b/tests/wave_finalize.test.ts
@@ -1,0 +1,568 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+
+type Responder = string | (() => string);
+
+let execRegistry: Array<{ match: string; respond: Responder }> = [];
+let execCalls: string[] = [];
+
+function mockExec(cmd: string): string {
+  execCalls.push(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  throw new Error(`Unexpected exec call: ${cmd}`);
+}
+
+mock.module('child_process', () => ({
+  execSync: (cmd: string, _opts?: unknown) => mockExec(cmd),
+}));
+
+let currentPlatform: 'github' | 'gitlab' = 'github';
+
+const { default: handler } = await import('../handlers/wave_finalize.ts');
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text) as Record<string, unknown>;
+}
+
+function onExec(match: string, respond: Responder) {
+  execRegistry.push({ match, respond });
+}
+
+// --- tmp artifacts helpers ---
+let tmpRoot: string = '';
+
+function makeTmpDir(): string {
+  const dir = `/tmp/wave-finalize-test-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeArtifact(root: string, relPath: string, content: string): void {
+  const full = join(root, relPath);
+  const dir = full.substring(0, full.lastIndexOf('/'));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(full, content);
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+  currentPlatform = 'github';
+  tmpRoot = makeTmpDir();
+  // detectPlatform() in lib/glab reads `git remote get-url origin`. Route it
+  // through the shared exec mock so individual tests control the platform
+  // via `currentPlatform`. Registered first so later test-specific matchers
+  // (registered via onExec) take precedence for other commands.
+  execRegistry.push({
+    match: 'git remote get-url origin',
+    respond: () => currentPlatform === 'gitlab'
+      ? 'git@gitlab.com:o/r.git'
+      : 'git@github.com:o/r.git',
+  });
+});
+
+afterEach(() => {
+  execRegistry = [];
+  execCalls = [];
+  try {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  } catch {
+    // ignore cleanup failures
+  }
+});
+
+describe('wave_finalize handler', () => {
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('wave_finalize');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  // --- schema validation ---
+  test('schema rejects missing epic_id', async () => {
+    const result = await handler.execute({
+      kahuna_branch: 'kahuna/42-foo',
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+    expect(data.error as string).toContain('epic_id');
+  });
+
+  test('schema rejects non-positive epic_id', async () => {
+    const result = await handler.execute({
+      epic_id: 0,
+      kahuna_branch: 'kahuna/42-foo',
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+  });
+
+  test('schema rejects missing kahuna_branch', async () => {
+    const result = await handler.execute({ epic_id: 42 });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+  });
+
+  test('target_branch defaults to main', async () => {
+    onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
+    onExec('gh pr list', JSON.stringify([{
+      number: 99, url: 'https://github.com/o/r/pull/99',
+      state: 'OPEN', headRefName: 'kahuna/42-foo', baseRefName: 'main',
+    }]));
+
+    const result = await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      body_artifacts_dir: tmpRoot,
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    // gh pr list was called with --base main (default)
+    const listCall = execCalls.find(c => c.includes('gh pr list'));
+    expect(listCall).toContain("--base 'main'");
+  });
+
+  // --- error: kahuna_branch_not_found ---
+  test('returns kahuna_branch_not_found when neither an open MR nor the branch exists', async () => {
+    onExec('gh pr list', '[]'); // no existing PR
+    onExec('git ls-remote', ''); // branch absent
+
+    const result = await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-nonexistent',
+      body_artifacts_dir: tmpRoot,
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+    expect(data.error).toBe('kahuna_branch_not_found');
+  });
+
+  // --- idempotency edge case: MR open but branch deleted post-merge-attempt ---
+  test('returns existing open MR even when the kahuna branch has been deleted', async () => {
+    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
+
+    onExec('gh pr list', JSON.stringify([{
+      number: 88, url: 'https://github.com/o/r/pull/88',
+      state: 'OPEN', headRefName: 'kahuna/42-foo', baseRefName: 'main',
+    }]));
+    onExec('git ls-remote', ''); // branch gone — should NOT matter since MR is found first
+
+    const result = await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      body_artifacts_dir: tmpRoot,
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(data.created).toBe(false);
+    expect(data.number).toBe(88);
+  });
+
+  // --- error: no_artifacts ---
+  test('returns no_artifacts when artifact tree has no flight results', async () => {
+    onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
+    onExec('gh pr list', '[]'); // no existing PR
+
+    const result = await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      body_artifacts_dir: tmpRoot, // empty directory
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+    expect(data.error).toBe('no_artifacts');
+  });
+
+  test('no_artifacts even when wave-* dirs exist but no flights', async () => {
+    mkdirSync(join(tmpRoot, 'wave-1'), { recursive: true });
+
+    onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
+    onExec('gh pr list', '[]');
+
+    const result = await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      body_artifacts_dir: tmpRoot,
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+    expect(data.error).toBe('no_artifacts');
+  });
+
+  // --- idempotency ---
+  test('returns existing PR with created: false when one already exists', async () => {
+    // Artifacts present so we can compute body_sha for drift detection.
+    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md',
+      '# results\n\n- Added widget\nPR: https://github.com/o/r/pull/100\n');
+
+    onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
+    onExec('gh pr list', JSON.stringify([{
+      number: 88, url: 'https://github.com/o/r/pull/88',
+      state: 'OPEN', headRefName: 'kahuna/42-foo', baseRefName: 'main',
+    }]));
+
+    const result = await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      body_artifacts_dir: tmpRoot,
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(data.created).toBe(false);
+    expect(data.number).toBe(88);
+    expect(data.url).toBe('https://github.com/o/r/pull/88');
+    // body_sha computed from artifacts for drift comparison
+    expect(typeof data.body_sha).toBe('string');
+    expect((data.body_sha as string).length).toBe(64); // SHA-256 hex
+  });
+
+  test('idempotent: does not call gh pr create when an existing PR is found', async () => {
+    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
+
+    onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
+    onExec('gh pr list', JSON.stringify([{
+      number: 88, url: 'https://github.com/o/r/pull/88',
+      state: 'OPEN', headRefName: 'kahuna/42-foo', baseRefName: 'main',
+    }]));
+
+    await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      body_artifacts_dir: tmpRoot,
+    });
+
+    expect(execCalls.some(c => c.includes('gh pr create'))).toBe(false);
+  });
+
+  // --- happy path: github ---
+  test('github happy path: creates PR with assembled body and returns body_sha', async () => {
+    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md',
+      '# Results\n\nAdded widget.\nPR: https://github.com/o/r/pull/100\n');
+    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-6/results.md',
+      '# Results\n\nFixed bug.\nPR: https://github.com/o/r/pull/101\n');
+
+    onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-wave-status-cli');
+    onExec('gh pr list', '[]');
+    onExec('gh pr create', 'https://github.com/o/r/pull/555');
+
+    const result = await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-wave-status-cli',
+      body_artifacts_dir: tmpRoot,
+    });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.created).toBe(true);
+    expect(data.number).toBe(555);
+    expect(data.url).toBe('https://github.com/o/r/pull/555');
+    expect(data.state).toBe('open');
+    expect(typeof data.body_sha).toBe('string');
+    expect((data.body_sha as string).length).toBe(64);
+  });
+
+  test('title uses epic(#N): <slug> — kahuna to <target_branch>', async () => {
+    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
+
+    onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-wave-status-cli');
+    onExec('gh pr list', '[]');
+    onExec('gh pr create', 'https://github.com/o/r/pull/555');
+
+    await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-wave-status-cli',
+      body_artifacts_dir: tmpRoot,
+    });
+
+    const createCall = execCalls.find(c => c.includes('gh pr create'));
+    expect(createCall).toBeDefined();
+    expect(createCall).toContain("--title 'epic(#42): wave-status-cli — kahuna to main'");
+  });
+
+  test('title uses explicit target_branch when provided', async () => {
+    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
+
+    onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
+    onExec('gh pr list', '[]');
+    onExec('gh pr create', 'https://github.com/o/r/pull/555');
+
+    await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'release/v2',
+      body_artifacts_dir: tmpRoot,
+    });
+
+    const createCall = execCalls.find(c => c.includes('gh pr create'));
+    expect(createCall).toContain("kahuna to release/v2");
+    expect(createCall).toContain("--base 'release/v2'");
+  });
+
+  // --- body assembly ---
+  test('body assembles per-flight bullets with issue IDs and PR links from results.md', async () => {
+    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md',
+      'Adds widget component.\nPR: https://github.com/o/r/pull/100\n');
+    writeArtifact(tmpRoot, 'wave-1/flight-2/issue-6/results.md',
+      'Fixes navigation crash.\nhttps://github.com/o/r/pull/101\n');
+
+    let capturedBody = '';
+    onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
+    onExec('gh pr list', '[]');
+    onExec('gh pr create', () => {
+      const createCall = execCalls[execCalls.length - 1];
+      const bodyMatch = /--body '((?:[^'\\]|\\.|'\\'')*)'/s.exec(createCall);
+      if (bodyMatch !== null) capturedBody = bodyMatch[1].replace(/'\\''/g, "'");
+      return 'https://github.com/o/r/pull/555';
+    });
+
+    await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      body_artifacts_dir: tmpRoot,
+    });
+
+    expect(capturedBody).toContain('Epic #42');
+    expect(capturedBody).toContain('wave-1');
+    expect(capturedBody).toContain('flight-1');
+    expect(capturedBody).toContain('flight-2');
+    expect(capturedBody).toContain('Issue #5');
+    expect(capturedBody).toContain('Issue #6');
+    expect(capturedBody).toContain('https://github.com/o/r/pull/100');
+    expect(capturedBody).toContain('https://github.com/o/r/pull/101');
+    expect(capturedBody).toContain('Adds widget component');
+    expect(capturedBody).toContain('Fixes navigation crash');
+  });
+
+  test('body assembly falls back to flight-level merge-report.md for MR URL when results.md lacks one', async () => {
+    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md',
+      'Adds widget component.\n(no URL here)\n');
+    writeArtifact(tmpRoot, 'wave-1/flight-1/merge-report.md',
+      '# Merge Report\n\n- issue-5 landed: https://github.com/o/r/pull/100 (CI green, direct squash)\n');
+
+    let capturedBody = '';
+    onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
+    onExec('gh pr list', '[]');
+    onExec('gh pr create', () => {
+      const createCall = execCalls[execCalls.length - 1];
+      const bodyMatch = /--body '((?:[^'\\]|\\.|'\\'')*)'/s.exec(createCall);
+      if (bodyMatch !== null) capturedBody = bodyMatch[1].replace(/'\\''/g, "'");
+      return 'https://github.com/o/r/pull/555';
+    });
+
+    await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      body_artifacts_dir: tmpRoot,
+    });
+
+    expect(capturedBody).toContain('https://github.com/o/r/pull/100');
+  });
+
+  test('body assembly supports fallback flat layout: flight-*/results.md (no issue-* dir)', async () => {
+    writeArtifact(tmpRoot, 'wave-1/flight-1/results.md',
+      'Combined flight summary.\nPR: https://github.com/o/r/pull/200\n');
+
+    let capturedBody = '';
+    onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
+    onExec('gh pr list', '[]');
+    onExec('gh pr create', () => {
+      const createCall = execCalls[execCalls.length - 1];
+      const bodyMatch = /--body '((?:[^'\\]|\\.|'\\'')*)'/s.exec(createCall);
+      if (bodyMatch !== null) capturedBody = bodyMatch[1].replace(/'\\''/g, "'");
+      return 'https://github.com/o/r/pull/555';
+    });
+
+    await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      body_artifacts_dir: tmpRoot,
+    });
+
+    expect(capturedBody).toContain('Combined flight summary');
+    expect(capturedBody).toContain('https://github.com/o/r/pull/200');
+  });
+
+  // --- body_sha determinism ---
+  test('body_sha is deterministic — same artifacts produce the same hash', async () => {
+    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'Summary A\nPR: https://github.com/o/r/pull/100');
+    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-6/results.md', 'Summary B\nPR: https://github.com/o/r/pull/101');
+
+    onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
+    onExec('gh pr list', JSON.stringify([{
+      number: 1, url: 'https://github.com/o/r/pull/1',
+      state: 'OPEN', headRefName: 'kahuna/42-foo', baseRefName: 'main',
+    }]));
+
+    const r1 = parseResult(await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      body_artifacts_dir: tmpRoot,
+    }));
+    const r2 = parseResult(await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      body_artifacts_dir: tmpRoot,
+    }));
+
+    expect(r1.body_sha).toBe(r2.body_sha);
+    expect((r1.body_sha as string).length).toBe(64);
+  });
+
+  // --- default body_artifacts_dir derivation ---
+  test('default body_artifacts_dir derives from kahuna_branch slug', async () => {
+    // Branch doesn't exist → path derivation not exercised; just confirm the
+    // error path (no artifact dir created) still fires correctly.
+    onExec('git ls-remote', 'abc\trefs/heads/kahuna/42-wave-status-cli');
+    onExec('gh pr list', '[]');
+
+    const result = await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-wave-status-cli',
+      // body_artifacts_dir omitted — defaults to /tmp/wavemachine/42-wave-status-cli
+    });
+    const data = parseResult(result);
+    // Directory doesn't exist → no artifacts
+    expect(data.ok).toBe(false);
+    expect(data.error).toBe('no_artifacts');
+  });
+
+  // --- gitlab happy path ---
+  test('gitlab happy path: creates MR with assembled body', async () => {
+    currentPlatform = 'gitlab';
+    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md',
+      'Done.\nMR: https://gitlab.com/o/r/-/merge_requests/100\n');
+
+    onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
+    onExec('glab mr list', '[]');
+    onExec('glab mr create', '');
+    onExec('glab mr view', JSON.stringify({
+      iid: 555,
+      web_url: 'https://gitlab.com/o/r/-/merge_requests/555',
+      source_branch: 'kahuna/42-foo',
+      target_branch: 'main',
+    }));
+
+    const result = await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      body_artifacts_dir: tmpRoot,
+    });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.created).toBe(true);
+    expect(data.number).toBe(555);
+    expect(data.url).toBe('https://gitlab.com/o/r/-/merge_requests/555');
+  });
+
+  test('gitlab idempotency: returns existing MR when one already exists', async () => {
+    currentPlatform = 'gitlab';
+    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
+
+    onExec('git ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
+    onExec('glab mr list', JSON.stringify([{
+      iid: 77,
+      web_url: 'https://gitlab.com/o/r/-/merge_requests/77',
+      state: 'opened',
+      source_branch: 'kahuna/42-foo',
+      target_branch: 'main',
+    }]));
+
+    const result = await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      body_artifacts_dir: tmpRoot,
+    });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.created).toBe(false);
+    expect(data.number).toBe(77);
+    expect(execCalls.some(c => c.includes('glab mr create'))).toBe(false);
+  });
+
+  // --- path containment ---
+  test('rejects body_artifacts_dir outside /tmp and project directory', async () => {
+    const result = await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      body_artifacts_dir: '/etc',
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+    expect(data.error as string).toContain('outside allowed roots');
+  });
+
+  test('accepts body_artifacts_dir under /tmp', async () => {
+    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
+    onExec('gh pr list', '[]');
+    onExec('git ls-remote', 'abc\trefs/heads/kahuna/42-foo');
+    onExec('gh pr create', 'https://github.com/o/r/pull/555');
+
+    const result = await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      body_artifacts_dir: tmpRoot, // /tmp/wave-finalize-test-...
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+  });
+
+  test('rejects body_artifacts_dir with parent-directory escape', async () => {
+    // resolve('/tmp/foo/../../etc') === '/etc', which is outside allowed roots.
+    const result = await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      body_artifacts_dir: '/tmp/foo/../../etc',
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+    expect(data.error as string).toContain('outside allowed roots');
+  });
+
+  // --- body_sha: empty when existing PR + no artifacts (post-cleanup) ---
+  test('body_sha is empty string when existing MR returned and artifacts are gone', async () => {
+    // Empty tmpRoot — no wave-* dirs at all
+    onExec('gh pr list', JSON.stringify([{
+      number: 88, url: 'https://github.com/o/r/pull/88',
+      state: 'OPEN', headRefName: 'kahuna/42-foo', baseRefName: 'main',
+    }]));
+
+    const result = await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      body_artifacts_dir: tmpRoot,
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(data.created).toBe(false);
+    expect(data.body_sha).toBe('');
+  });
+
+  // --- shell escaping ---
+  test('shell-escapes kahuna_branch and target_branch in all commands', async () => {
+    writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
+
+    onExec('git ls-remote', 'abc\trefs/heads/kahuna/42-foo');
+    onExec('gh pr list', '[]');
+    onExec('gh pr create', 'https://github.com/o/r/pull/555');
+
+    await handler.execute({
+      epic_id: 42,
+      kahuna_branch: "kahuna/42-has 'quotes'",
+      target_branch: 'main',
+      body_artifacts_dir: tmpRoot,
+    });
+
+    // Every command that uses these values should single-quote and escape.
+    for (const c of execCalls) {
+      if (c.includes("kahuna/42-has")) {
+        expect(c).toContain(`'kahuna/42-has '\\''quotes'\\'''`);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds `wave_finalize`, the KAHUNA epic-final gate that opens the `kahuna→target_branch` MR once an epic's waves have all landed in the kahuna integration branch. Idempotent on `(kahuna_branch, target_branch)`. Body is assembled from the wavebus artifact tree.

## Changes

- `handlers/wave_finalize.ts` — NEW handler (70th):
  - Inputs: `{root?, epic_id, kahuna_branch, target_branch?, body_artifacts_dir?}`
  - Returns: `{ok, number, url, state, created, body_sha}` (per devspec §5.1.1)
  - Order of checks (devspec §5.1.1): `pr_list` (idempotent short-circuit) → branch exists on remote → walk artifacts → `pr_create`
  - `body_sha` is SHA-256 of the assembled body, populated even on `created: false` for drift detection; empty string when artifacts have been cleaned up
  - Body assembly walks `body_artifacts_dir/wave-*/flight-*/issue-*/results.md` (canonical wavebus layout) with a fallback to `flight-*/results.md` (devspec literal). PR/MR URLs extracted from results.md content directly, falling back to flight-level `merge-report.md`.
  - Path containment: `body_artifacts_dir` must resolve under `/tmp` or the project directory. Rejected with explicit error otherwise — the handler reads every `results.md`/`merge-report.md` into the MR body, so unchecked paths would leak file contents.
  - Platform-neutral (gh + glab) via existing `detectPlatform` from `lib/glab`. Inline gh/glab calls per project pattern (handlers do not invoke other handlers).
- `tests/wave_finalize.test.ts` — NEW. 26 tests: schema validation, error paths (kahuna_branch_not_found, no_artifacts ×2, path-containment ×3), idempotency including the branch-deleted-but-MR-open edge case, github + gitlab happy paths, title format, body assembly variants (canonical layout, merge-report fallback, flat layout), body_sha determinism + empty-on-post-cleanup, default artifacts dir derivation, shell escaping.

## Linked Issues

Closes #204

## Test Plan

- [x] `bun test tests/wave_finalize.test.ts` — 26/26 pass
- [x] `bun test` full suite — 1228/1228 pass (was 1197 + 31 new from prior PRs in lane)
- [x] `./scripts/ci/validate.sh` — 70/70 handlers pass-list assertions, typecheck clean
- [x] `trivy fs --severity HIGH,CRITICAL` — 0 findings
- [x] `feature-dev:code-reviewer` — 4 findings, all addressed:
  - **CRITICAL**: path traversal on `body_artifacts_dir` → `resolveArtifactsDir()` with /tmp + project-root allowlist + tests
  - **CRITICAL**: dead `body.length > 0` guard for `body_sha` (always true since header lines are unconditional) → switched to `issueCount > 0`
  - **IMPORTANT**: original implementation checked branch-exists before pr_list — wrong order per devspec §5.1.1, also broke crash-recovery (deleted-branch + open-MR returns kahuna_branch_not_found instead of returning the MR). Swapped + regression test.
  - **IMPORTANT**: `detectPlatform()` runs in server cwd not args.root (pre-existing codebase pattern) — annotated with NOTE comment

## Notes

Canonical contract: claudecode-workflow:docs/kahuna-devspec.md §5.1.1.

This is the third and final story in tachikoma's lane of Wave 1a (Phase 1 Plumbing). Stories 1.4 (#207, lib/wave_state.ts) and 1.2 (#205, commutativity_verify single-target mode) are already on main. After this lands, the sdlc-server side of KAHUNA Phase 1 is complete; the wavebus consumer (`/wavemachine`) and `/precheck` sandbox-aware adaptations are tracked in claudecode-workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)