### PR TITLE
fix(wave_previous_merged): filter accepted-deferred issues from open_issues

### DIFF
--- a/handlers/wave_previous_merged.ts
+++ b/handlers/wave_previous_merged.ts
@@ -42,9 +42,47 @@ interface WaveState {
   status?: string;
 }
 
+// One deferral entry from `state.deferrals[]`. Schema is owned by the Python
+// `wave_status` CLI in claudecode-workflow (see `src/wave_status/deferrals.py`):
+//   { wave: <wave_id>, description: <free-form>, risk: low|medium|high, status: pending|accepted }
+// The deferred issue number is conventionally embedded in `description` as a
+// `#N` reference (e.g. "Defer #420 (story title) — reason"). There is no
+// structured `issue_number` field on disk today.
+interface Deferral {
+  wave?: string;
+  description?: string;
+  risk?: string;
+  status?: string;
+}
+
 interface StateData {
   current_wave?: string | null;
   waves?: Record<string, WaveState>;
+  deferrals?: Deferral[];
+}
+
+// Extract the set of issue numbers covered by accepted deferrals against the
+// given wave. The `#N` pattern matches the established convention in
+// cc-workflow's deferrals (canonical fixture: `"Defer #420 (test...): ..."`).
+// The negative lookbehind `(?<!\w)` ensures we only match `#N` at a word
+// boundary — `abc#123` or markdown anchors `[link](#123-section)` will not
+// extract `123`. Multiple `#N` references in one description are all
+// collected; the caller also intersects against the wave's planned issues
+// as a second safety net.
+//
+// Why filter only ACCEPTED (not pending): an accepted deferral is the
+// completion contract for the wave — the team explicitly agreed the issue
+// wouldn't merge in this wave. Pending deferrals are still under discussion
+// and SHOULD continue to count as open. See #223 + lesson_wave_status_commands.md.
+function deferredIssueNumbers(state: StateData, waveId: string): Set<number> {
+  const out = new Set<number>();
+  for (const d of state.deferrals ?? []) {
+    if (d.status !== 'accepted' || d.wave !== waveId) continue;
+    for (const m of (d.description ?? '').matchAll(/(?<!\w)#(\d+)/g)) {
+      out.add(parseInt(m[1], 10));
+    }
+  }
+  return out;
 }
 
 function flatWaveIds(plan: PlanData): string[] {
@@ -201,6 +239,7 @@ const wavePreviousMergedHandler: HandlerDef = {
                 previous_wave_id: null,
                 all_merged: true,
                 open_issues: [],
+                deferred_issues: [],
               }),
             },
           ],
@@ -238,8 +277,17 @@ const wavePreviousMergedHandler: HandlerDef = {
         };
       }
       const openIssues: number[] = [];
+      const deferredIssues = deferredIssueNumbers(state, prevId);
+      const deferredFiltered: number[] = [];
 
       for (const issue of prevWave.issues ?? []) {
+        // Accepted-deferred issues are part of the wave's completion contract
+        // — skip them entirely (no closure check, not added to open_issues).
+        // See #223.
+        if (deferredIssues.has(issue.number)) {
+          deferredFiltered.push(issue.number);
+          continue;
+        }
         try {
           const info =
             platform === 'github'
@@ -262,6 +310,10 @@ const wavePreviousMergedHandler: HandlerDef = {
               previous_wave_id: prevId,
               all_merged: openIssues.length === 0,
               open_issues: openIssues,
+              // Issues filtered out of the closure check because they're
+              // covered by an accepted deferral against this wave (#223).
+              // Surfaced so callers can see the wave-completion contract.
+              deferred_issues: deferredFiltered,
             }),
           },
         ],

