### PR TITLE
feat(spec_validate_structure): accept **Dependencies:** label fallback for parity with spec_dependencies

### DIFF
--- a/handlers/spec_dependencies.ts
+++ b/handlers/spec_dependencies.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
+import { findBoldLabelDependencies, parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
 import { detectPlatformForRef, parseRepoSlug, gitlabApiIssue } from '../lib/glab';
 
 const inputSchema = z.object({
@@ -80,27 +80,8 @@ function parseDependenciesSection(section: string, currentSlug: string | null): 
   return deps;
 }
 
-/**
- * Fallback extractor for stories that embed dependencies as a bold label
- * (e.g. `**Dependencies:** Stories 1.1 (#86), 2.1 (#87)`) inside another
- * section like `## Metadata`, rather than in a dedicated `## Dependencies`
- * H2 section.
- *
- * Returns the content following the first `**Dependencies:**` label in any
- * section, up to the next bold label, next H2-equivalent break, or end of
- * that section's content.
- */
-function findBoldLabelDependencies(sections: Record<string, string>): string {
-  // Content after **Dependencies:** up to: next bold label (possibly on a
-  // bulleted line, e.g. `- **Reviewer:**`), next H2, or end of section.
-  const labelRe =
-    /\*\*Dependencies:?\*\*\s*(.+?)(?=\n\s*(?:[-*]\s+)?\*\*[A-Z][A-Za-z ]*:?\*\*|\n##\s|\n*$)/s;
-  for (const sec of Object.values(sections)) {
-    const m = labelRe.exec(sec);
-    if (m && m[1].trim()) return m[1].trim();
-  }
-  return '';
-}
+// findBoldLabelDependencies lives in lib/spec_parser so spec_validate_structure
+// can apply the same fallback rule. See SUB_ISSUE_SECTION_KEYS / lib comment.
 
 const specDependenciesHandler: HandlerDef = {
   name: 'spec_dependencies',

--- a/handlers/spec_validate_structure.ts
+++ b/handlers/spec_validate_structure.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
+import { findBoldLabelDependencies, parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
 import { detectPlatform, gitlabApiIssue } from '../lib/glab';
 
 const inputSchema = z.object({
@@ -39,7 +39,7 @@ function fetchBody(ref: IssueRef): string {
 const specValidateStructureHandler: HandlerDef = {
   name: 'spec_validate_structure',
   description:
-    'Check for presence of required sections in an issue spec. Accepts H2 heading aliases: `## Changes` or `## Implementation Steps`; `## Tests` or `## Test Procedures`; `## Acceptance Criteria`. Optional: `## Dependencies`. See docs/issue-body-grammar.md.',
+    'Check for presence of required sections in an issue spec. Accepts H2 heading aliases: `## Changes` or `## Implementation Steps`; `## Tests` or `## Test Procedures`; `## Acceptance Criteria`. Optional: `## Dependencies` (or a `**Dependencies:**` bold-label inside any other section, mirroring spec_dependencies). See docs/issue-body-grammar.md.',
   inputSchema,
   async execute(rawArgs: unknown) {
     let args: z.infer<typeof inputSchema>;
@@ -88,6 +88,16 @@ const specValidateStructureHandler: HandlerDef = {
         presence[`has_${canonical}`] = aliases.some(
           (alias) => sections[alias] && sections[alias].trim().length > 0,
         );
+      }
+      // Bold-label fallback for `has_dependencies` only (mirrors
+      // spec_dependencies' fallback). Stories that embed deps as
+      // `**Dependencies:** #5, #6` inside ## Metadata count as declared.
+      // The narrow scope is deliberate — implementation/test sections must
+      // remain strict because they carry semantic content, not metadata.
+      // Truthiness check matches the idiom in spec_dependencies (the helper
+      // returns `''` when no label is present or its content is empty).
+      if (!presence.has_dependencies && findBoldLabelDependencies(sections)) {
+        presence.has_dependencies = true;
       }
 
       const response: Record<string, unknown> = {

--- a/lib/spec_parser.ts
+++ b/lib/spec_parser.ts
@@ -132,3 +132,37 @@ export function findSubIssueSection(sections: Record<string, string>): string | 
   }
   return null;
 }
+
+/**
+ * Match a `**Dependencies:**` (or `**Dependencies**`) bold label inside any
+ * section body, capturing its content up to the next bold label or end of
+ * section.
+ *
+ * Used by both `spec_dependencies` (for ref extraction) and
+ * `spec_validate_structure` (for presence detection) so the two tools agree
+ * on what counts as "declared dependencies." Without this, an issue with
+ * `**Dependencies:** #5, #6` inside `## Metadata` extracts refs via
+ * `spec_dependencies` but reports `has_dependencies: false` from
+ * `spec_validate_structure` — a real inconsistency users hit during the
+ * KAHUNA Dev Spec /prepwaves flow (2026-04-24).
+ *
+ * The `\n##\s` lookahead alternative is inert when this regex runs against
+ * `parseSections` output (H2 lines have already been stripped as section
+ * keys). It's preserved for callers who feed in raw markdown.
+ *
+ * Prefer calling `findBoldLabelDependencies` over using the regex directly.
+ */
+export const BOLD_LABEL_DEPENDENCIES_REGEX =
+  /\*\*Dependencies:?\*\*\s*(.+?)(?=\n\s*(?:[-*]\s+)?\*\*[A-Z][A-Za-z ]*:?\*\*|\n##\s|\n*$)/s;
+
+/**
+ * Return the content following the first `**Dependencies:**` label across
+ * any section. Empty string when the label is absent or has no content.
+ */
+export function findBoldLabelDependencies(sections: Record<string, string>): string {
+  for (const sec of Object.values(sections)) {
+    const m = BOLD_LABEL_DEPENDENCIES_REGEX.exec(sec);
+    if (m && m[1].trim()) return m[1].trim();
+  }
+  return '';
+}

--- a/tests/spec_validate_structure.test.ts
+++ b/tests/spec_validate_structure.test.ts
@@ -151,4 +151,72 @@ describe('spec_validate_structure handler', () => {
     expect(parsed.valid).toBe(true);
     expect(parsed.accepted_headings).toBeUndefined();
   });
+
+  // ---- #208: bold-label dependencies fallback (parity with spec_dependencies) ----
+
+  test('has_dependencies_true — explicit ## Dependencies H2 (regression)', async () => {
+    mockBody(
+      '## Changes\nc\n## Tests\nt\n## Acceptance Criteria\n- [ ] ok\n## Dependencies\n- #5\n',
+    );
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.has_dependencies).toBe(true);
+  });
+
+  test('has_dependencies_true — bold-label fallback inside ## Metadata', async () => {
+    // Mirrors what /devspec upshift produces for stories: deps live as a
+    // **Dependencies:** label under ## Metadata, not in a dedicated H2.
+    mockBody(
+      '## Changes\nc\n## Tests\nt\n## Acceptance Criteria\n- [ ] ok\n' +
+      '## Metadata\n\n**Priority:** medium\n**Dependencies:** #86, #87\n',
+    );
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.has_dependencies).toBe(true);
+  });
+
+  test('has_dependencies_true — bold-label fallback in arbitrary section', async () => {
+    mockBody(
+      '## Changes\nc\n## Tests\nt\n## Acceptance Criteria\n- [ ] ok\n' +
+      '## Notes\nSome prose.\n\n**Dependencies:** Wave-Engineering/foo#42\n',
+    );
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.has_dependencies).toBe(true);
+  });
+
+  test('has_dependencies_false — neither ## Dependencies nor bold label present', async () => {
+    mockBody(
+      '## Changes\nc\n## Tests\nt\n## Acceptance Criteria\n- [ ] ok\n## Metadata\n**Priority:** low\n',
+    );
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.has_dependencies).toBe(false);
+  });
+
+  test('explicit ## Dependencies still wins when both forms are present', async () => {
+    mockBody(
+      '## Changes\nc\n## Tests\nt\n## Acceptance Criteria\n- [ ] ok\n' +
+      '## Dependencies\n- #5\n## Metadata\n**Dependencies:** #6\n',
+    );
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.has_dependencies).toBe(true);
+  });
+
+  test('changes/tests fallback NOT relaxed — bold-label scope is dependencies-only', async () => {
+    // **Tests:** inside another section must NOT count as has_tests.
+    // Implementation/test sections remain strict; only the dependencies
+    // metadata field gets the fallback.
+    mockBody(
+      '## Changes\nc\n## Acceptance Criteria\n- [ ] ok\n' +
+      '## Metadata\n**Tests:** see other repo\n**Dependencies:** #5\n',
+    );
+    const result = await handler.execute({ issue_ref: '#1' });
+    const parsed = parseResult(result);
+    expect(parsed.has_tests).toBe(false);
+    expect(parsed.has_dependencies).toBe(true);
+    expect(parsed.valid).toBe(false);
+    expect(parsed.missing_sections).toContain('tests');
+  });
 });


### PR DESCRIPTION
## Summary

`spec_dependencies` accepts a `**Dependencies:**` bold label inside any section (typically `## Metadata`) as a valid source of dependency info. `spec_validate_structure` only counted explicit `## Dependencies` H2 sections, so the two tools disagreed about whether a given issue had dependencies declared.

Discovered during the KAHUNA Dev Spec `/prepwaves` flow (2026-04-24): 20/20 sub-issues had deps embedded as `**Dependencies:**` under `## Metadata`. `spec_dependencies` extracted them; `spec_validate_structure` reported them all as missing.

## Changes

- `lib/spec_parser.ts` — extracted `BOLD_LABEL_DEPENDENCIES_REGEX` + `findBoldLabelDependencies(sections)` from `spec_dependencies` so both handlers share the matcher. JSDoc explains the cross-tool contract and documents that the `\n##\s` lookahead alt is inert against `parseSections` output but preserved for raw-markdown callers.
- `handlers/spec_dependencies.ts` — refactored to import the shared helper. Behavior preserved bit-for-bit.
- `handlers/spec_validate_structure.ts` — `has_dependencies` now ORs explicit-section presence with `findBoldLabelDependencies(sections)`. Scope is intentionally narrow: `## Changes` / `## Tests` validation remains strict because they carry semantic content, not metadata. Truthiness check (not `.length > 0`) matches the established idiom in `spec_dependencies`. Handler description updated to mention the fallback.
- `tests/spec_validate_structure.test.ts` — 6 new tests:
  1. Regression: explicit `## Dependencies` H2 still works
  2. Bold-label inside `## Metadata` → `has_dependencies: true`
  3. Bold-label inside arbitrary section → `has_dependencies: true`
  4. Neither form present → `has_dependencies: false`
  5. Both forms present → `has_dependencies: true` (explicit wins)
  6. NEGATIVE: bold-label `**Tests:**` does NOT set `has_tests` (proves scope is dependencies-only)

## Linked Issues

Closes #208

Sibling: #209 (just merged, also a parser-consistency fix). Same theme: stop the parser/validator pair from disagreeing about what counts as "declared."

## Test Plan

- [x] `bun test tests/spec_validate_structure.test.ts tests/spec_dependencies.test.ts` — 36/36 (was 30, +6 new, no regressions)
- [x] `bun test` full suite — 1262/1262 pass, 3119 expect() calls
- [x] `./scripts/ci/validate.sh` — 70/70 handlers, typecheck clean
- [x] `trivy fs --severity HIGH,CRITICAL` — 0 findings
- [x] `feature-dev:code-reviewer` — 2 actionable: (1) `.length > 0` on a string return → switched to truthy idiom matching `spec_dependencies`, (2) inert `\n##\s` lookahead alt → documented in JSDoc rather than removed (preserves general usefulness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)