### PR TITLE
feat(labels): add label_list and label_create tools — idempotent, cross-platform

### DIFF
--- a/handlers/label_create.ts
+++ b/handlers/label_create.ts
@@ -1,0 +1,213 @@
+// Origin Operations family handler.
+// See docs/handlers/origin-operations-guide.md for the canonical pattern,
+// gh ↔ glab field mappings, and normalized response schemas.
+
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+import { detectPlatform } from '../lib/glab';
+
+// 6-char hex (no leading #). Both gh and glab accept color in this form.
+const HEX_COLOR_RE = /^[0-9a-fA-F]{6}$/;
+
+const inputSchema = z.object({
+  name: z.string().min(1, 'name must be a non-empty string'),
+  description: z.string().optional().default(''),
+  color: z
+    .string()
+    .regex(HEX_COLOR_RE, 'color must be a 6-char hex (no leading #)')
+    .optional(),
+  repo: z
+    .string()
+    .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/, 'repo must be owner/repo format')
+    .optional(),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+interface NormalizedLabel {
+  name: string;
+  description: string;
+  color: string;
+  created: boolean; // true if newly created, false if already existed
+}
+
+interface ExecError extends Error {
+  stderr?: Buffer | string;
+  stdout?: Buffer | string;
+}
+
+function bufToString(b: unknown): string {
+  if (b === undefined || b === null) return '';
+  if (typeof b === 'string') return b;
+  if (typeof (b as Buffer).toString === 'function') return (b as Buffer).toString();
+  return String(b);
+}
+
+function exec(cmd: string): { ok: boolean; stdout: string; stderr: string } {
+  try {
+    const out = execSync(cmd, { encoding: 'utf8' });
+    return { ok: true, stdout: out.trim(), stderr: '' };
+  } catch (err) {
+    const e = err as ExecError;
+    return {
+      ok: false,
+      stdout: bufToString(e.stdout).trim(),
+      stderr: bufToString(e.stderr).trim() || e.message || '',
+    };
+  }
+}
+
+function quoteArg(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * gh and glab both report "label already exists" on the duplicate path.
+ * Heuristic match — phrasing varies across CLI versions but consistently
+ * includes the substring "already exists".
+ */
+function stderrIndicatesDuplicate(text: string): boolean {
+  return /already exists/i.test(text);
+}
+
+function lookupGithubLabel(name: string, repo: string | undefined): NormalizedLabel | null {
+  const parts = ['gh', 'label', 'list', '--search', quoteArg(name), '--json', 'name,description,color', '--limit', '20'];
+  if (repo !== undefined) {
+    parts.push('--repo', quoteArg(repo));
+  }
+  const result = exec(parts.join(' '));
+  if (!result.ok) return null;
+  try {
+    const labels = JSON.parse(result.stdout) as Array<{ name: string; description?: string; color?: string }>;
+    // gh label list --search is a fuzzy match; pick the exact case-insensitive name.
+    const match = labels.find((l) => l.name.toLowerCase() === name.toLowerCase());
+    if (match === undefined) return null;
+    return {
+      name: match.name,
+      description: match.description ?? '',
+      color: match.color ?? '',
+      created: false,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function createGithubLabel(args: Input): NormalizedLabel {
+  const parts = ['gh', 'label', 'create', quoteArg(args.name)];
+  if (args.description.length > 0) {
+    parts.push('--description', quoteArg(args.description));
+  }
+  if (args.color !== undefined) {
+    parts.push('--color', quoteArg(args.color));
+  }
+  if (args.repo !== undefined) {
+    parts.push('--repo', quoteArg(args.repo));
+  }
+  const result = exec(parts.join(' '));
+  if (!result.ok) {
+    if (stderrIndicatesDuplicate(result.stderr) || stderrIndicatesDuplicate(result.stdout)) {
+      const existing = lookupGithubLabel(args.name, args.repo);
+      if (existing !== null) return existing;
+      throw new Error(
+        `gh label create: label '${args.name}' already exists but could not be found via lookup`,
+      );
+    }
+    throw new Error(`gh label create failed: ${result.stderr || result.stdout}`);
+  }
+  return {
+    name: args.name,
+    description: args.description,
+    color: args.color ?? '',
+    created: true,
+  };
+}
+
+function lookupGitlabLabel(name: string, repo: string | undefined): NormalizedLabel | null {
+  const parts = ['glab', 'label', 'list', '-F', 'json', '--per-page', '100'];
+  if (repo !== undefined) {
+    parts.push('-R', quoteArg(repo));
+  }
+  const result = exec(parts.join(' '));
+  if (!result.ok) return null;
+  try {
+    const labels = JSON.parse(result.stdout) as Array<{ name: string; description?: string; color?: string }>;
+    const match = labels.find((l) => l.name.toLowerCase() === name.toLowerCase());
+    if (match === undefined) return null;
+    return {
+      name: match.name,
+      description: match.description ?? '',
+      color: (match.color ?? '').replace(/^#/, ''),
+      created: false,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function createGitlabLabel(args: Input): NormalizedLabel {
+  const parts = ['glab', 'label', 'create', '--name', quoteArg(args.name)];
+  if (args.description.length > 0) {
+    parts.push('--description', quoteArg(args.description));
+  }
+  if (args.color !== undefined) {
+    // GitLab's REST API requires `#RRGGBB`; bare hex is rejected. Schema
+    // takes bare hex (consumer-friendly, symmetric with the gh path);
+    // prepend the `#` here when handing off to glab.
+    parts.push('--color', quoteArg(`#${args.color}`));
+  }
+  if (args.repo !== undefined) {
+    parts.push('-R', quoteArg(args.repo));
+  }
+  const result = exec(parts.join(' '));
+  if (!result.ok) {
+    if (stderrIndicatesDuplicate(result.stderr) || stderrIndicatesDuplicate(result.stdout)) {
+      const existing = lookupGitlabLabel(args.name, args.repo);
+      if (existing !== null) return existing;
+      throw new Error(
+        `glab label create: label '${args.name}' already exists but could not be found via lookup`,
+      );
+    }
+    throw new Error(`glab label create failed: ${result.stderr || result.stdout}`);
+  }
+  return {
+    name: args.name,
+    description: args.description,
+    color: args.color ?? '',
+    created: true,
+  };
+}
+
+const labelCreateHandler: HandlerDef = {
+  name: 'label_create',
+  description:
+    'Create a label on the current repo. Idempotent: returns the existing label with `created: false` if it already exists. Color is a 6-char hex (no leading #). Cross-platform (gh + glab).',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: Input;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const platform = detectPlatform();
+      const label = platform === 'github' ? createGithubLabel(args) : createGitlabLabel(args);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: true, ...label }) }],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default labelCreateHandler;

--- a/handlers/label_list.ts
+++ b/handlers/label_list.ts
@@ -1,0 +1,108 @@
+// Origin Operations family handler.
+// See docs/handlers/origin-operations-guide.md for the canonical pattern,
+// gh ↔ glab field mappings, and normalized response schemas.
+
+import { execSync } from 'child_process';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+import { detectPlatform } from '../lib/glab';
+
+const inputSchema = z.object({
+  limit: z.number().int().positive().optional().default(100),
+  repo: z
+    .string()
+    .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/, 'repo must be owner/repo format')
+    .optional(),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+interface NormalizedLabel {
+  name: string;
+  description: string;
+  color: string;
+}
+
+function exec(cmd: string): string {
+  return execSync(cmd, { encoding: 'utf8' }).trim();
+}
+
+function quoteArg(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+interface GithubLabel {
+  name: string;
+  description?: string;
+  color?: string;
+}
+
+function listGithubLabels(args: Input): NormalizedLabel[] {
+  const parts = ['gh', 'label', 'list', '--json', 'name,description,color', '--limit', String(args.limit)];
+  if (args.repo !== undefined) {
+    parts.push('--repo', quoteArg(args.repo));
+  }
+  const raw = exec(parts.join(' '));
+  const parsed = JSON.parse(raw) as GithubLabel[];
+  return parsed.map((l) => ({
+    name: l.name,
+    description: l.description ?? '',
+    color: l.color ?? '',
+  }));
+}
+
+interface GitlabLabel {
+  name: string;
+  description?: string;
+  // glab label list returns `color` as `#RRGGBB` (with leading #); normalize to bare hex.
+  color?: string;
+}
+
+function listGitlabLabels(args: Input): NormalizedLabel[] {
+  const parts = ['glab', 'label', 'list', '-F', 'json', '--per-page', String(args.limit)];
+  if (args.repo !== undefined) {
+    parts.push('-R', quoteArg(args.repo));
+  }
+  const raw = exec(parts.join(' '));
+  const parsed = JSON.parse(raw) as GitlabLabel[];
+  return parsed.map((l) => ({
+    name: l.name,
+    description: l.description ?? '',
+    color: (l.color ?? '').replace(/^#/, ''),
+  }));
+}
+
+const labelListHandler: HandlerDef = {
+  name: 'label_list',
+  description:
+    'List labels for the current repo. Returns name, description, and color (bare 6-char hex, no leading #) for each. Cross-platform (gh + glab).',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: Input;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const platform = detectPlatform();
+      const labels = platform === 'github' ? listGithubLabels(args) : listGitlabLabels(args);
+      return {
+        content: [
+          { type: 'text' as const, text: JSON.stringify({ ok: true, labels, count: labels.length }) },
+        ],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default labelListHandler;

--- a/tests/label_create.test.ts
+++ b/tests/label_create.test.ts
@@ -1,0 +1,270 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+interface MockExecError extends Error {
+  stderr?: string;
+  stdout?: string;
+}
+
+function mockExec(cmd: string): string {
+  execCalls.push(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  throw new Error(`Unexpected exec call: ${cmd}`);
+}
+
+mock.module('child_process', () => ({
+  execSync: (cmd: string, _opts?: unknown) => mockExec(cmd),
+}));
+
+const { default: handler } = await import('../handlers/label_create.ts');
+
+function parseResult(content: Array<{ type: string; text: string }>) {
+  return JSON.parse(content[0].text) as Record<string, unknown>;
+}
+
+function onExec(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('label_create handler', () => {
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('label_create');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  // ---- schema validation ----
+
+  test('schema rejects missing name', async () => {
+    const result = await handler.execute({ color: 'd73a4a' });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+  });
+
+  test('schema rejects color with leading # (must be bare hex)', async () => {
+    const result = await handler.execute({ name: 'bug', color: '#d73a4a' });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+    expect(String(data.error)).toContain('hex');
+  });
+
+  test('schema accepts uppercase hex color', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
+    onExec('gh label create', '');
+    const result = await handler.execute({ name: 'bug', color: 'D73A4A' });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+  });
+
+  test('schema rejects malformed repo', async () => {
+    const result = await handler.execute({ name: 'bug', repo: 'not-a-slug' });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+  });
+
+  // ---- github happy path ----
+
+  test('github — creates new label, returns created:true', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
+    onExec('gh label create', '');
+    const result = await handler.execute({
+      name: 'priority::high',
+      description: 'Top priority',
+      color: 'd73a4a',
+    });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    expect(data.created).toBe(true);
+    expect(data.name).toBe('priority::high');
+    expect(data.color).toBe('d73a4a');
+    expect(data.description).toBe('Top priority');
+  });
+
+  test('github — quotes name and description with shell-escape', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
+    onExec('gh label create', '');
+    await handler.execute({
+      name: "needs-review's-input",
+      description: "It's important",
+      color: 'd73a4a',
+    });
+    const createCall = execCalls.find((c) => c.includes('gh label create')) ?? '';
+    expect(createCall).toContain(`'needs-review'\\''s-input'`);
+    expect(createCall).toContain(`'It'\\''s important'`);
+  });
+
+  // ---- github idempotent path ----
+
+  test('github — idempotent: duplicate triggers lookup, returns created:false', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
+    onExec('gh label create', () => {
+      const err: MockExecError = new Error('label already exists') as MockExecError;
+      err.stderr = '! Label "bug" already exists\n';
+      throw err;
+    });
+    onExec('gh label list', JSON.stringify([
+      { name: 'bug', description: 'pre-existing', color: 'aabbcc' },
+    ]));
+    const result = await handler.execute({
+      name: 'bug',
+      description: 'requested description (will be ignored — label already exists)',
+      color: 'd73a4a',
+    });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    expect(data.created).toBe(false);
+    expect(data.name).toBe('bug');
+    // Returned values reflect what's already on the platform, not what we asked for
+    expect(data.description).toBe('pre-existing');
+    expect(data.color).toBe('aabbcc');
+  });
+
+  test('github — non-duplicate failure surfaces ok:false', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
+    onExec('gh label create', () => {
+      const err: MockExecError = new Error('auth required') as MockExecError;
+      err.stderr = 'gh: not authenticated\n';
+      throw err;
+    });
+    const result = await handler.execute({ name: 'bug', color: 'd73a4a' });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+    expect(String(data.error)).toContain('gh label create failed');
+  });
+
+  test('github — repo flag passed through to both create and lookup', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
+    onExec('gh label create', '');
+    await handler.execute({ name: 'bug', color: 'd73a4a', repo: 'foo/bar' });
+    const createCall = execCalls.find((c) => c.includes('gh label create')) ?? '';
+    expect(createCall).toContain("--repo 'foo/bar'");
+  });
+
+  // ---- gitlab happy path ----
+
+  test('gitlab — creates new label, returns created:true', async () => {
+    onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git');
+    onExec('glab label create', '');
+    const result = await handler.execute({
+      name: 'priority::high',
+      description: 'Top priority',
+      color: 'd73a4a',
+    });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    expect(data.created).toBe(true);
+    expect(data.name).toBe('priority::high');
+  });
+
+  test('gitlab — uses --name (not positional) for label name', async () => {
+    onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git');
+    onExec('glab label create', '');
+    await handler.execute({ name: 'bug', color: 'd73a4a' });
+    const createCall = execCalls.find((c) => c.includes('glab label create')) ?? '';
+    expect(createCall).toContain("--name 'bug'");
+  });
+
+  test('gitlab — prepends `#` to color (GitLab REST API rejects bare hex)', async () => {
+    onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git');
+    onExec('glab label create', '');
+    await handler.execute({ name: 'bug', color: 'd73a4a' });
+    const createCall = execCalls.find((c) => c.includes('glab label create')) ?? '';
+    expect(createCall).toContain("--color '#d73a4a'");
+    // Sanity: bare hex must NOT appear as a standalone color value (would
+    // mean we forgot the # prepend).
+    expect(createCall).not.toContain("--color 'd73a4a'");
+  });
+
+  test('github — passes color bare (gh accepts bare hex, no # prepend)', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
+    onExec('gh label create', '');
+    await handler.execute({ name: 'bug', color: 'd73a4a' });
+    const createCall = execCalls.find((c) => c.includes('gh label create')) ?? '';
+    expect(createCall).toContain("--color 'd73a4a'");
+    expect(createCall).not.toContain("--color '#d73a4a'");
+  });
+
+  // ---- gitlab idempotent path ----
+
+  test('gitlab — idempotent: duplicate triggers lookup, returns created:false', async () => {
+    onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git');
+    onExec('glab label create', () => {
+      const err: MockExecError = new Error('label already exists') as MockExecError;
+      err.stderr = 'Label already exists\n';
+      throw err;
+    });
+    onExec('glab label list', JSON.stringify([
+      { name: 'bug', description: 'pre-existing', color: '#aabbcc' },
+    ]));
+    const result = await handler.execute({
+      name: 'bug',
+      description: 'ignored',
+      color: 'd73a4a',
+    });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    expect(data.created).toBe(false);
+    expect(data.color).toBe('aabbcc'); // # stripped
+  });
+
+  test('gitlab — repo flag uses -R (glab convention, not --repo)', async () => {
+    onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git');
+    onExec('glab label create', '');
+    await handler.execute({ name: 'bug', color: 'd73a4a', repo: 'foo/bar' });
+    const createCall = execCalls.find((c) => c.includes('glab label create')) ?? '';
+    expect(createCall).toContain("-R 'foo/bar'");
+  });
+
+  // ---- color is optional ----
+
+  test('color may be omitted', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
+    onExec('gh label create', '');
+    const result = await handler.execute({ name: 'bug' });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    const createCall = execCalls.find((c) => c.includes('gh label create')) ?? '';
+    expect(createCall).not.toContain('--color');
+  });
+
+  // ---- duplicate detection regex ----
+
+  test('"already exists" detection is case-insensitive', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
+    onExec('gh label create', () => {
+      const err: MockExecError = new Error('') as MockExecError;
+      err.stderr = 'Label Already Exists in repo\n'; // mixed case
+      throw err;
+    });
+    onExec('gh label list', JSON.stringify([{ name: 'bug', description: '', color: '' }]));
+    const result = await handler.execute({ name: 'bug', color: 'd73a4a' });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    expect(data.created).toBe(false);
+  });
+
+  test('"already exists" detection also matches against stdout (some CLI versions)', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
+    onExec('gh label create', () => {
+      const err: MockExecError = new Error('') as MockExecError;
+      err.stdout = 'label already exists\n'; // on stdout, not stderr
+      err.stderr = '';
+      throw err;
+    });
+    onExec('gh label list', JSON.stringify([{ name: 'bug', description: '', color: '' }]));
+    const result = await handler.execute({ name: 'bug', color: 'd73a4a' });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    expect(data.created).toBe(false);
+  });
+});

--- a/tests/label_list.test.ts
+++ b/tests/label_list.test.ts
@@ -1,0 +1,111 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+let execRegistry: Record<string, string> = {};
+let execCalls: string[] = [];
+let execError: Error | null = null;
+
+function mockExec(cmd: string): string {
+  execCalls.push(cmd);
+  if (execError) throw execError;
+  for (const [key, value] of Object.entries(execRegistry)) {
+    if (cmd.includes(key)) return value;
+  }
+  throw new Error(`Unexpected exec call: ${cmd}`);
+}
+
+mock.module('child_process', () => ({
+  execSync: (cmd: string, _opts?: unknown) => mockExec(cmd),
+}));
+
+const { default: handler } = await import('../handlers/label_list.ts');
+
+function parseResult(content: Array<{ type: string; text: string }>) {
+  return JSON.parse(content[0].text) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  execRegistry = {};
+  execCalls = [];
+  execError = null;
+});
+
+describe('label_list handler', () => {
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('label_list');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('github — returns normalized labels from gh label list', async () => {
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    execRegistry['gh label list'] = JSON.stringify([
+      { name: 'bug', description: 'Something broken', color: 'd73a4a' },
+      { name: 'enhancement', description: 'New feature', color: 'a2eeef' },
+    ]);
+    const result = await handler.execute({});
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    expect(data.count).toBe(2);
+    const labels = data.labels as Array<{ name: string; color: string }>;
+    expect(labels[0].name).toBe('bug');
+    expect(labels[0].color).toBe('d73a4a');
+  });
+
+  test('github — passes --limit and --repo flags', async () => {
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    execRegistry['gh label list'] = '[]';
+    await handler.execute({ limit: 50, repo: 'foo/bar' });
+    const ghCall = execCalls.find((c) => c.includes('gh label list')) ?? '';
+    expect(ghCall).toContain('--limit 50');
+    expect(ghCall).toContain("--repo 'foo/bar'");
+    expect(ghCall).toContain('--json name,description,color');
+  });
+
+  test('gitlab — returns normalized labels from glab label list, strips leading # from color', async () => {
+    execRegistry['git remote get-url origin'] = 'https://gitlab.com/org/repo.git';
+    execRegistry['glab label list'] = JSON.stringify([
+      { name: 'bug', description: 'Bug', color: '#d73a4a' },
+      { name: 'enhancement', color: '#a2eeef' }, // no description
+    ]);
+    const result = await handler.execute({});
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    const labels = data.labels as Array<{ name: string; color: string; description: string }>;
+    expect(labels[0].color).toBe('d73a4a'); // # stripped
+    expect(labels[1].color).toBe('a2eeef');
+    expect(labels[1].description).toBe(''); // missing → empty string
+  });
+
+  test('gitlab — passes --per-page and -R flags', async () => {
+    execRegistry['git remote get-url origin'] = 'https://gitlab.com/org/repo.git';
+    execRegistry['glab label list'] = '[]';
+    await handler.execute({ limit: 25, repo: 'foo/bar' });
+    const glabCall = execCalls.find((c) => c.includes('glab label list')) ?? '';
+    expect(glabCall).toContain('--per-page 25');
+    expect(glabCall).toContain("-R 'foo/bar'");
+    expect(glabCall).toContain('-F json');
+  });
+
+  test('returns ok:false on subprocess failure', async () => {
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    execError = new Error('gh not authenticated');
+    const result = await handler.execute({});
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+    expect(String(data.error)).toContain('gh not authenticated');
+  });
+
+  test('default limit is 100 when not specified', async () => {
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    execRegistry['gh label list'] = '[]';
+    await handler.execute({});
+    const ghCall = execCalls.find((c) => c.includes('gh label list')) ?? '';
+    expect(ghCall).toContain('--limit 100');
+  });
+
+  test('schema rejects malformed repo', async () => {
+    const result = await handler.execute({ repo: 'not-a-slug' });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+    expect(String(data.error)).toContain('owner/repo');
+  });
+});


### PR DESCRIPTION
## Summary

Two new MCP tools so `/issue`, `/ccfold`, and any other skill that needs label management can stop shelling out to `gh label` / `glab label` with their own platform branching.

## Changes

- `handlers/label_list.ts` — NEW. Returns `{name, description, color}` per label. Color normalized to bare 6-char hex (gh returns bare; glab returns `#RRGGBB`, stripped on read). Supports `limit` (default 100) and `repo` slug.
- `handlers/label_create.ts` — NEW. Idempotent: catches "already exists" patterns (case-insensitive, stderr or stdout) then runs a follow-up list-and-find to return the existing label with `created: false`. Schema enforces bare 6-char hex on input.
  - **GitLab gotcha:** `glab label create --color` requires `#RRGGBB` even though the input schema is bare hex — `#` is prepended at the call site. (Caught in code review; mocks initially gave false confidence.)
- `tests/label_list.test.ts` — NEW. 8 tests: github + gitlab happy paths, # stripping on read, flag passing, schema, default limit.
- `tests/label_create.test.ts` — NEW. 19 tests: schema validation, github + gitlab happy paths, idempotency on both, shell-escape, color optional, color-format regression tests for both platforms, case-insensitive duplicate detection, stdout-source duplicate detection.

## Linked Issues

Closes #158

## Test Plan

- [x] `bun test tests/label_list.test.ts tests/label_create.test.ts` — 27/27 pass
- [x] `bun test` full suite — 1302/1302 pass, 3200 expect() calls
- [x] `./scripts/ci/validate.sh` — 72/72 handlers (was 70 — `label_list` + `label_create` registered via codegen), typecheck clean
- [x] `trivy fs --severity HIGH,CRITICAL` — 0 findings
- [x] `feature-dev:code-reviewer` — 1 critical caught (initial impl passed bare hex to `glab label create --color`, GitLab REST API rejects without `#`). Fixed + 2 regression tests pinning the correct color format on each platform.

## Notes

This wraps up BJ's queue — all 6 issues from the morning's list are now done. Closes the loop on the parser-consistency theme (#208/#209) and the cross-platform tool-surface theme (#159/#158).

🤖 Generated with [Claude Code](https://claude.com/claude-code)