--- a/tests/wave_previous_merged.test.ts
+++ b/tests/wave_previous_merged.test.ts
@@ -257,6 +257,278 @@ describe('wave_previous_merged handler', () => {
     expect(parsed.previous_wave_id).toBe(null);
     expect(parsed.all_merged).toBe(true);
     expect(parsed.open_issues).toEqual([]);
+    // #223 contract: deferred_issues present in the early-return shape too,
+    // so callers can rely on the field being there regardless of which path
+    // produced the response.
+    expect(parsed.deferred_issues).toEqual([]);
+  });
+
+  // Regression guard for the regex word-boundary fix surfaced in code review:
+  // `#N` should only match at a word boundary so a stray `abc#123` in a
+  // description doesn't accidentally extract 123.
+  test('regex_word_boundary — embedded "abc#420" does NOT extract 420', async () => {
+    const plan = {
+      phases: [
+        {
+          waves: [
+            { id: 'w1', issues: [{ number: 420 }] },
+            { id: 'w2', issues: [] },
+          ],
+        },
+      ],
+    };
+    const state = {
+      current_wave: 'w2',
+      waves: { w1: { status: 'completed' }, w2: { status: 'in_progress' } },
+      deferrals: [
+        {
+          wave: 'w1',
+          // No leading `Defer #420` — the only `#420` here is embedded in
+          // the alphanumeric token `abc#420`, which the word-boundary guard
+          // must exclude. Without the guard, this would falsely filter #420.
+          description: 'Some context: abc#420 ref in unrelated text',
+          risk: 'low',
+          status: 'accepted',
+        },
+      ],
+    };
+    await setupFixture(plan, state);
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      return ghClosureResponse({ state: 'OPEN' });
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.all_merged).toBe(false);
+    expect(parsed.open_issues).toEqual([420]); // #420 NOT extracted, still counts
+    expect(parsed.deferred_issues).toEqual([]);
+  });
+
+  // ----- accepted-deferral filtering (#223) -----
+  // Canonical fixture: cc-workflow's deferrals look like
+  //   { wave: "wave-3a", description: "Defer #420 (...)", risk: "low", status: "accepted" }
+  // The deferred issue number is embedded as `#N` in the free-form description
+  // (the Python writer in claudecode-workflow has no structured issue field).
+  // wave_previous_merged should skip those issues when computing all_merged.
+
+  test('accepted_deferral — issue filtered from open_issues, all_merged stays true', async () => {
+    const plan = {
+      phases: [
+        {
+          waves: [
+            { id: 'w1', issues: [{ number: 100 }, { number: 420 }] },
+            { id: 'w2', issues: [] },
+          ],
+        },
+      ],
+    };
+    const state = {
+      current_wave: 'w2',
+      waves: { w1: { status: 'completed' }, w2: { status: 'in_progress' } },
+      deferrals: [
+        {
+          wave: 'w1',
+          description: 'Defer #420 (story title) — blocked on external dep',
+          risk: 'low',
+          status: 'accepted',
+        },
+      ],
+    };
+    await setupFixture(plan, state);
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      if (cmd.includes('num=420')) {
+        throw new Error('Stub rejection: gh should NOT be called for accepted-deferred issue #420');
+      }
+      // Issue 100 closes cleanly via merged PR.
+      return ghClosureResponse({ state: 'CLOSED', mergedPRs: [true] });
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.all_merged).toBe(true);
+    expect(parsed.open_issues).toEqual([]);
+    expect(parsed.deferred_issues).toEqual([420]);
+  });
+
+  test('pending_deferral — issue NOT filtered (only accepted is the contract)', async () => {
+    const plan = {
+      phases: [
+        {
+          waves: [
+            { id: 'w1', issues: [{ number: 420 }] },
+            { id: 'w2', issues: [] },
+          ],
+        },
+      ],
+    };
+    const state = {
+      current_wave: 'w2',
+      waves: { w1: { status: 'completed' }, w2: { status: 'in_progress' } },
+      deferrals: [
+        {
+          wave: 'w1',
+          description: 'Defer #420 — under discussion',
+          risk: 'low',
+          status: 'pending', // not yet accepted
+        },
+      ],
+    };
+    await setupFixture(plan, state);
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      return ghClosureResponse({ state: 'OPEN' }); // still open
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.all_merged).toBe(false);
+    expect(parsed.open_issues).toEqual([420]); // pending deferrals don't filter
+    expect(parsed.deferred_issues).toEqual([]);
+  });
+
+  test('wrong_wave_deferral — issue NOT filtered when deferral is for a different wave', async () => {
+    const plan = {
+      phases: [
+        {
+          waves: [
+            { id: 'w1', issues: [{ number: 420 }] },
+            { id: 'w2', issues: [] },
+          ],
+        },
+      ],
+    };
+    const state = {
+      current_wave: 'w2',
+      waves: { w1: { status: 'completed' }, w2: { status: 'in_progress' } },
+      deferrals: [
+        {
+          // Accepted, mentions #420, but for a DIFFERENT wave.
+          wave: 'wave-99',
+          description: 'Defer #420 — was accepted in another wave context',
+          risk: 'low',
+          status: 'accepted',
+        },
+      ],
+    };
+    await setupFixture(plan, state);
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      return ghClosureResponse({ state: 'OPEN' });
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.all_merged).toBe(false);
+    expect(parsed.open_issues).toEqual([420]);
+    expect(parsed.deferred_issues).toEqual([]);
+  });
+
+  test('multi_N_in_description — all referenced wave-issues filtered', async () => {
+    const plan = {
+      phases: [
+        {
+          waves: [
+            { id: 'w1', issues: [{ number: 420 }, { number: 421 }, { number: 100 }] },
+            { id: 'w2', issues: [] },
+          ],
+        },
+      ],
+    };
+    const state = {
+      current_wave: 'w2',
+      waves: { w1: { status: 'completed' }, w2: { status: 'in_progress' } },
+      deferrals: [
+        {
+          wave: 'w1',
+          // Single deferral mentioning two issue numbers (rare but possible).
+          description: 'Defer #420 and #421 — same root cause, blocked together',
+          risk: 'medium',
+          status: 'accepted',
+        },
+      ],
+    };
+    await setupFixture(plan, state);
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      if (cmd.includes('num=420') || cmd.includes('num=421')) {
+        throw new Error('Stub rejection: deferred issues should not be queried');
+      }
+      return ghClosureResponse({ state: 'CLOSED', mergedPRs: [true] });
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.all_merged).toBe(true);
+    expect(parsed.open_issues).toEqual([]);
+    expect(parsed.deferred_issues.sort()).toEqual([420, 421]);
+  });
+
+  test('no_N_in_description — no filtering happens (description without #N is harmless)', async () => {
+    const plan = {
+      phases: [
+        {
+          waves: [
+            { id: 'w1', issues: [{ number: 420 }] },
+            { id: 'w2', issues: [] },
+          ],
+        },
+      ],
+    };
+    const state = {
+      current_wave: 'w2',
+      waves: { w1: { status: 'completed' }, w2: { status: 'in_progress' } },
+      deferrals: [
+        {
+          wave: 'w1',
+          description: 'general scope deferral, no specific issue mentioned',
+          risk: 'low',
+          status: 'accepted',
+        },
+      ],
+    };
+    await setupFixture(plan, state);
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      return ghClosureResponse({ state: 'OPEN' });
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.all_merged).toBe(false);
+    expect(parsed.open_issues).toEqual([420]);
+    expect(parsed.deferred_issues).toEqual([]);
+  });
+
+  test('mixed — some open, some closed, some deferred', async () => {
+    const plan = {
+      phases: [
+        {
+          waves: [
+            { id: 'w1', issues: [{ number: 1 }, { number: 2 }, { number: 420 }] },
+            { id: 'w2', issues: [] },
+          ],
+        },
+      ],
+    };
+    const state = {
+      current_wave: 'w2',
+      waves: { w1: { status: 'completed' }, w2: { status: 'in_progress' } },
+      deferrals: [
+        { wave: 'w1', description: 'Defer #420 (...)', risk: 'low', status: 'accepted' },
+      ],
+    };
+    await setupFixture(plan, state);
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
+      if (cmd.includes('num=420')) {
+        throw new Error('Stub rejection: deferred #420 should not be queried');
+      }
+      if (cmd.includes('num=1')) return ghClosureResponse({ state: 'CLOSED', mergedPRs: [true] });
+      if (cmd.includes('num=2')) return ghClosureResponse({ state: 'OPEN' });
+      return ghClosureResponse({ state: 'OPEN' });
+    };
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.all_merged).toBe(false);
+    expect(parsed.open_issues).toEqual([2]); // only the genuinely open issue
+    expect(parsed.deferred_issues).toEqual([420]);
   });
 
   test('handles_missing_state_files — returns structured error', async () => {


### PR DESCRIPTION
## Summary

`wave_previous_merged()` returned `all_merged: false` when the previous wave had accepted deferrals, listing the deferred issue numbers in `open_issues`. Accepted-deferral issues are part of the wave's completion contract — the team explicitly agreed they wouldn't merge in that wave — so they shouldn't block the all_merged check. Pending deferrals still count as open (under discussion, not agreed).

Repro from the issue: `{"ok":true,"previous_wave_id":"wave-3a","all_merged":false,"open_issues":[420]}` where #420 was deferred-and-accepted before wave-3a was marked complete. Now: `{"all_merged":true,"open_issues":[],"deferred_issues":[420]}`.

## Changes

- `handlers/wave_previous_merged.ts` — new `Deferral` interface mirroring the cc-workflow Python shape (`{ wave, description, risk, status }`); `StateData` extended with `deferrals?: Deferral[]`; new `deferredIssueNumbers(state, waveId)` helper extracts `#N` from accepted-deferral descriptions with word-boundary guard `(?<!\w)#(\d+)/g`; closure-check loop skips deferred issues entirely; response gains `deferred_issues: number[]` listing what was filtered (in both success + early-return paths).
- `tests/wave_previous_merged.test.ts` — 7 new tests: accepted-deferral filtered, pending-deferral NOT filtered, wrong-wave NOT filtered, multi-`#N` in description, no-`#N` description, mixed open+closed+deferred, regex word-boundary regression. Existing 10 tests unchanged. Updated `no_previous_wave` to assert `deferred_issues: []` in the early-return shape.

The deferred-issue-number filter has two safety nets: the word-boundary regex (eliminates `abc#123` false matches) and the wave-plan intersection (only numbers in `prevWave.issues` are actually filtered, so a stray ref is harmlessly ignored).

## Linked Issues

Closes #223

Schema reference: `claudecode-workflow/src/wave_status/deferrals.py` is the canonical writer.

## Test Plan

- [x] `bun test` — 1332/0 pass (was 1325; +7)
- [x] `tests/wave_previous_merged.test.ts` — 17 tests (was 10)
- [x] `./scripts/ci/validate.sh` — 72/72 handlers
- [x] `trivy fs --severity HIGH,CRITICAL` — 0 findings
- [x] `feature-dev:code-reviewer` — 2 important fixed (regex word-boundary tightened, `no_previous_wave` `deferred_issues:[]` coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)