### PR TITLE
feat(pr_create): auto-resolve default branch when base is omitted

### DIFF
--- a/handlers/pr_create.ts
+++ b/handlers/pr_create.ts
@@ -8,7 +8,10 @@ import type { HandlerDef } from '../types.js';
 const inputSchema = z.object({
   title: z.string().min(1, 'title must be a non-empty string'),
   body: z.string().min(1, 'body must be a non-empty string'),
-  base: z.string().min(1, 'base must be a non-empty string'),
+  // base is optional — when omitted, the handler queries the platform for
+  // the repo's default branch. /scp + sibling skills can stop probing for
+  // it themselves. See #159.
+  base: z.string().min(1).optional(),
   head: z.string().optional(),
   draft: z.boolean().optional().default(false),
   repo: z
@@ -65,6 +68,58 @@ function getCurrentBranch(cwd: string): string {
   return result.stdout.trim();
 }
 
+/**
+ * Query the platform for the repo's default branch name. Used when the
+ * caller omits `base` so /scp + sibling skills can stop probing for it
+ * themselves (#159).
+ *
+ * GitHub: `gh repo view <slug?> --json defaultBranchRef --jq .defaultBranchRef.name`
+ * GitLab: `glab api projects/<encoded> --jq .default_branch` (or `glab repo view`
+ *         when no explicit slug is provided — the porcelain command resolves
+ *         from the cwd's remote).
+ */
+function getDefaultBranch(
+  platform: 'github' | 'gitlab',
+  repo: string | undefined,
+  cwd: string,
+): string {
+  if (platform === 'github') {
+    const cmd = ['gh', 'repo', 'view'];
+    if (repo !== undefined) cmd.push(repo);
+    cmd.push('--json', 'defaultBranchRef', '--jq', '.defaultBranchRef.name');
+    const result = run(cmd, cwd);
+    if (result.exitCode !== 0 || result.stdout.trim().length === 0) {
+      throw new Error(
+        `failed to resolve GitHub default branch: ${result.stderr.trim() || 'empty response'}`,
+      );
+    }
+    return result.stdout.trim();
+  }
+  // GitLab — `glab repo view` doesn't expose default_branch reliably across
+  // versions; the API path does. Use `glab api projects/<encoded>` when an
+  // explicit slug is provided, fall back to `:id` (which glab resolves from
+  // the cwd remote) when not. NB: `glab api` has NO `--jq` flag (unlike
+  // `gh api`); we parse the JSON in-process.
+  const project = repo !== undefined ? repo.replace(/\//g, '%2F') : ':id';
+  const result = run(['glab', 'api', `projects/${project}`], cwd);
+  if (result.exitCode !== 0 || result.stdout.trim().length === 0) {
+    throw new Error(
+      `failed to resolve GitLab default branch: ${result.stderr.trim() || 'empty response'}`,
+    );
+  }
+  try {
+    const parsed = JSON.parse(result.stdout) as { default_branch?: string };
+    if (typeof parsed.default_branch !== 'string' || parsed.default_branch.length === 0) {
+      throw new Error('default_branch missing or empty in glab api response');
+    }
+    return parsed.default_branch;
+  } catch (err) {
+    throw new Error(
+      `failed to resolve GitLab default branch: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
 interface NormalizedPr {
   number: number;
   url: string;
@@ -98,6 +153,12 @@ function lookupGithubPr(head: string, cwd: string, repo?: string): NormalizedPr 
 }
 
 function createGithubPr(args: Input, head: string, cwd: string): NormalizedPr {
+  // Caller guarantees base is resolved (default-branch lookup happens in
+  // execute() before dispatch). Assert here to satisfy the type narrower —
+  // a missing base at this point indicates a logic bug in the caller.
+  if (args.base === undefined) {
+    throw new Error('createGithubPr called without resolved base — caller bug');
+  }
   const createCmd = [
     'gh',
     'pr',
@@ -187,6 +248,10 @@ function lookupGitlabMr(head: string, cwd: string, repo?: string): NormalizedPr 
 }
 
 function createGitlabMr(args: Input, head: string, cwd: string): NormalizedPr {
+  // Caller guarantees base is resolved — see comment in createGithubPr.
+  if (args.base === undefined) {
+    throw new Error('createGitlabMr called without resolved base — caller bug');
+  }
   const createCmd = [
     'glab',
     'mr',
@@ -261,6 +326,12 @@ const prCreateHandler: HandlerDef = {
       const cwd = projectDir();
       const head = args.head ?? getCurrentBranch(cwd);
       const platform = await detectPlatform(cwd);
+      // Resolve `base` from the repo's default branch when omitted (#159).
+      // `createGithub*/createGitlab*` both read from `args.base`, so we
+      // mutate the parsed args in place — keeps both downstream paths simple.
+      if (args.base === undefined || args.base.length === 0) {
+        args.base = getDefaultBranch(platform, args.repo, cwd);
+      }
       const pr =
         platform === 'github'
           ? createGithubPr(args, head, cwd)

--- a/tests/pr_create.test.ts
+++ b/tests/pr_create.test.ts
@@ -309,11 +309,231 @@ exit 1
     expect(String(data.error)).toContain('body');
   });
 
-  test('missing_required_base — schema rejects', async () => {
-    const result = await handler.execute({ title: 't', body: 'b' });
+  // ---- #159: auto-resolve default branch when base is omitted ------------
+
+  test('default_branch_resolution_github — base omitted resolves via gh repo view', async () => {
+    const { fixture, stubBin } = await makeFixture({
+      '.claude-project.md': '# platform: github\n',
+    });
+    fixtureDir = fixture;
+    stubBinDir = stubBin;
+
+    await writeStub(
+      stubBin,
+      'git',
+      `
+case "$1 $2" in
+  "branch --show-current") echo "feature/159-default-branch" ;;
+  "remote -v") echo "origin\tgit@github.com:org/repo.git (fetch)" ;;
+  *) echo "unhandled git: $*" >&2; exit 1 ;;
+esac
+`,
+    );
+
+    // gh stub: repo view returns the default branch name; pr create succeeds; pr view normalizes.
+    await writeStub(
+      stubBin,
+      'gh',
+      `
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+  # Verify --json defaultBranchRef --jq .defaultBranchRef.name is in argv.
+  echo "main"
+  exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  # Verify --base main was passed (default-branch resolution worked).
+  case " $* " in
+    *" --base main "*) ;;
+    *) echo "expected --base main in argv, got: $*" >&2; exit 1 ;;
+  esac
+  echo "https://github.com/org/repo/pull/42"
+  exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  cat <<'EOF'
+{"number":42,"url":"https://github.com/org/repo/pull/42","state":"OPEN","headRefName":"feature/159-default-branch","baseRefName":"main"}
+EOF
+  exit 0
+fi
+echo "unhandled gh: $*" >&2; exit 1
+`,
+    );
+
+    activate(fixture, stubBin);
+
+    const result = await handler.execute({
+      title: 'feat: default branch',
+      body: 'Body',
+      // base intentionally omitted
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(data.base).toBe('main');
+  });
+
+  test('default_branch_resolution_gitlab — base omitted resolves via glab api', async () => {
+    const { fixture, stubBin } = await makeFixture({
+      '.claude-project.md': '# platform: gitlab\n',
+    });
+    fixtureDir = fixture;
+    stubBinDir = stubBin;
+
+    await writeStub(
+      stubBin,
+      'git',
+      `
+case "$1 $2" in
+  "branch --show-current") echo "feature/159-default-branch" ;;
+  "remote -v") echo "origin\tgit@gitlab.com:org/repo.git (fetch)" ;;
+  *) echo "unhandled git: $*" >&2; exit 1 ;;
+esac
+`,
+    );
+
+    await writeStub(
+      stubBin,
+      'glab',
+      `
+if [ "$1" = "api" ] && [[ "$2" =~ ^projects/ ]]; then
+  # Faithful to the real glab binary: --jq is NOT a recognized flag.
+  # If the handler ever passes it, the stub fails so tests catch the regression.
+  for arg in "$@"; do
+    if [ "$arg" = "--jq" ]; then
+      echo "FAIL: glab api does not accept --jq" >&2
+      exit 99
+    fi
+  done
+  cat <<'EOF'
+{"id":42,"name":"repo","default_branch":"develop","path_with_namespace":"org/repo"}
+EOF
+  exit 0
+fi
+if [ "$1" = "mr" ] && [ "$2" = "create" ]; then
+  case " $* " in
+    *" --target-branch develop "*) ;;
+    *) echo "expected --target-branch develop in argv, got: $*" >&2; exit 1 ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "mr" ] && [ "$2" = "view" ]; then
+  cat <<'EOF'
+{"iid":7,"web_url":"https://gitlab.com/org/repo/-/merge_requests/7","state":"opened","source_branch":"feature/159-default-branch","target_branch":"develop"}
+EOF
+  exit 0
+fi
+echo "unhandled glab: $*" >&2; exit 1
+`,
+    );
+
+    activate(fixture, stubBin);
+
+    const result = await handler.execute({
+      title: 'feat: default branch',
+      body: 'Body',
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(data.base).toBe('develop');
+  });
+
+  test('explicit_base_wins — auto-resolution skipped when base is provided', async () => {
+    const { fixture, stubBin } = await makeFixture({
+      '.claude-project.md': '# platform: github\n',
+    });
+    fixtureDir = fixture;
+    stubBinDir = stubBin;
+
+    await writeStub(
+      stubBin,
+      'git',
+      `
+case "$1 $2" in
+  "branch --show-current") echo "feature/159-default-branch" ;;
+  "remote -v") echo "origin\tgit@github.com:org/repo.git (fetch)" ;;
+  *) echo "unhandled git: $*" >&2; exit 1 ;;
+esac
+`,
+    );
+
+    // gh repo view MUST NOT be called when explicit base provided — fail loudly.
+    await writeStub(
+      stubBin,
+      'gh',
+      `
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+  echo "FAIL: repo view should not be called with explicit base" >&2
+  exit 99
+fi
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  case " $* " in
+    *" --base release/v2 "*) ;;
+    *) echo "expected --base release/v2 in argv, got: $*" >&2; exit 1 ;;
+  esac
+  echo "https://github.com/org/repo/pull/77"
+  exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  cat <<'EOF'
+{"number":77,"url":"https://github.com/org/repo/pull/77","state":"OPEN","headRefName":"feature/159-default-branch","baseRefName":"release/v2"}
+EOF
+  exit 0
+fi
+echo "unhandled gh: $*" >&2; exit 1
+`,
+    );
+
+    activate(fixture, stubBin);
+
+    const result = await handler.execute({
+      title: 'feat: explicit base',
+      body: 'Body',
+      base: 'release/v2',
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(data.base).toBe('release/v2');
+  });
+
+  test('default_branch_resolution_failure — surfaces ok:false when gh repo view fails', async () => {
+    const { fixture, stubBin } = await makeFixture({
+      '.claude-project.md': '# platform: github\n',
+    });
+    fixtureDir = fixture;
+    stubBinDir = stubBin;
+
+    await writeStub(
+      stubBin,
+      'git',
+      `
+case "$1 $2" in
+  "branch --show-current") echo "feature/159-default-branch" ;;
+  "remote -v") echo "origin\tgit@github.com:org/repo.git (fetch)" ;;
+  *) echo "unhandled git: $*" >&2; exit 1 ;;
+esac
+`,
+    );
+
+    await writeStub(
+      stubBin,
+      'gh',
+      `
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+  echo "auth required" >&2
+  exit 1
+fi
+echo "unhandled gh: $*" >&2; exit 1
+`,
+    );
+
+    activate(fixture, stubBin);
+
+    const result = await handler.execute({
+      title: 'feat: no base',
+      body: 'Body',
+    });
     const data = parseResult(result);
     expect(data.ok).toBe(false);
-    expect(String(data.error)).toContain('base');
+    expect(String(data.error)).toContain('default branch');
   });
 
   test('explicit_head_overrides_git_branch — uses args.head when provided', async () => {


### PR DESCRIPTION
## Summary

Skills like `/scp` previously had to call `gh repo view --json defaultBranchRef` themselves before invoking `pr_create`. The handler now does the lookup internally so callers can omit `base` entirely.

## Changes

- `handlers/pr_create.ts`:
  - Schema: `base` is now `z.string().min(1).optional()` (was required)
  - New `getDefaultBranch(platform, repo, cwd)` helper:
    - GitHub: `gh repo view [<slug>] --json defaultBranchRef --jq .defaultBranchRef.name`
    - GitLab: `glab api projects/<encoded-or-:id>` — parses `default_branch` from JSON in-process. **Note:** `glab api` does NOT support `--jq` (unlike `gh api`).
  - `execute()` mutates `args.base` in place when omitted; downstream `createGithubPr` / `createGitlabMr` have defensive `if (args.base === undefined) throw` for type narrowing
- `tests/pr_create.test.ts`:
  - 4 new tests: github + gitlab auto-resolve, explicit-base-wins (resolver skipped), resolution-failure surfaces `ok:false`
  - GitLab stub fails loudly with exit 99 if `--jq` ever reappears in argv — guards the regression caught in code review
  - Replaced obsolete `missing_required_base — schema rejects` test (no longer valid)

## Linked Issues

Closes #159

## Test Plan

- [x] `bun test tests/pr_create.test.ts` — 20/20 (was 17, +4 new, -1 obsolete)
- [x] `bun test` full suite — 1265/1265 pass, 3125 expect() calls
- [x] `./scripts/ci/validate.sh` — 70/70 handlers, typecheck clean
- [x] `trivy fs --severity HIGH,CRITICAL` — 0 findings
- [x] `feature-dev:code-reviewer` — 1 critical caught (initial impl used `glab api --jq` which doesn't exist; my stub gave false confidence). Fixed by parsing JSON in-process + tightening stub to fail on `--jq`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)