### PR TITLE
feat(commutativity_verify): install probe + PROBE_UNAVAILABLE verdict

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ SDLC workflow MCP server for Claude Code agents.
 
 - [Bun](https://bun.sh) >= 1.0
 - A `GITHUB_TOKEN` or `GITLAB_TOKEN` environment variable (required for tools that interact with GitHub/GitLab APIs)
+- **Python 3.11+** (optional, but required for `commutativity_verify` — see [commutativity-probe](#commutativity-probe) below)
 
 ## Quickstart
 
@@ -13,6 +14,13 @@ SDLC workflow MCP server for Claude Code agents.
    ```bash
    curl -fsSL https://raw.githubusercontent.com/Wave-Engineering/mcp-server-sdlc/main/scripts/install-remote.sh | bash
    ```
+
+   Install-time options:
+   | Variable / flag | Effect |
+   |---|---|
+   | `SDLC_VERSION=v1.2.3` | Override sdlc-server release tag (default: latest release) |
+   | `SDLC_PROBE_REF=<git-ref>` | Override commutativity-probe git ref (default: `v0.1.0`) |
+   | `--skip-probe` | Skip commutativity-probe install (handler degrades to `verdict: PROBE_UNAVAILABLE`) |
 
 2. **Configure your token** in `~/.claude.json` under the `sdlc-server` entry:
    ```json
@@ -50,6 +58,37 @@ const handler: HandlerDef = {
 };
 
 export default handler;
+```
+
+## commutativity-probe
+
+The `commutativity_verify` MCP tool shells out to the
+[`commutativity-probe`](https://github.com/Wave-Engineering/commutativity-probe)
+Python CLI to compute changeset commutativity from real git diffs. The
+installer bundles it via `pip install --user` (pinned to `v0.1.0`).
+
+If the probe binary is missing from `PATH`, `commutativity_verify` returns
+the same body shape as a timeout, with `verdict: "PROBE_UNAVAILABLE"`:
+
+```json
+{
+  "ok": true,
+  "mode": "pairwise",
+  "verdict": "PROBE_UNAVAILABLE",
+  "group_verdict": "PROBE_UNAVAILABLE",
+  "pairs": [],
+  "pairwise_results": [],
+  "warnings": ["commutativity-probe binary not found on PATH; install via mcp-server-sdlc/scripts/install-remote.sh"]
+}
+```
+
+Callers should treat `PROBE_UNAVAILABLE` as conservative-fail (sequential
+merge fallback) — equivalent to `ORACLE_REQUIRED` for dispatch purposes.
+
+To install or upgrade the probe manually:
+
+```bash
+pip install --user 'git+https://github.com/Wave-Engineering/commutativity-probe.git@v0.1.0'
 ```
 
 ## Tool Reference

--- a/handlers/commutativity_verify.ts
+++ b/handlers/commutativity_verify.ts
@@ -36,10 +36,17 @@ interface ProbeOutput {
   pairs: ProbePair[];
 }
 
-const VALID_VERDICTS = ['STRONG', 'MEDIUM', 'WEAK', 'ORACLE_REQUIRED'] as const;
+// Wire-side: verdicts the probe is allowed to emit. Validation against
+// probe stdout uses this set.
+const PROBE_VERDICTS = ['STRONG', 'MEDIUM', 'WEAK', 'ORACLE_REQUIRED'] as const;
+// Full union: includes envelope-only verdicts the handler synthesizes
+// (timeout → ORACLE_REQUIRED; binary missing → PROBE_UNAVAILABLE). Response
+// types and the public schema document this set.
+const VERDICTS = [...PROBE_VERDICTS, 'PROBE_UNAVAILABLE'] as const;
+type Verdict = (typeof VERDICTS)[number];
 
-function isValidVerdict(v: string): v is (typeof VALID_VERDICTS)[number] {
-  return (VALID_VERDICTS as readonly string[]).includes(v);
+function isProbeVerdict(v: string): v is (typeof PROBE_VERDICTS)[number] {
+  return (PROBE_VERDICTS as readonly string[]).includes(v);
 }
 
 /**
@@ -86,12 +93,45 @@ interface SingleTargetResult {
   head_ref: string;
 }
 
+// Build the "fail-safe verdict" envelope shared by the timeout path and the
+// probe-missing path. Both synthesize a verdict the probe never emitted, so
+// the body shape (mode, alias, mode-appropriate sub-result) must stay
+// consistent — divergence here would make callers' dispatch logic brittle.
+function buildFailSafeBody(
+  args: Input,
+  mode: Mode,
+  verdict: Verdict,
+  warning: string,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    ok: true,
+    mode,
+    verdict,
+    group_verdict: verdict,
+    pairs: [],
+    warnings: [warning],
+  };
+  if (mode === 'pairwise') {
+    body.pairwise_results = [];
+  } else {
+    const cs = args.changesets[0];
+    body.single_target_result = {
+      verdict,
+      changeset_id: cs.id,
+      head_ref: cs.head_ref,
+    } satisfies SingleTargetResult;
+  }
+  return body;
+}
+
 const commutativityVerifyHandler: HandlerDef = {
   name: 'commutativity_verify',
   description:
     'Verify changeset commutativity / single-target safety from actual git diffs. ' +
     'Pairwise mode (≥2 changesets): decides whether the merge train pipeline is needed for a flight of MRs — call AFTER all MR pipelines in the flight pass (pr_wait_ci green) and BEFORE pr_merge. ' +
     'Single-target mode (1 changeset): KAHUNA composed-diff safety gate — is this branch safe to land in base_ref? ' +
+    'Verdict union: STRONG | MEDIUM | WEAK | ORACLE_REQUIRED (probe-emitted) | PROBE_UNAVAILABLE (handler-synthesized when the probe binary is missing from PATH; install via scripts/install-remote.sh). ' +
+    'PROBE_UNAVAILABLE shares the same body shape as a timeout (mode, verdict, group_verdict alias, pairs:[], warnings:[...], mode-appropriate single_target_result/pairwise_results) and should be treated as conservative-fail (sequential merge fallback) by callers. ' +
     'The response includes both mode-specific fields and legacy aliases (`group_verdict`, `pairs`) for backward compat.',
   inputSchema,
   async execute(rawArgs: unknown) {
@@ -129,36 +169,48 @@ const commutativityVerifyHandler: HandlerDef = {
       log.info('subprocess', { cmd: 'commutativity-probe', exit_code: 0, ms: Date.now() - subStart });
     } catch (err) {
       const subMs = Date.now() - subStart;
-      // Fail safe: any subprocess error → ORACLE_REQUIRED verdict with warning.
       const message = err instanceof Error ? err.message : String(err);
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      const status = (err as { status?: number } | undefined)?.status;
+
+      // Probe binary not on PATH → synthesize PROBE_UNAVAILABLE (#218). With
+      // execSync in shell mode (the call above), Node spawns `/bin/sh -c …`
+      // which always succeeds (sh is found), so an ENOENT spawn failure is
+      // unreachable here — the real signal is the shell exiting 127 ("command
+      // not found"). The message regex catches mocked errors and odd shells
+      // that don't propagate the status cleanly. NB: only the missing-binary
+      // case becomes PROBE_UNAVAILABLE — probe crashes / non-zero exits stay
+      // {ok: false} so real probe bugs surface.
+      const probeMissing = status === 127
+        || /commutativity-probe[^:]*:\s*(command )?not found/i.test(message);
+      if (probeMissing) {
+        log.warn('subprocess', { cmd: 'commutativity-probe', exit_code: status ?? -1, ms: subMs }, 'commutativity-probe binary not found on PATH');
+        const body = buildFailSafeBody(
+          args,
+          mode,
+          'PROBE_UNAVAILABLE',
+          'commutativity-probe binary not found on PATH; install via mcp-server-sdlc/scripts/install-remote.sh or `pip install --user git+https://github.com/Wave-Engineering/commutativity-probe.git@v0.1.0`',
+        );
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(body) }],
+        };
+      }
+
       // Real execSync timeouts set err.code === 'ETIMEDOUT'. Fall back to
       // substring match for mocked errors and older runtimes.
-      const code = (err as NodeJS.ErrnoException | undefined)?.code;
       const timedOut = code === 'ETIMEDOUT'
         || message.includes('ETIMEDOUT')
         || message.includes('timed out');
       if (timedOut) {
         log.warn('subprocess', { cmd: 'commutativity-probe', exit_code: -1, ms: subMs }, 'Subprocess timed out');
-        const timeoutBody: Record<string, unknown> = {
-          ok: true,
+        const body = buildFailSafeBody(
+          args,
           mode,
-          verdict: 'ORACLE_REQUIRED',
-          group_verdict: 'ORACLE_REQUIRED',
-          pairs: [],
-          warnings: [`Subprocess timed out after ${timeoutMs}ms. Failing safe to ORACLE_REQUIRED.`],
-        };
-        if (mode === 'pairwise') {
-          timeoutBody.pairwise_results = [];
-        } else {
-          const cs = args.changesets[0];
-          timeoutBody.single_target_result = {
-            verdict: 'ORACLE_REQUIRED',
-            changeset_id: cs.id,
-            head_ref: cs.head_ref,
-          } satisfies SingleTargetResult;
-        }
+          'ORACLE_REQUIRED',
+          `Subprocess timed out after ${timeoutMs}ms. Failing safe to ORACLE_REQUIRED.`,
+        );
         return {
-          content: [{ type: 'text' as const, text: JSON.stringify(timeoutBody) }],
+          content: [{ type: 'text' as const, text: JSON.stringify(body) }],
         };
       }
       log.error('subprocess', { cmd: 'commutativity-probe', exit_code: -1, ms: subMs, stderr: message.slice(0, 200) });
@@ -180,12 +232,12 @@ const commutativityVerifyHandler: HandlerDef = {
     }
 
     // Validate the verdict value from the probe.
-    const verdict = isValidVerdict(probe.flight_verdict)
+    const verdict = isProbeVerdict(probe.flight_verdict)
       ? probe.flight_verdict
       : 'ORACLE_REQUIRED';
 
     const warnings: string[] = [];
-    if (!isValidVerdict(probe.flight_verdict)) {
+    if (!isProbeVerdict(probe.flight_verdict)) {
       warnings.push(`Unknown verdict '${probe.flight_verdict}' from probe — defaulting to ORACLE_REQUIRED`);
     }
 
@@ -195,7 +247,7 @@ const commutativityVerifyHandler: HandlerDef = {
     // single_target_result and pairwise_results populated.
     let pairs = mapPairIds(probe.pairs, refToId).map(p => ({
       ...p,
-      verdict: isValidVerdict(p.verdict) ? p.verdict : 'ORACLE_REQUIRED',
+      verdict: isProbeVerdict(p.verdict) ? p.verdict : 'ORACLE_REQUIRED',
     }));
     if (mode === 'single_target' && pairs.length > 0) {
       warnings.push(`Probe returned ${pairs.length} pair(s) for a single-target call — discarding (unexpected shape)`);

--- a/scripts/install-remote.sh
+++ b/scripts/install-remote.sh
@@ -1,13 +1,34 @@
 #!/usr/bin/env bash
 # Install sdlc-server from a GitHub release.
 # Detects platform, downloads the appropriate binary, installs to ~/.local/bin,
-# and registers the MCP server in ~/.claude.json.
+# registers the MCP server in ~/.claude.json, and bundles the
+# commutativity-probe Python CLI (skip with --skip-probe).
 set -euo pipefail
 
 REPO="Wave-Engineering/mcp-server-sdlc"
 BINARY_NAME="sdlc-server"
 INSTALL_DIR="${HOME}/.local/bin"
 CLAUDE_CONFIG="${HOME}/.claude.json"
+
+# Probe install config (#218). Pin to v0.1.0 by default; SDLC_PROBE_REF env
+# var overrides for dev/CI without editing the script.
+PROBE_REPO_URL="https://github.com/Wave-Engineering/commutativity-probe.git"
+PROBE_REF="${SDLC_PROBE_REF:-v0.1.0}"
+
+# Parse flags. Currently only --skip-probe; positional args ignored.
+SKIP_PROBE=0
+for arg in "$@"; do
+    case "$arg" in
+        --skip-probe) SKIP_PROBE=1 ;;
+        --help|-h)
+            echo "Usage: install-remote.sh [--skip-probe]"
+            echo "  --skip-probe          Skip commutativity-probe install"
+            echo "  SDLC_VERSION=...      Override sdlc-server release tag"
+            echo "  SDLC_PROBE_REF=...    Override commutativity-probe git ref (default: v0.1.0)"
+            exit 0
+            ;;
+    esac
+done
 
 # Detect platform
 OS="$(uname -s)"
@@ -61,4 +82,60 @@ else
     echo "  Add sdlc-server to mcpServers in ${CLAUDE_CONFIG} with command: ${INSTALL_DIR}/${BINARY_NAME}"
 fi
 
+# --- commutativity-probe install (#218) ---
+# Bundled so a fresh sdlc-server install gets a working `commutativity_verify`
+# tool out of the box. Skip with --skip-probe; failure here warns but does
+# NOT fail the sdlc-server install (the handler degrades gracefully via
+# PROBE_UNAVAILABLE verdict when the binary is missing).
+
+echo ""
+if [[ "${SKIP_PROBE}" -eq 1 ]]; then
+    echo "Skipping commutativity-probe install (--skip-probe set)"
+elif ! command -v python3 >/dev/null 2>&1; then
+    echo "  ✗ python3 not found — skipping commutativity-probe install"
+    echo "    The handler will return verdict=PROBE_UNAVAILABLE until installed."
+    echo "    Hint: install Python 3.11+ and re-run, or use --skip-probe to silence."
+else
+    PY_VERSION="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null || echo "0.0")"
+    PY_MAJOR="${PY_VERSION%%.*}"
+    PY_MINOR="${PY_VERSION##*.}"
+    if [[ "${PY_MAJOR}" -lt 3 ]] || { [[ "${PY_MAJOR}" -eq 3 ]] && [[ "${PY_MINOR}" -lt 11 ]]; }; then
+        echo "  ✗ python3 ${PY_VERSION} too old (need 3.11+) — skipping commutativity-probe install"
+        echo "    The handler will return verdict=PROBE_UNAVAILABLE until installed."
+    else
+        echo "Installing commutativity-probe @ ${PROBE_REF}..."
+        if pip install --user --quiet "git+${PROBE_REPO_URL}@${PROBE_REF}"; then
+            if command -v commutativity-probe >/dev/null 2>&1 && commutativity-probe --help >/dev/null 2>&1; then
+                echo "  ✓ commutativity-probe installed and verified"
+            else
+                echo "  ⚠️  commutativity-probe installed but not on PATH or --help failed"
+                echo "    Ensure ${INSTALL_DIR} is in PATH (see warning below)."
+            fi
+        else
+            echo "  ✗ pip install failed for commutativity-probe — skipping"
+            echo "    The handler will return verdict=PROBE_UNAVAILABLE until installed."
+        fi
+    fi
+fi
+
+# --- ~/.local/bin PATH check (#218) ---
+# pip --user puts console scripts in ~/.local/bin. Most users have it on PATH
+# via shell profile, but Claude Code's MCP subprocess env can be sparser. Warn
+# at install time so the user can fix it before the missing-binary symptom
+# appears at probe-invocation time.
+case ":${PATH}:" in
+    *":${INSTALL_DIR}:"*)
+        # ~/.local/bin already on PATH — nothing to do.
+        ;;
+    *)
+        echo ""
+        echo "⚠️  ${INSTALL_DIR} is not in your PATH."
+        echo "    sdlc-server and commutativity-probe will not be found at runtime."
+        echo "    Add to your shell profile (~/.bashrc or ~/.zshrc):"
+        echo "      export PATH=\"\$HOME/.local/bin:\$PATH\""
+        echo "    Then restart your shell and Claude Code."
+        ;;
+esac
+
+echo ""
 echo "Done. Restart Claude Code to activate the sdlc-server MCP."

--- a/tests/commutativity_verify.test.ts
+++ b/tests/commutativity_verify.test.ts
@@ -1,6 +1,10 @@
 import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
 
-type Responder = string | (() => string);
+// Responder returns a string (probe stdout) when called. The function form
+// receives the full cmd so tests can REJECT wrong-shape argv loudly per
+// `lesson_origin_ops_pitfalls.md` — substring-only matching gave us false
+// confidence twice this session (glab `--jq`, bare-hex `--color`).
+type Responder = string | ((cmd: string) => string);
 
 let execRegistry: Array<{ match: string; respond: Responder }> = [];
 let execCalls: string[] = [];
@@ -11,7 +15,7 @@ function mockExec(cmd: string, opts?: { timeout?: number; cwd?: string }): strin
   lastExecOpts = opts;
   for (const { match, respond } of execRegistry) {
     if (cmd.includes(match)) {
-      return typeof respond === 'function' ? respond() : respond;
+      return typeof respond === 'function' ? respond(cmd) : respond;
     }
   }
   throw new Error(`Unexpected exec call: ${cmd}`);
@@ -29,6 +33,35 @@ function parseResult(result: { content: Array<{ type: string; text: string }> })
 
 function onExec(match: string, respond: Responder) {
   execRegistry.push({ match, respond });
+}
+
+// Throw a shaped error that mimics execSync on `command not found` via the
+// POSIX shell exit-127 signal ONLY. Message intentionally generic so the
+// regex-arm of probeMissing can NOT also fire — keeps the test isolated to
+// status-detection per the false-confidence pitfall in
+// `lesson_origin_ops_pitfalls.md`. Used by the canonical PROBE_UNAVAILABLE
+// tests because exit-127 is the production path with execSync in shell mode.
+function throwBinaryMissing(): never {
+  const err = new Error('subprocess exited 127') as Error & { status?: number };
+  err.status = 127;
+  throw err;
+}
+
+// Throw a shaped error that mimics shells which don't propagate exit-127
+// cleanly but still print the canonical "command not found" message. The
+// message is the ONLY signal here (no status set) so this exercises the
+// regex-arm of probeMissing in isolation.
+function throwBinaryMissingShellMessage(): never {
+  throw new Error('/bin/sh: 1: commutativity-probe: not found');
+}
+
+// Throw a shaped error that mimics a probe that ran but exited non-zero
+// (a real probe bug). Distinct from binary-missing so we can prove the
+// handler does NOT blanket-convert all subprocess errors to PROBE_UNAVAILABLE.
+function throwProbeCrash(): never {
+  const err = new Error('commutativity-probe analyze: AnalysisError: tree-sitter parse failed') as Error & { status?: number };
+  err.status = 1;
+  throw err;
 }
 
 function probeJson(verdict: string, pairs: Array<{
@@ -207,11 +240,83 @@ describe('commutativity_verify handler', () => {
     expect(data.group_verdict).toBe('ORACLE_REQUIRED');
   });
 
-  // --- subprocess error ---
-  test('subprocess error — returns ok:false with error message', async () => {
-    onExec('commutativity-probe', () => {
-      throw new Error('commutativity-probe: command not found');
+  // --- probe binary missing (ENOENT / shell exit 127) → PROBE_UNAVAILABLE ---
+  test('pairwise mode: ENOENT (binary missing) → PROBE_UNAVAILABLE with mirrored timeout shape', async () => {
+    onExec('commutativity-probe', throwBinaryMissing);
+
+    const result = await handler.execute({
+      repo_path: '/repo',
+      base_ref: 'main',
+      changesets: [
+        { id: 'mr-1', head_ref: 'feature/1' },
+        { id: 'mr-2', head_ref: 'feature/2' },
+      ],
     });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.mode).toBe('pairwise');
+    expect(data.verdict).toBe('PROBE_UNAVAILABLE');
+    expect(data.group_verdict).toBe('PROBE_UNAVAILABLE'); // legacy alias
+    expect(data.pairs).toEqual([]);
+    expect(data.pairwise_results).toEqual([]);
+    expect(data.single_target_result).toBeUndefined();
+    const warnings = data.warnings as string[];
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('not found on PATH');
+    expect(warnings[0]).toContain('install-remote.sh');
+  });
+
+  test('single-target mode: ENOENT (binary missing) → PROBE_UNAVAILABLE with single_target_result populated', async () => {
+    onExec('commutativity-probe', throwBinaryMissing);
+
+    const result = await handler.execute({
+      repo_path: '/repo',
+      base_ref: 'main',
+      changesets: [{ id: 'kahuna', head_ref: 'kahuna/42-foo' }],
+    });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.mode).toBe('single_target');
+    expect(data.verdict).toBe('PROBE_UNAVAILABLE');
+    expect(data.group_verdict).toBe('PROBE_UNAVAILABLE');
+    expect(data.pairs).toEqual([]);
+    expect(data.pairwise_results).toBeUndefined();
+    const single = data.single_target_result as { verdict: string; changeset_id: string; head_ref: string };
+    expect(single.verdict).toBe('PROBE_UNAVAILABLE');
+    expect(single.changeset_id).toBe('kahuna');
+    expect(single.head_ref).toBe('kahuna/42-foo');
+  });
+
+  // --- isolation: shell-message-only path also yields PROBE_UNAVAILABLE ---
+  // Asserts the regex-arm of probeMissing fires independently of status===127.
+  // If only one arm of the OR were left wired, this test would catch it (the
+  // canonical throwBinaryMissing test would NOT — it sets status=127 and a
+  // message that does NOT match the regex on purpose).
+  test('shell-message-only (no status) — regex arm catches PROBE_UNAVAILABLE', async () => {
+    onExec('commutativity-probe', throwBinaryMissingShellMessage);
+
+    const result = await handler.execute({
+      repo_path: '/repo',
+      base_ref: 'main',
+      changesets: [
+        { id: 'mr-1', head_ref: 'feature/1' },
+        { id: 'mr-2', head_ref: 'feature/2' },
+      ],
+    });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.verdict).toBe('PROBE_UNAVAILABLE');
+  });
+
+  // --- regression: probe-crash (non-ENOENT) MUST stay {ok:false} (#218) ---
+  // Spec: only ENOENT becomes PROBE_UNAVAILABLE. Probe ran but exited
+  // non-zero (real probe bug, malformed input, tree-sitter failure, etc.)
+  // → still {ok:false} so we don't swallow real failures.
+  test('probe-crash (non-ENOENT subprocess error) — keeps {ok:false} contract', async () => {
+    onExec('commutativity-probe', throwProbeCrash);
 
     const result = await handler.execute({
       repo_path: '/repo',
@@ -225,6 +330,50 @@ describe('commutativity_verify handler', () => {
 
     expect(data.ok).toBe(false);
     expect(data.error as string).toContain('commutativity-probe failed');
+    expect(data.error as string).toContain('tree-sitter parse failed');
+    // Make sure we didn't synthesize a verdict for a real probe failure.
+    expect(data.verdict).toBeUndefined();
+    expect(data.group_verdict).toBeUndefined();
+  });
+
+  // --- argv-strictness: stub explicitly rejects wrong-shape commands ---
+  // Per `lesson_origin_ops_pitfalls.md`: substring-only matching gave us
+  // false confidence twice this session (glab `--jq`, bare-hex `--color`).
+  // The handler must always invoke the probe with `analyze` + `--json` +
+  // `--repo` + `--base`. If a refactor ever drops one of those flags, this
+  // test fires immediately rather than passing silently.
+  test('argv-strictness: stub rejects probe invocations missing required flags', async () => {
+    onExec('commutativity-probe', (cmd) => {
+      if (!/\bcommutativity-probe\s+analyze\b/.test(cmd)) {
+        throw new Error(`Stub rejection: missing 'analyze' subcommand: ${cmd}`);
+      }
+      if (!cmd.includes('--json')) {
+        throw new Error(`Stub rejection: missing --json flag: ${cmd}`);
+      }
+      // Word-boundary matches so a hypothetical future flag named --repository
+      // or --baseline can't satisfy these checks accidentally.
+      if (!/\s--repo\s/.test(cmd)) {
+        throw new Error(`Stub rejection: missing --repo flag: ${cmd}`);
+      }
+      if (!/\s--base\s/.test(cmd)) {
+        throw new Error(`Stub rejection: missing --base flag: ${cmd}`);
+      }
+      return probeJson('STRONG', [{
+        a: 'feature/1', b: 'feature/2', verdict: 'STRONG', reason: 'Disjoint',
+      }]);
+    });
+
+    const result = await handler.execute({
+      repo_path: '/repo',
+      base_ref: 'main',
+      changesets: [
+        { id: 'mr-1', head_ref: 'feature/1' },
+        { id: 'mr-2', head_ref: 'feature/2' },
+      ],
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(data.verdict).toBe('STRONG');
   });
 
   // --- subprocess timeout ---


### PR DESCRIPTION
## Summary

Bundles `commutativity-probe@v0.1.0` in `install-remote.sh` and adds a `PROBE_UNAVAILABLE` verdict to `commutativity_verify` so a fresh sdlc-server install gets a working probe out of the box, and so callers can distinguish "probe says non-commutative" from "probe is unavailable" (vs. the previous opaque `{ok:false}`). Unblocks cc-workflow#418 KAHUNA wave-2b trust-score gate.

## Changes

**`scripts/install-remote.sh`**
- `pip install --user` the probe, pinned to `v0.1.0` by default; `SDLC_PROBE_REF` env override
- `--skip-probe` flag for CI/minimal installs
- Python 3.11+ check: missing or too old → warn-and-skip (does NOT fail sdlc-server install — handler degrades via `PROBE_UNAVAILABLE`)
- `~/.local/bin` PATH check at install time
- `--help` documents env vars + flags

**`handlers/commutativity_verify.ts`**
- Split verdict union: `PROBE_VERDICTS` (wire-side, what probe emits: `STRONG/MEDIUM/WEAK/ORACLE_REQUIRED`) + `VERDICTS` (full union including envelope-only `PROBE_UNAVAILABLE`)
- ENOENT-only synthesis: shell exit 127 OR canonical "command not found" regex → `PROBE_UNAVAILABLE`. Probe-crash (status≠127) stays `{ok:false}` so real probe bugs surface — explicit anti-blanket-conversion AC
- Factored `buildFailSafeBody` shared between timeout and probe-missing paths so divergence in body shape is structurally impossible
- Tool description documents the contract + conservative-fail dispatch semantics

**`tests/commutativity_verify.test.ts`**
- 5 net additions: pairwise/single-target ENOENT → `PROBE_UNAVAILABLE`, shell-message-only regex isolation, probe-crash regression keeps `{ok:false}`, argv-strictness via stub-side rejection
- Extended `Responder` type to accept full `cmd` so stubs can REJECT wrong-shape argv — pattern from `lesson_origin_ops_pitfalls.md` that would have caught the glab `--jq` + bare-hex `--color` bugs from earlier this session

**`README.md`** — probe dependency, `SDLC_PROBE_REF`, `--skip-probe`, valid JSON example of the `PROBE_UNAVAILABLE` response shape

## Linked Issues

Closes #218

## Test Plan

- [x] `bun test` — 1306/0 pass, 3226 expect() calls
- [x] `./scripts/ci/validate.sh` — 72/72 handlers
- [x] `bash -n install-remote.sh` + `--help` smoke-test
- [x] `trivy fs --scanners vuln --severity HIGH,CRITICAL` — 0 findings
- [x] `feature-dev:code-reviewer` agent — 2 important findings fixed (dead ENOENT branch, test-isolation gap), 2 nits fixed (argv regex, README JSON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)