### PR TITLE
fix(pr_wait_ci): all-skipped checks no longer deadlock decide()

### DIFF
--- a/handlers/pr_wait_ci.ts
+++ b/handlers/pr_wait_ci.ts
@@ -204,7 +204,11 @@ function snapshotChecks(number: number, repo?: string): ChecksSnapshot {
 
 function decide(snap: ChecksSnapshot): FinalState | null {
   if (snap.failed > 0) return 'failed';
-  if (snap.total > 0 && snap.pending === 0 && snap.passed >= 1) return 'passed';
+  // No failures + nothing pending → passed, even when `passed === 0` (every
+  // check skipped). The previous `passed >= 1` guard deadlocked on PRs whose
+  // entire check set was SKIPPED — common for docs-only PRs in repos with
+  // conditional CI. See #221.
+  if (snap.total > 0 && snap.pending === 0 && snap.failed === 0) return 'passed';
   return null;
 }
 

--- a/tests/pr_wait_ci.test.ts
+++ b/tests/pr_wait_ci.test.ts
@@ -126,6 +126,27 @@ describe('pr_wait_ci handler', () => {
     expect(snapshotCalls.length).toBe(2);
   });
 
+  // --- regression for #221: all checks SKIPPED → passed on first poll ---
+  // Previously deadlocked because `decide` required `passed >= 1`. Common
+  // for docs-only PRs in repos with conditional CI: every workflow has an
+  // `if:` guard that doesn't match → all jobs SKIPPED → uncounted in
+  // passed/failed/pending → loop spins to timeout for no reason.
+  test('passed — all checks skipped (passed=0, failed=0, pending=0) → passed on first poll', async () => {
+    const allSkipped = snap({ total: 3, passed: 0, failed: 0, pending: 0, summary: '0/3 (all skipped)' });
+    const { deps, snapshotCalls, sleepCalls } = makeDeps([allSkipped], 5);
+
+    const result = await runWithDeps(
+      { number: 1, poll_interval_sec: 5, timeout_sec: 600 },
+      deps,
+    );
+
+    expect(result.final_state).toBe('passed');
+    expect(result.checks.passed).toBe(0);
+    expect(result.checks.total).toBe(3);
+    expect(snapshotCalls.length).toBe(1); // proves first poll terminated
+    expect(sleepCalls.length).toBe(0);    // no sleep needed
+  });
+
   test('timed_out — loop exits when elapsed > timeout', async () => {
     // Every snapshot stays pending forever.
     const stuck = snap({ total: 2, passed: 0, pending: 2 });


### PR DESCRIPTION
## Summary

`decide` required `passed >= 1` to return `'passed'`, deadlocking when every check classified as `skipping` (e.g. docs-only PR in a repo where every workflow has an `if:` branch-name guard that doesn't match → all jobs SKIPPED → uncounted in passed/failed/pending). The loop spun until `timeout_sec` expired with nothing failing and nothing to wait for.

## Changes

- `handlers/pr_wait_ci.ts:decide` — drop the `passed >= 1` clause. Any snapshot with `total > 0 && pending === 0 && failed === 0` is now `'passed'`. Inline comment cites #221 and names the docs-only-PR-with-conditional-CI failure mode.
- `tests/pr_wait_ci.test.ts` — 1 new regression test driving the all-skipped scenario through `runWithDeps`. Asserts `final_state === 'passed'` on the first poll, `snapshotCalls.length === 1`, `sleepCalls.length === 0`.

Pre-existing bug — the old `bucket === 'skipping'` path also produced uncounted checks the same way. Surfaced by the code-reviewer agent during the #220 review and filed then; fixed now.

## Linked Issues

Closes #221

## Test Plan

- [x] `bun test` — 1325/0 pass (was 1324; +1 regression)
- [x] `tests/pr_wait_ci.test.ts` — 37 → 38 tests
- [x] `./scripts/ci/validate.sh` — 72/72 handlers
- [x] `trivy fs --severity HIGH,CRITICAL` — 0 findings
- [x] `feature-dev:code-reviewer` — no HIGH+ findings; verified GitLab path can't false-positive (`total = passed+failed+pending` invariant), GitHub path's only `total > 0, all-zero` shape is exactly the target scenario, bootstrap `lastSnap` (`total: 0`) still safely returns `null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)