### PR TITLE
feat(wave_init): optional kahuna branch creation and recording

### DIFF
--- a/handlers/wave_init.ts
+++ b/handlers/wave_init.ts
@@ -3,6 +3,7 @@ import { writeFileSync } from 'fs';
 import { join } from 'path';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
+import { detectPlatform, parseRepoSlug } from '../lib/glab.js';
 
 const inputSchema = z.object({
   plan_json: z.string().min(1, 'plan_json must be a non-empty JSON string'),
@@ -11,6 +12,14 @@ const inputSchema = z.object({
   repo: z
     .string()
     .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/, 'repo must be owner/repo format')
+    .optional(),
+  // KAHUNA bootstrap (devspec §5.1.3). Optional; absence preserves the
+  // pre-KAHUNA behavior end-to-end (CT-03 backward compat).
+  kahuna: z
+    .object({
+      epic_id: z.number().int().positive(),
+      slug: z.string().min(1).regex(/^[a-z0-9][a-z0-9-]*$/, 'slug must be kebab-case (lowercase, digits, hyphens)'),
+    })
     .optional(),
 });
 
@@ -96,9 +105,178 @@ function extractPlanWaveIds(plan: PlanData): string[] {
   return ids;
 }
 
+// ---------------------------------------------------------------------------
+// KAHUNA bootstrap helpers (devspec §5.1.3)
+// ---------------------------------------------------------------------------
+
+function shellEscape(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+function execOk(cmd: string, cwd: string): { ok: boolean; stdout: string; stderr: string } {
+  try {
+    const stdout = execSync(cmd, { encoding: 'utf8', cwd });
+    return { ok: true, stdout: stdout.trim(), stderr: '' };
+  } catch (err) {
+    const e = err as { stderr?: Buffer | string; stdout?: Buffer | string; message?: string };
+    const stderr = (typeof e.stderr === 'string' ? e.stderr : e.stderr?.toString() ?? '') ?? '';
+    const stdout = (typeof e.stdout === 'string' ? e.stdout : e.stdout?.toString() ?? '') ?? '';
+    return { ok: false, stdout: stdout.trim(), stderr: stderr.trim() || e.message || '' };
+  }
+}
+
+function branchExistsOnRemote(cwd: string, branch: string): boolean {
+  const out = execOk(`git ls-remote --heads origin ${shellEscape(branch)}`, cwd);
+  return out.ok && out.stdout.length > 0;
+}
+
+const SHA_RE = /^[0-9a-f]{40}$/;
+
+function getMainHeadSha(cwd: string, repoSlug: string | null, platform: 'github' | 'gitlab', baseBranch: string): string {
+  // `gh api` and `glab api` resolve repo context from the URL path itself —
+  // no `--repo` flag (that belongs to the porcelain subcommands like
+  // `gh pr ...`). The slug is validated by parseRepoSlug's regex; baseBranch
+  // is shell-escaped because it originates from operator-controlled plan_json.
+  if (platform === 'github') {
+    const slug = repoSlug ?? ':owner/:repo';
+    const out = execOk(
+      `gh api repos/${slug}/branches/${shellEscape(baseBranch)} --jq .commit.sha`,
+      cwd,
+    );
+    if (!out.ok || out.stdout.length === 0) {
+      throw new Error(`failed to read ${baseBranch} HEAD SHA: ${out.stderr || 'empty response'}`);
+    }
+    if (!SHA_RE.test(out.stdout)) {
+      throw new Error(`unexpected SHA from gh api: ${out.stdout.slice(0, 80)}`);
+    }
+    return out.stdout;
+  }
+  // GitLab
+  const slug = repoSlug ?? '';
+  const encoded = slug.replace(/\//g, '%2F');
+  const out = execOk(
+    `glab api projects/${encoded}/repository/branches/${shellEscape(baseBranch)}`,
+    cwd,
+  );
+  if (!out.ok) {
+    throw new Error(`failed to read ${baseBranch} HEAD SHA: ${out.stderr || 'empty response'}`);
+  }
+  try {
+    const parsed = JSON.parse(out.stdout) as { commit?: { id?: string } };
+    const sha = parsed.commit?.id;
+    if (typeof sha !== 'string' || !SHA_RE.test(sha)) {
+      throw new Error(`unexpected branches API shape: invalid or missing commit.id`);
+    }
+    return sha;
+  } catch (err) {
+    throw new Error(`failed to parse ${baseBranch} branches API: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+function createKahunaBranch(
+  cwd: string,
+  repoSlug: string | null,
+  platform: 'github' | 'gitlab',
+  branch: string,
+  sha: string,
+): void {
+  if (platform === 'github') {
+    const slug = repoSlug ?? ':owner/:repo';
+    const out = execOk(
+      `gh api repos/${slug}/git/refs -X POST -f ref=${shellEscape(`refs/heads/${branch}`)} -f sha=${shellEscape(sha)}`,
+      cwd,
+    );
+    if (!out.ok) {
+      throw new Error(`failed to create branch ${branch}: ${out.stderr || out.stdout}`);
+    }
+    return;
+  }
+  // GitLab — POST /projects/:id/repository/branches?branch=<name>&ref=<sha>
+  const encoded = (repoSlug ?? '').replace(/\//g, '%2F');
+  const out = execOk(
+    `glab api projects/${encoded}/repository/branches -X POST -f branch=${shellEscape(branch)} -f ref=${shellEscape(sha)}`,
+    cwd,
+  );
+  if (!out.ok) {
+    throw new Error(`failed to create branch ${branch}: ${out.stderr || out.stdout}`);
+  }
+}
+
+function recordKahunaBranchInState(cwd: string, branch: string): void {
+  const out = execOk(`wave-status set-kahuna-branch ${shellEscape(branch)}`, cwd);
+  if (!out.ok) {
+    throw new Error(`wave-status set-kahuna-branch failed: ${out.stderr || out.stdout}`);
+  }
+}
+
+interface KahunaBootstrapResult {
+  ok: true;
+  kahuna_branch: string;
+  created: boolean; // true if newly created, false if reused
+}
+
+interface KahunaBootstrapError {
+  ok: false;
+  error: string;
+}
+
+async function bootstrapKahunaBranch(
+  cwd: string,
+  kahuna: { epic_id: number; slug: string },
+  baseBranch: string,
+  readState: () => Promise<{ kahuna_branch?: string | null }>,
+): Promise<KahunaBootstrapResult | KahunaBootstrapError> {
+  const desired = `kahuna/${kahuna.epic_id}-${kahuna.slug}`;
+  const platform = detectPlatform();
+  const repoSlug = parseRepoSlug();
+
+  const state = await readState();
+  const recorded = state.kahuna_branch ?? null;
+
+  if (recorded === desired) {
+    // State already records the desired branch — verify presence on remote.
+    if (branchExistsOnRemote(cwd, desired)) {
+      return { ok: true, kahuna_branch: desired, created: false };
+    }
+    // Recorded but missing from remote: state and platform are out of sync.
+    // Refuse rather than silently recreate; this is a corruption signal that
+    // warrants human attention (matches the spirit of the spec's orphan rule).
+    return {
+      ok: false,
+      error: `kahuna_branch ${desired} is recorded in state but missing from remote — manual triage required`,
+    };
+  }
+
+  if (recorded !== null && recorded !== desired) {
+    // State has a different kahuna_branch — refuse rather than overwrite.
+    return {
+      ok: false,
+      error: `wave state already records kahuna_branch '${recorded}' which does not match requested '${desired}'`,
+    };
+  }
+
+  // recorded === null: state is unset. Check the remote for an orphan.
+  if (branchExistsOnRemote(cwd, desired)) {
+    return {
+      ok: false,
+      error: `orphan kahuna branch ${desired} exists on remote but is not recorded in state — manual triage required`,
+    };
+  }
+
+  // Fresh creation path.
+  const sha = getMainHeadSha(cwd, repoSlug, platform, baseBranch);
+  createKahunaBranch(cwd, repoSlug, platform, desired, sha);
+  recordKahunaBranchInState(cwd, desired);
+  return { ok: true, kahuna_branch: desired, created: true };
+}
+
 const waveInitHandler: HandlerDef = {
   name: 'wave_init',
-  description: 'Initialize a wave plan from structured JSON; supports --extend mode',
+  description:
+    'Initialize a wave plan from structured JSON; supports --extend mode. ' +
+    'Optional `kahuna` argument bootstraps a `kahuna/<epic_id>-<slug>` integration branch ' +
+    'off the plan\'s base_branch (default `main`) and records it in wave state — used by ' +
+    'autonomous /wavemachine flows; pre-KAHUNA callers omit `kahuna` and see no behavior change.',
   inputSchema,
   async execute(rawArgs: unknown) {
     let args: Input;
@@ -214,6 +392,35 @@ const waveInitHandler: HandlerDef = {
         // failing the whole call — the CLI already succeeded.
       }
 
+      // KAHUNA bootstrap (devspec §5.1.3): runs after init/extend has written
+      // state.json, so we can read+update it. Failures here surface as
+      // ok:false but do NOT roll back the wave init — the plan is already
+      // recorded; the operator can retry the kahuna step.
+      let kahunaBranch: string | undefined;
+      let kahunaCreated: boolean | undefined;
+      if (args.kahuna !== undefined) {
+        const cwd = projectDir(args.project_root);
+        const planParsedForBase = JSON.parse(args.plan_json) as PlanData & { base_branch?: string };
+        const baseBranch = typeof planParsedForBase.base_branch === 'string' && planParsedForBase.base_branch.length > 0
+          ? planParsedForBase.base_branch
+          : 'main';
+        const dir = await statusDir(cwd);
+        const statePath = join(dir, 'state.json');
+        const result = await bootstrapKahunaBranch(
+          cwd,
+          args.kahuna,
+          baseBranch,
+          async () => (await readJson(statePath)) as { kahuna_branch?: string | null },
+        );
+        if (!result.ok) {
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error: result.error }) }],
+          };
+        }
+        kahunaBranch = result.kahuna_branch;
+        kahunaCreated = result.created;
+      }
+
       return {
         content: [
           {
@@ -226,6 +433,7 @@ const waveInitHandler: HandlerDef = {
               issues_added,
               total_phases,
               total_waves,
+              ...(kahunaBranch !== undefined ? { kahuna_branch: kahunaBranch, kahuna_created: kahunaCreated } : {}),
             }),
           },
         ],

--- a/tests/wave_init.test.ts
+++ b/tests/wave_init.test.ts
@@ -256,6 +256,294 @@ describe('wave_init handler', () => {
     expect(parsed.error).toContain('owner/repo');
   });
 
+  // ---- kahuna bootstrap (devspec §5.1.3) ----------------------------------
+
+  /**
+   * Helper: install an execMockFn that routes commands by substring match.
+   * Tests register a map of {substring → response or thrower}; unmatched
+   * commands fall through to the default `wave plan initialized` response so
+   * the existing wave-status init call keeps working.
+   */
+  function setExecRoutes(routes: Array<{ match: string; respond: string | (() => string) }>): void {
+    execMockFn = (cmd: string) => {
+      for (const r of routes) {
+        if (cmd.includes(r.match)) {
+          return typeof r.respond === 'function' ? r.respond() : r.respond;
+        }
+      }
+      return 'wave plan initialized\n';
+    };
+  }
+
+  test('kahuna bootstrap — fresh creation: branch absent everywhere → creates and records', async () => {
+    await setupStatusFixture({ kahuna_branch: null });
+    setExecRoutes([
+      { match: 'git remote get-url', respond: 'git@github.com:Wave-Engineering/mcp-server-sdlc.git' },
+      { match: 'git ls-remote --heads origin', respond: '' }, // branch absent
+      { match: "gh api repos/Wave-Engineering/mcp-server-sdlc/branches/'main'", respond: '0000000000000000000000000000000000000abc' },
+      { match: 'gh api repos/Wave-Engineering/mcp-server-sdlc/git/refs', respond: '' },
+      { match: 'wave-status set-kahuna-branch', respond: '' },
+    ]);
+
+    const result = await handler.execute({
+      plan_json: JSON.stringify({ phases: [] }),
+      kahuna: { epic_id: 42, slug: 'wave-status-cli' },
+    });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.kahuna_branch).toBe('kahuna/42-wave-status-cli');
+    expect(parsed.kahuna_created).toBe(true);
+
+    // The platform API was actually called to create the branch
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string);
+    expect(calls.some(c => c.includes('gh api repos/Wave-Engineering/mcp-server-sdlc/git/refs -X POST'))).toBe(true);
+    expect(calls.some(c => c.includes("ref='refs/heads/kahuna/42-wave-status-cli'"))).toBe(true);
+    expect(calls.some(c => c.includes("sha='0000000000000000000000000000000000000abc'"))).toBe(true);
+    // And state was updated via the new CLI subcommand
+    expect(calls.some(c => c.includes("wave-status set-kahuna-branch 'kahuna/42-wave-status-cli'"))).toBe(true);
+  });
+
+  test('kahuna bootstrap — idempotent reuse: state matches and branch exists on remote → no creation', async () => {
+    await setupStatusFixture({ kahuna_branch: 'kahuna/42-wave-status-cli' });
+    setExecRoutes([
+      { match: 'git remote get-url', respond: 'git@github.com:Wave-Engineering/mcp-server-sdlc.git' },
+      { match: 'git ls-remote --heads origin', respond: 'abc123\trefs/heads/kahuna/42-wave-status-cli' },
+    ]);
+
+    const result = await handler.execute({
+      plan_json: JSON.stringify({ phases: [] }),
+      kahuna: { epic_id: 42, slug: 'wave-status-cli' },
+    });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.kahuna_branch).toBe('kahuna/42-wave-status-cli');
+    expect(parsed.kahuna_created).toBe(false);
+
+    // No branch creation, no state-write CLI call
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string);
+    expect(calls.some(c => c.includes('git/refs -X POST'))).toBe(false);
+    expect(calls.some(c => c.includes('set-kahuna-branch'))).toBe(false);
+  });
+
+  test('kahuna bootstrap — orphan refused: branch on remote but state empty', async () => {
+    await setupStatusFixture({ kahuna_branch: null });
+    setExecRoutes([
+      { match: 'git remote get-url', respond: 'git@github.com:Wave-Engineering/mcp-server-sdlc.git' },
+      { match: 'git ls-remote --heads origin', respond: 'abc123\trefs/heads/kahuna/42-orphan' },
+    ]);
+
+    const result = await handler.execute({
+      plan_json: JSON.stringify({ phases: [] }),
+      kahuna: { epic_id: 42, slug: 'orphan' },
+    });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error as string).toContain('orphan');
+    expect(parsed.error as string).toContain('kahuna/42-orphan');
+  });
+
+  test('kahuna bootstrap — state-mismatch refused: state has different branch', async () => {
+    await setupStatusFixture({ kahuna_branch: 'kahuna/41-prior-epic' });
+    setExecRoutes([
+      { match: 'git remote get-url', respond: 'git@github.com:Wave-Engineering/mcp-server-sdlc.git' },
+    ]);
+
+    const result = await handler.execute({
+      plan_json: JSON.stringify({ phases: [] }),
+      kahuna: { epic_id: 42, slug: 'new-epic' },
+    });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error as string).toContain('kahuna/41-prior-epic');
+    expect(parsed.error as string).toContain('kahuna/42-new-epic');
+  });
+
+  test('kahuna bootstrap — recorded but missing on remote: refuse (state/platform desync)', async () => {
+    await setupStatusFixture({ kahuna_branch: 'kahuna/42-foo' });
+    setExecRoutes([
+      { match: 'git remote get-url', respond: 'git@github.com:Wave-Engineering/mcp-server-sdlc.git' },
+      { match: 'git ls-remote --heads origin', respond: '' }, // branch missing
+    ]);
+
+    const result = await handler.execute({
+      plan_json: JSON.stringify({ phases: [] }),
+      kahuna: { epic_id: 42, slug: 'foo' },
+    });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error as string).toContain('missing from remote');
+    expect(parsed.error as string).toContain('triage');
+  });
+
+  test('kahuna bootstrap — schema rejects uppercase or non-kebab slug', async () => {
+    const result = await handler.execute({
+      plan_json: JSON.stringify({ phases: [] }),
+      kahuna: { epic_id: 42, slug: 'BadSlug' },
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error as string).toContain('kebab-case');
+  });
+
+  test('kahuna bootstrap — schema rejects non-positive epic_id', async () => {
+    const result = await handler.execute({
+      plan_json: JSON.stringify({ phases: [] }),
+      kahuna: { epic_id: 0, slug: 'foo' },
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test('kahuna bootstrap — backward compat: omitting kahuna leaves response field absent', async () => {
+    await setupStatusFixture(null);
+    const result = await handler.execute({
+      plan_json: JSON.stringify({ phases: [] }),
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.kahuna_branch).toBeUndefined();
+    expect(parsed.kahuna_created).toBeUndefined();
+  });
+
+  test('kahuna bootstrap — gitlab platform: uses glab api for branch creation', async () => {
+    await setupStatusFixture({ kahuna_branch: null });
+    setExecRoutes([
+      { match: 'git remote get-url', respond: 'git@gitlab.com:my-group/my-repo.git' },
+      { match: 'git ls-remote --heads origin', respond: '' },
+      { match: "glab api projects/my-group%2Fmy-repo/repository/branches/'main'", respond: JSON.stringify({ commit: { id: '3333333333333333333333333333333333333333' } }) },
+      { match: 'glab api projects/my-group%2Fmy-repo/repository/branches -X POST', respond: '' },
+      { match: 'wave-status set-kahuna-branch', respond: '' },
+    ]);
+
+    const result = await handler.execute({
+      plan_json: JSON.stringify({ phases: [] }),
+      kahuna: { epic_id: 7, slug: 'feature-x' },
+    });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.kahuna_branch).toBe('kahuna/7-feature-x');
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string);
+    expect(calls.some(c => c.includes('glab api projects/my-group%2Fmy-repo/repository/branches -X POST'))).toBe(true);
+    expect(calls.some(c => c.includes("branch='kahuna/7-feature-x'"))).toBe(true);
+    expect(calls.some(c => c.includes("ref='3333333333333333333333333333333333333333'"))).toBe(true);
+  });
+
+  test('kahuna bootstrap — uses plan.base_branch when provided (default main)', async () => {
+    await setupStatusFixture({ kahuna_branch: null });
+    setExecRoutes([
+      { match: 'git remote get-url', respond: 'git@github.com:org/repo.git' },
+      { match: 'git ls-remote --heads origin', respond: '' },
+      { match: "gh api repos/org/repo/branches/'develop'", respond: '1111111111111111111111111111111111111111' },
+      { match: 'gh api repos/org/repo/git/refs', respond: '' },
+      { match: 'wave-status set-kahuna-branch', respond: '' },
+    ]);
+
+    const result = await handler.execute({
+      plan_json: JSON.stringify({ phases: [], base_branch: 'develop' }),
+      kahuna: { epic_id: 99, slug: 'foo' },
+    });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string);
+    expect(calls.some(c => c.includes("branches/'develop'"))).toBe(true);
+    expect(calls.some(c => c.includes("sha='1111111111111111111111111111111111111111'"))).toBe(true);
+  });
+
+  test('kahuna bootstrap — gh api returns non-SHA garbage: defensive validator rejects', async () => {
+    await setupStatusFixture({ kahuna_branch: null });
+    setExecRoutes([
+      { match: 'git remote get-url', respond: 'git@github.com:org/repo.git' },
+      { match: 'git ls-remote --heads origin', respond: '' },
+      // Could happen if the API shape changes or --jq returns null/empty.
+      { match: "gh api repos/org/repo/branches/'main'", respond: 'null' },
+    ]);
+
+    const result = await handler.execute({
+      plan_json: JSON.stringify({ phases: [] }),
+      kahuna: { epic_id: 1, slug: 'foo' },
+    });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error as string).toContain('unexpected SHA');
+    // Critically, no branch creation attempted with the bogus SHA
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string);
+    expect(calls.some(c => c.includes('git/refs -X POST'))).toBe(false);
+  });
+
+  test('kahuna bootstrap — gh api command does NOT use --repo flag (gh api is path-resolved)', async () => {
+    await setupStatusFixture({ kahuna_branch: null });
+    setExecRoutes([
+      { match: 'git remote get-url', respond: 'git@github.com:org/repo.git' },
+      { match: 'git ls-remote --heads origin', respond: '' },
+      { match: "gh api repos/org/repo/branches/'main'", respond: '4444444444444444444444444444444444444444' },
+      { match: 'gh api repos/org/repo/git/refs', respond: '' },
+      { match: 'wave-status set-kahuna-branch', respond: '' },
+    ]);
+
+    await handler.execute({
+      plan_json: JSON.stringify({ phases: [] }),
+      kahuna: { epic_id: 1, slug: 'foo' },
+    });
+
+    // Regression: --repo is a porcelain flag, not valid on `gh api`.
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string);
+    const ghApiCalls = calls.filter(c => c.includes('gh api'));
+    for (const c of ghApiCalls) {
+      expect(c).not.toContain('--repo');
+    }
+  });
+
+  test('kahuna bootstrap — base_branch is shell-escaped in the URL path', async () => {
+    await setupStatusFixture({ kahuna_branch: null });
+    let capturedBaseCmd = '';
+    setExecRoutes([
+      { match: 'git remote get-url', respond: 'git@github.com:org/repo.git' },
+      { match: 'git ls-remote --heads origin', respond: '' },
+      // Match a benign substring; the test asserts the call shape after.
+      { match: 'gh api repos/org/repo/branches/', respond: () => {
+        capturedBaseCmd = mockExecSync.mock.calls[mockExecSync.mock.calls.length - 1][0] as string;
+        return '5555555555555555555555555555555555555555';
+      } },
+      { match: 'gh api repos/org/repo/git/refs', respond: '' },
+      { match: 'wave-status set-kahuna-branch', respond: '' },
+    ]);
+
+    await handler.execute({
+      plan_json: JSON.stringify({ phases: [], base_branch: "weird; rm -rf /" }),
+      kahuna: { epic_id: 1, slug: 'foo' },
+    });
+
+    // The malicious value must be wrapped in single quotes — proves shell escaping fires
+    expect(capturedBaseCmd).toContain(`'weird; rm -rf /'`);
+  });
+
+  test('kahuna bootstrap — wave-status set-kahuna-branch failure surfaces as ok:false', async () => {
+    await setupStatusFixture({ kahuna_branch: null });
+    setExecRoutes([
+      { match: 'git remote get-url', respond: 'git@github.com:org/repo.git' },
+      { match: 'git ls-remote --heads origin', respond: '' },
+      { match: "gh api repos/org/repo/branches/'main'", respond: '2222222222222222222222222222222222222222' },
+      { match: 'gh api repos/org/repo/git/refs', respond: '' },
+      { match: 'wave-status set-kahuna-branch', respond: () => { throw new Error('CLI exploded'); } },
+    ]);
+
+    const result = await handler.execute({
+      plan_json: JSON.stringify({ phases: [] }),
+      kahuna: { epic_id: 1, slug: 'foo' },
+    });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error as string).toContain('set-kahuna-branch');
+  });
+
   // ---- extend_missing_state -----------------------------------------------
   test('extend_missing_state — returns ok:false without throwing', async () => {
     // Point at a fresh empty tempdir; no state.json exists.


### PR DESCRIPTION
## Summary

Extends `wave_init` with an optional `kahuna: { epic_id, slug }` argument. When passed, creates a `kahuna/<epic_id>-<slug>` integration branch off the plan's `base_branch` (default `main`) via the platform API and records the branch in wave state via the new `wave-status set-kahuna-branch` CLI subcommand (claudecode-workflow#433, just landed).

Default behavior unchanged when `kahuna` is omitted (CT-03 backward compat).

## Changes

- `handlers/wave_init.ts`:
  - Zod input adds optional `kahuna` object with kebab-case slug regex
  - New helpers: `branchExistsOnRemote` (platform-neutral via `git ls-remote`), `getMainHeadSha` (gh/glab API + SHA_RE validation), `createKahunaBranch` (gh/glab refs/branches API), `recordKahunaBranchInState` (shells to the new CLI subcommand)
  - `bootstrapKahunaBranch` orchestrates idempotency rules:
    - state match + branch on remote → reuse (`created: false`)
    - orphan (branch on remote, state empty) → refuse with triage hint
    - recorded but missing on remote → refuse with triage hint (state/platform desync)
    - state has different `kahuna_branch` → refuse rather than overwrite
  - Bootstrap runs AFTER `wave-status init` succeeds; failures surface as `ok: false` without rolling back the wave plan
- `tests/wave_init.test.ts` — 14 new kahuna tests added (29 total in file). Coverage: fresh creation, idempotent reuse, orphan/state-mismatch/desync refusal, schema rejections (uppercase slug, non-positive epic_id), backward compat (no kahuna arg), gitlab path, base_branch override, set-CLI failure, malformed-SHA defensive guard, `gh api` no-`--repo`-flag regression, base_branch shell-escape regression.

## Linked Issues

Closes #206

Depends on: claudecode-workflow#433 (set-kahuna-branch CLI subcommand — already merged)

## Test Plan

- [x] `bun test tests/wave_init.test.ts` — 29/29 pass
- [x] `bun test` full suite — 1243/1243 pass, 3072 expect() calls
- [x] `./scripts/ci/validate.sh` — 70/70 handlers, typecheck clean
- [x] `trivy fs --severity HIGH,CRITICAL` — 0 findings
- [x] `feature-dev:code-reviewer` — 3 findings, all addressed:
  - **CRITICAL**: `slugFlag` (`--repo` appended to `gh api`) was dead/wrong; `gh api` is path-resolved. Removed entirely + regression test asserting no gh-api call carries `--repo`.
  - **CRITICAL**: `base_branch` (operator-controlled via plan_json) was not shell-escaped in URL paths. Added `shellEscape` in both gh and glab paths + regression test with `weird; rm -rf /` value confirming escaping fires.
  - **IMPORTANT**: SHA from API was interpolated without validation. Added `SHA_RE = /^[0-9a-f]{40}$/` check after extraction + dedicated test for `null` / non-SHA garbage path.

## Notes

Canonical contract: claudecode-workflow:docs/kahuna-devspec.md §5.1.3.

This completes the sdlc-server side of Wave 1b. The handler is the surface that autonomous `/wavemachine` and `/nextwave auto` flows will call to bootstrap a per-epic KAHUNA integration branch. Manual `/nextwave` callers omit the `kahuna` argument and see no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)