### PR TITLE
feat(pr_merge): aggregate response + new pr_merge_wait tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,39 @@ To install or upgrade the probe manually:
 pip install --user 'git+https://github.com/Wave-Engineering/commutativity-probe.git@v0.1.0'
 ```
 
+## Merge tools: `pr_merge` vs `pr_merge_wait`
+
+Two tools, deliberately split by what the caller cares about:
+
+| Tool | Returns | Use when |
+|---|---|---|
+| `pr_merge` | Eager — `enrolled:true` always; `merged` reflects the moment-of-call truth (`true` for direct merge, `false` for queue path until the queue lands). | You need the platform to accept the merge, then keep working. Don't care exactly when the commit lands. |
+| `pr_merge_wait` | Blocking — guarantees `merged:true, pr_state:"MERGED"` on success, or a timeout error. | You need the commit observable on `main` before the next step (e.g. `git pull`, post-merge CI, downstream wave work). |
+
+Both return the same aggregate envelope:
+
+```json
+{
+  "ok": true,
+  "number": 42,
+  "enrolled": true,
+  "merged": false,
+  "merge_method": "merge_queue",
+  "queue": { "enabled": true, "position": null, "enforced": true },
+  "pr_state": "OPEN",
+  "url": "https://github.com/org/repo/pull/42",
+  "warnings": []
+}
+```
+
+### `skip_train` and merge-queue-enforced repos
+
+When a repo enforces a merge queue via ruleset, GitHub ignores `skip_train`. Both tools detect this upfront and silently drop the flag, surfacing a `warnings[]` entry rather than erroring. On non-enforced repos `skip_train:true` honors the flag (direct merge, no queue fallback) — useful when `commutativity_verify` has proven the merge safe.
+
+### Migrating callers
+
+Pre-`v1.7.0` callers expected `pr_merge` to return `merged:true` after enrolling in the queue (eager-but-misleading). The new aggregate response always reflects the truth: `merged:false` until the commit is on main. Callers that need the old "wait for it" behavior should switch to `pr_merge_wait`.
+
 ## Tool Reference
 
 See [docs/tool-reference.md](docs/tool-reference.md) _(coming soon)_.

--- a/handlers/pr_merge.ts
+++ b/handlers/pr_merge.ts
@@ -6,7 +6,9 @@ import { execSync } from 'child_process';
 import { writeFileSync } from 'fs';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform, gitlabApiMr } from '../lib/glab.js';
+import { detectPlatform, parseRepoSlug } from '../lib/glab.js';
+import { detectMergeQueue, type MergeQueueInfo } from '../lib/merge_queue_detect.js';
+import { fetchGithubPrState, fetchGitlabMrState } from '../lib/pr_state.js';
 
 // Codebase convention: child_process.execSync (29/36 handlers). Tests mock it
 // via `mock.module('child_process', ...)` — see tests/pr_merge.test.ts.
@@ -28,6 +30,33 @@ const inputSchema = z.object({
 });
 
 type Input = z.infer<typeof inputSchema>;
+type Platform = 'github' | 'gitlab';
+type MergeMethod = 'direct_squash' | 'merge_queue';
+type PrStateLabel = 'OPEN' | 'MERGED';
+
+interface QueueState {
+  enabled: boolean;
+  position: number | null;
+  enforced: boolean;
+}
+
+interface AggregateResponse {
+  ok: true;
+  number: number;
+  enrolled: boolean;
+  merged: boolean;
+  merge_method: MergeMethod;
+  queue: QueueState;
+  pr_state: PrStateLabel;
+  url: string;
+  merge_commit_sha?: string;
+  warnings: string[];
+}
+
+interface FailureResponse {
+  ok: false;
+  error: string;
+}
 
 interface ExecError extends Error {
   stdout?: Buffer | string;
@@ -47,33 +76,23 @@ function bufToString(b: unknown): string {
   return String(b);
 }
 
-/**
- * Extract a failure message + stderr from a thrown exec error. Both real
- * `execSync` errors (Buffer stderr) and test mocks (plain Error) are handled.
- */
 function extractFailure(err: unknown): FailureInfo {
   if (err instanceof Error) {
     const e = err as ExecError;
     const stderr = bufToString(e.stderr);
     const stdout = bufToString(e.stdout);
     const message = stderr.trim() || stdout.trim() || err.message;
-    // When tests mock by throwing new Error('...merge queue...'), stderr is
-    // empty but the merge-queue phrase lives in err.message. Fall back to
-    // err.message so the merge-queue detector can see it.
     return { message, stderr: stderr || err.message };
   }
   const text = String(err);
   return { message: text, stderr: text };
 }
 
-/**
- * Heuristic for detecting GitHub merge-queue enforcement. Phrasings seen in
- * the wild include:
- *   - "merge strategy for main is set by the merge queue"
- *   - "the merge queue is required"
- *   - "changes must be made through a merge queue"
- * We match case-insensitively on "merge queue" to tolerate phrasing drift.
- */
+// Heuristic for detecting GitHub merge-queue enforcement from stderr. Phrasings
+// seen in the wild: "merge strategy for main is set by the merge queue", "the
+// merge queue is required", "changes must be made through a merge queue". Match
+// case-insensitive on "merge queue" to tolerate phrasing drift. Used as a
+// safety net when up-front GraphQL detection returns a false-negative.
 function stderrIndicatesMergeQueue(text: string): boolean {
   return /merge\s*queue/i.test(text);
 }
@@ -82,27 +101,14 @@ function exec(cmd: string): string {
   return execSync(cmd, { encoding: 'utf8' });
 }
 
-/**
- * Escape a value for safe inclusion inside a single-quoted shell argument.
- * Used only for single-line squash messages; multi-line messages go via file.
- */
 function shellEscape(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 function writeTempMessageFile(message: string): string {
-  // /tmp is cleaned by the OS; we intentionally do not delete the file to avoid
-  // complicating the fs-module surface already mocked by tests (writeFileSync only).
   const path = `/tmp/pr-merge-msg-${Date.now()}-${Math.floor(Math.random() * 1e6)}.txt`;
   writeFileSync(path, message);
   return path;
-}
-
-function parseSlugOpts(slug: string | undefined): { owner?: string; repo?: string } | undefined {
-  if (slug === undefined) return undefined;
-  const idx = slug.indexOf('/');
-  if (idx <= 0 || idx === slug.length - 1) return undefined;
-  return { owner: slug.slice(0, idx), repo: slug.slice(idx + 1) };
 }
 
 function buildGithubMergeCommand(
@@ -115,7 +121,6 @@ function buildGithubMergeCommand(
   if (auto) parts.push('--auto');
   if (squashMessage !== undefined && squashMessage.length > 0) {
     if (squashMessage.includes('\n')) {
-      // Multi-line body: write to a temp file and pass via --body-file.
       const tempFile = writeTempMessageFile(squashMessage);
       parts.push('--body-file', shellEscape(tempFile));
     } else {
@@ -143,116 +148,159 @@ function buildGitlabMergeCommand(
     '--yes',
   ];
   if (squashMessage !== undefined && squashMessage.length > 0) {
-    // glab exposes --squash-message (inline only). Single-quoted args
-    // preserve newlines in POSIX shells.
     parts.push('--squash-message', shellEscape(squashMessage));
   }
-  if (repo !== undefined) {
-    parts.push('-R', repo);
-  }
-  return parts.join(' ');
+  return repo !== undefined ? `${parts.join(' ')} -R ${repo}` : parts.join(' ');
 }
 
-interface GithubPrViewResponse {
-  mergeCommit?: { oid?: string } | null;
-  url?: string;
+// Resolve the repo slug for queue detection. Prefer the explicit input; fall
+// back to the cwd remote; null if neither yields a usable slug. When null,
+// queue detection is skipped (treated as no queue) and the legacy stderr
+// fallback remains the only path into the queue.
+function resolveRepoSlug(args: Input): string | null {
+  if (args.repo !== undefined) return args.repo;
+  return parseRepoSlug();
 }
 
-function repoFlag(repo: string | undefined): string {
-  return repo !== undefined ? ` --repo ${repo}` : '';
+function emptyQueue(): QueueState {
+  return { enabled: false, position: null, enforced: false };
 }
 
-function fetchGithubPrMergeInfo(
-  number: number,
-  repo?: string,
-): { url: string; merge_commit_sha?: string } {
-  const raw = exec(`gh pr view ${number} --json mergeCommit,url${repoFlag(repo)}`);
-  const parsed = JSON.parse(raw) as GithubPrViewResponse;
+function queueFromInfo(info: MergeQueueInfo): QueueState {
   return {
-    url: parsed.url ?? '',
-    merge_commit_sha: parsed.mergeCommit?.oid,
+    enabled: info.enabled,
+    enforced: info.enforced,
+    // queue.position is reserved for future enrichment via the mergeQueue.entries
+    // GraphQL field. Today we leave it null (a documented valid value per #225)
+    // because the position is racy and would require a follow-up query for every
+    // merge; the cost isn't justified by current callers.
+    position: null,
   };
 }
 
-function fetchGithubPrUrl(number: number, repo?: string): string {
-  const raw = exec(`gh pr view ${number} --json url${repoFlag(repo)}`);
-  const parsed = JSON.parse(raw) as { url?: string };
-  return parsed.url ?? '';
-}
-
-function fetchGitlabMrMergeInfo(
-  number: number,
-  repo?: string,
-): { url: string; merge_commit_sha?: string } {
-  const mr = gitlabApiMr(number, parseSlugOpts(repo));
-  return {
-    url: mr.web_url ?? '',
-    merge_commit_sha: mr.merge_commit_sha ?? undefined,
-  };
-}
-
-interface MergeSuccess {
-  ok: true;
+function aggregateOk(args: {
   number: number;
+  enrolled: boolean;
   merged: boolean;
-  merge_method: 'direct_squash' | 'merge_queue';
+  method: MergeMethod;
+  queue: QueueState;
   url: string;
-  merge_commit_sha?: string;
-  queue_position?: number;
+  mergeCommitSha?: string;
+  warnings: string[];
+}): AggregateResponse {
+  return {
+    ok: true,
+    number: args.number,
+    enrolled: args.enrolled,
+    merged: args.merged,
+    merge_method: args.method,
+    queue: args.queue,
+    pr_state: args.merged ? 'MERGED' : 'OPEN',
+    url: args.url,
+    merge_commit_sha: args.mergeCommitSha,
+    warnings: args.warnings,
+  };
 }
 
-interface MergeFailure {
-  ok: false;
-  error: string;
-}
-
-function mergeGithub(args: Input): MergeSuccess | MergeFailure {
-  // Forced merge-queue path.
+// Decide the merge intent given user input + detected queue state. Returns
+// the effective method and any warnings to surface. Pre-detection of an
+// enforced queue lets us skip the legacy "try-direct-then-fallback-on-stderr"
+// dance — saving a guaranteed-to-fail exec — while folding in #224's
+// skip_train graceful-degrade behavior.
+function decideIntent(
+  args: Input,
+  mq: MergeQueueInfo,
+): { useQueue: boolean; warnings: string[] } {
+  const warnings: string[] = [];
   if (args.use_merge_queue === true) {
-    const cmd = buildGithubMergeCommand(args.number, true, args.squash_message, args.repo);
-    try {
-      exec(cmd);
-    } catch (err) {
-      const fail = extractFailure(err);
-      return {
-        ok: false,
-        error: `gh pr merge --auto failed: ${fail.message}`,
-      };
+    if (args.skip_train === true) {
+      // The two flags are mutually contradictory. use_merge_queue is the
+      // explicit caller intent, so it wins, but skip_train must not be
+      // silently dropped per the #224/#225 contract.
+      warnings.push(
+        'skip_train ignored — use_merge_queue:true takes precedence; merge proceeded via merge_queue strategy',
+      );
     }
-    const url = fetchGithubPrUrl(args.number, args.repo);
+    return { useQueue: true, warnings };
+  }
+  if (mq.enforced && args.skip_train === true) {
+    warnings.push(
+      'skip_train ignored — merge queue enforced; merge proceeded via merge_queue strategy',
+    );
+    return { useQueue: true, warnings };
+  }
+  if (mq.enforced) {
+    return { useQueue: true, warnings };
+  }
+  return { useQueue: false, warnings };
+}
+
+function mergeGithubViaQueue(
+  args: Input,
+  queue: QueueState,
+  warnings: string[],
+): AggregateResponse | FailureResponse {
+  const cmd = buildGithubMergeCommand(args.number, true, args.squash_message, args.repo);
+  try {
+    exec(cmd);
+  } catch (err) {
     return {
-      ok: true,
-      number: args.number,
-      merged: true,
-      merge_method: 'merge_queue',
-      url,
+      ok: false,
+      error: `gh pr merge --auto failed: ${extractFailure(err).message}`,
     };
   }
+  // Queue enrollment is eager: gh returns immediately, the PR remains OPEN
+  // until the queue rebases + reruns CI + lands. Honest reporting per #225:
+  // enrolled but not yet merged.
+  const info = fetchGithubPrState(args.number, args.repo);
+  return aggregateOk({
+    number: args.number,
+    enrolled: true,
+    merged: info.state === 'merged',
+    method: 'merge_queue',
+    queue,
+    url: info.url,
+    mergeCommitSha: info.mergeCommitSha,
+    warnings,
+  });
+}
 
-  // Direct-squash merge (no merge-queue enrollment).
-  const directCmd = buildGithubMergeCommand(args.number, false, args.squash_message, args.repo);
+function mergeGithubDirect(
+  args: Input,
+  queue: QueueState,
+  warnings: string[],
+): AggregateResponse | FailureResponse {
+  const directCmd = buildGithubMergeCommand(
+    args.number,
+    false,
+    args.squash_message,
+    args.repo,
+  );
   try {
     exec(directCmd);
-    const info = fetchGithubPrMergeInfo(args.number, args.repo);
-    return {
-      ok: true,
+    const info = fetchGithubPrState(args.number, args.repo);
+    return aggregateOk({
       number: args.number,
+      enrolled: true,
       merged: true,
-      merge_method: 'direct_squash',
+      method: 'direct_squash',
+      queue,
       url: info.url,
-      merge_commit_sha: info.merge_commit_sha,
-    };
+      mergeCommitSha: info.mergeCommitSha,
+      warnings,
+    });
   } catch (err) {
     const fail = extractFailure(err);
-    // When skip_train is set, commutativity analysis has proven the merge is safe.
-    // Do not fall back to the merge queue — surface the error directly.
     if (args.skip_train === true) {
       return {
         ok: false,
         error: `gh pr merge failed (skip_train): ${fail.message}`,
       };
     }
-    if (!stderrIndicatesMergeQueue(fail.stderr) && !stderrIndicatesMergeQueue(fail.message)) {
+    if (
+      !stderrIndicatesMergeQueue(fail.stderr) &&
+      !stderrIndicatesMergeQueue(fail.message)
+    ) {
       return {
         ok: false,
         error: `gh pr merge failed: ${fail.message}`,
@@ -260,29 +308,45 @@ function mergeGithub(args: Input): MergeSuccess | MergeFailure {
     }
   }
 
-  // Merge-queue fallback (only reached when skip_train is not set).
+  // Stderr-fallback path: detection thought no queue, but the API rejected
+  // the direct merge with a queue-related error. Promote the queue state so
+  // the response reflects what we just learned.
+  const fallbackQueue: QueueState = { enabled: true, position: null, enforced: true };
   const autoCmd = buildGithubMergeCommand(args.number, true, args.squash_message, args.repo);
   try {
     exec(autoCmd);
   } catch (err) {
-    const fail = extractFailure(err);
     return {
       ok: false,
-      error: `gh pr merge --auto failed after merge-queue fallback: ${fail.message}`,
+      error: `gh pr merge --auto failed after merge-queue fallback: ${extractFailure(err).message}`,
     };
   }
-  const url = fetchGithubPrUrl(args.number, args.repo);
-  return {
-    ok: true,
+  const info = fetchGithubPrState(args.number, args.repo);
+  return aggregateOk({
     number: args.number,
-    merged: true,
-    merge_method: 'merge_queue',
-    url,
-  };
+    enrolled: true,
+    merged: info.state === 'merged',
+    method: 'merge_queue',
+    queue: fallbackQueue,
+    url: info.url,
+    mergeCommitSha: info.mergeCommitSha,
+    warnings,
+  });
 }
 
-function mergeGitlab(args: Input): MergeSuccess | MergeFailure {
-  // GitLab has no merge-queue concept; always direct.
+function mergeGithub(args: Input): AggregateResponse | FailureResponse {
+  const slug = resolveRepoSlug(args);
+  const mqInfo = slug !== null ? detectMergeQueue(slug) : { enabled: false, enforced: false };
+  const queue = queueFromInfo(mqInfo);
+  const intent = decideIntent(args, mqInfo);
+
+  return intent.useQueue
+    ? mergeGithubViaQueue(args, queue, intent.warnings)
+    : mergeGithubDirect(args, queue, intent.warnings);
+}
+
+function mergeGitlab(args: Input): AggregateResponse | FailureResponse {
+  // GitLab has no merge-queue concept; queue stays empty.
   const cmd = buildGitlabMergeCommand(args.number, args.squash_message, args.repo);
   try {
     exec(cmd);
@@ -292,23 +356,36 @@ function mergeGitlab(args: Input): MergeSuccess | MergeFailure {
       error: `glab mr merge failed: ${extractFailure(err).message}`,
     };
   }
-  const info = fetchGitlabMrMergeInfo(args.number, args.repo);
-  return {
-    ok: true,
+  const info = fetchGitlabMrState(args.number, args.repo);
+  return aggregateOk({
     number: args.number,
-    merged: true,
-    merge_method: 'direct_squash',
+    enrolled: true,
+    merged: info.state === 'merged',
+    method: 'direct_squash',
+    queue: emptyQueue(),
     url: info.url,
-    merge_commit_sha: info.merge_commit_sha,
-  };
+    mergeCommitSha: info.mergeCommitSha,
+    warnings: [],
+  });
+}
+
+export function performMerge(
+  platform: Platform,
+  args: Input,
+): AggregateResponse | FailureResponse {
+  return platform === 'github' ? mergeGithub(args) : mergeGitlab(args);
 }
 
 const prMergeHandler: HandlerDef = {
   name: 'pr_merge',
   description:
-    'Merge a PR/MR with squash + delete source branch. Auto-detects merge-queue enforcement on GitHub and falls back to --auto mode. ' +
-    'Set skip_train=true to bypass merge queue enrollment when commutativity analysis (commutativity_verify) has proven the merge is safe. ' +
-    'Supports custom multi-line squash messages.',
+    'Merge a PR/MR with squash + delete source branch. Returns the AGGREGATE state — ' +
+    '{enrolled, merged, merge_method, queue:{enabled,position,enforced}, pr_state, warnings} — ' +
+    'so the caller decides what "merged" means for their use case. On a merge-queue-enforced repo ' +
+    'the response is eager: enrolled=true, merged=false, pr_state="OPEN" (the PR is queued, not yet ' +
+    'on main). For "block until commit lands on main", use pr_merge_wait. ' +
+    'skip_train=true bypasses the queue when commutativity_verify has proven the merge safe, except ' +
+    'on queue-enforced repos where the flag is silently dropped (warning emitted).',
   inputSchema,
   async execute(rawArgs: unknown) {
     let args: Input;
@@ -323,7 +400,7 @@ const prMergeHandler: HandlerDef = {
 
     try {
       const platform = detectPlatform();
-      const result = platform === 'github' ? mergeGithub(args) : mergeGitlab(args);
+      const result = performMerge(platform, args);
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(result) }],
       };

--- a/handlers/pr_merge_wait.ts
+++ b/handlers/pr_merge_wait.ts
@@ -1,0 +1,272 @@
+// Origin Operations family handler.
+// See docs/handlers/origin-operations-guide.md for the canonical pattern.
+//
+// pr_merge_wait wraps pr_merge with a "block until commit lands on main" guarantee.
+// Use this when downstream work (`git pull main`, post-merge CI checks) needs the
+// merge to be observable. For "I just need to enroll the PR; I'll keep working,"
+// stick with pr_merge.
+
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+import { detectPlatform, parseRepoSlug } from '../lib/glab.js';
+import { fetchPrState, type PrStateInfo } from '../lib/pr_state.js';
+import { performMerge } from './pr_merge.js';
+
+const inputSchema = z.object({
+  number: z.number().int().positive('number must be a positive integer'),
+  squash_message: z.string().optional(),
+  use_merge_queue: z.boolean().optional(),
+  skip_train: z.boolean().optional(),
+  repo: z
+    .string()
+    .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/, 'repo must be owner/repo format')
+    .optional(),
+  timeout_sec: z
+    .number()
+    .int()
+    .positive('timeout_sec must be a positive integer')
+    .optional(),
+});
+
+type Input = z.infer<typeof inputSchema>;
+type Platform = 'github' | 'gitlab';
+
+const DEFAULT_TIMEOUT_SEC = 600;
+const POLL_INTERVAL_MS = 10_000;
+
+// Detect-and-skip synthesizes this aggregate when the PR is already MERGED
+// before invocation. We don't know how it was merged historically (direct vs
+// queue, this session vs earlier), so report the conservative defaults and
+// surface the situation via a warning.
+function synthesizeAlreadyMerged(num: number, info: PrStateInfo) {
+  return {
+    ok: true as const,
+    number: num,
+    enrolled: true,
+    merged: true,
+    merge_method: 'direct_squash' as const,
+    queue: { enabled: false, position: null, enforced: false },
+    pr_state: 'MERGED' as const,
+    url: info.url,
+    merge_commit_sha: info.mergeCommitSha,
+    warnings: ['PR was already merged before invocation; pr_merge was not called'],
+  };
+}
+
+export interface PollDeps {
+  fetchState: () => PrStateInfo;
+  intervalMs: number;
+  timeoutMs: number;
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+}
+
+export interface PollSuccess {
+  ok: true;
+  state: PrStateInfo;
+  elapsedMs: number;
+}
+
+export interface PollTimeout {
+  ok: false;
+  reason: 'timeout';
+  lastState: PrStateInfo;
+  elapsedMs: number;
+}
+
+export interface PollFetchError {
+  ok: false;
+  reason: 'fetch_error';
+  error: string;
+  lastState: PrStateInfo | null;
+  elapsedMs: number;
+}
+
+// Pure poller — no module-level globals, no platform knowledge. Loops:
+// fetch → return on merged → check timeout → sleep. The sleep happens AFTER
+// the timeout check, so if the budget is already spent we don't waste another
+// interval before reporting it. Injectable now/sleep makes tests instant.
+//
+// fetchState exceptions are caught and reported as a `fetch_error` variant so
+// the caller can preserve the "PR was already enrolled" context — distinct
+// from a clean timeout. Without this distinction, a transient `gh` failure
+// mid-poll would surface as a generic outer-catch error and the caller would
+// have no idea whether the merge itself failed or just the polling did.
+export async function pollUntilMerged(
+  deps: PollDeps,
+): Promise<PollSuccess | PollTimeout | PollFetchError> {
+  const start = deps.now();
+  let lastState: PrStateInfo | null = null;
+  while (true) {
+    let info: PrStateInfo;
+    try {
+      info = deps.fetchState();
+    } catch (err) {
+      return {
+        ok: false,
+        reason: 'fetch_error',
+        error: err instanceof Error ? err.message : String(err),
+        lastState,
+        elapsedMs: deps.now() - start,
+      };
+    }
+    lastState = info;
+    const elapsedMs = deps.now() - start;
+    if (info.state === 'merged') {
+      return { ok: true, state: info, elapsedMs };
+    }
+    if (elapsedMs >= deps.timeoutMs) {
+      return { ok: false, reason: 'timeout', lastState: info, elapsedMs };
+    }
+    await deps.sleep(deps.intervalMs);
+  }
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+interface MergeAggregate {
+  ok: true;
+  number: number;
+  enrolled: boolean;
+  merged: boolean;
+  merge_method: 'direct_squash' | 'merge_queue';
+  queue: { enabled: boolean; position: number | null; enforced: boolean };
+  pr_state: 'OPEN' | 'MERGED';
+  url: string;
+  merge_commit_sha?: string;
+  warnings: string[];
+}
+
+interface MergeFailure {
+  ok: false;
+  error: string;
+}
+
+function isFailure(r: MergeAggregate | MergeFailure): r is MergeFailure {
+  return r.ok === false;
+}
+
+async function executeWait(
+  args: Input,
+  platform: Platform,
+  pollOverrides?: Partial<Pick<PollDeps, 'now' | 'sleep' | 'intervalMs'>>,
+): Promise<MergeAggregate | MergeFailure> {
+  const slug = args.repo ?? parseRepoSlug() ?? undefined;
+  const timeoutMs = (args.timeout_sec ?? DEFAULT_TIMEOUT_SEC) * 1000;
+
+  // Detect-and-skip: if the PR is already MERGED, return immediately. Saves a
+  // pointless `gh pr merge` call (which would error "already merged") and a
+  // full polling cycle.
+  let preState: PrStateInfo;
+  try {
+    preState = fetchPrState(platform, args.number, slug);
+  } catch (err) {
+    return {
+      ok: false,
+      error: `pr_merge_wait failed to read initial PR state: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    };
+  }
+  if (preState.state === 'merged') {
+    return synthesizeAlreadyMerged(args.number, preState);
+  }
+
+  const mergeResult = performMerge(platform, args) as MergeAggregate | MergeFailure;
+  if (isFailure(mergeResult)) return mergeResult;
+  if (mergeResult.merged) {
+    // Direct path — already on main. No need to poll.
+    return mergeResult;
+  }
+
+  // Queue path: enrolled but not yet on main. Poll until merged or timeout.
+  const poll = await pollUntilMerged({
+    fetchState: () => fetchPrState(platform, args.number, slug),
+    intervalMs: pollOverrides?.intervalMs ?? POLL_INTERVAL_MS,
+    timeoutMs,
+    now: pollOverrides?.now ?? Date.now,
+    sleep: pollOverrides?.sleep ?? defaultSleep,
+  });
+
+  if (!poll.ok) {
+    if (poll.reason === 'fetch_error') {
+      // Critical context: the PR was successfully enrolled — only the polling
+      // loop failed. Caller can retry the wait without re-enrolling.
+      const lastSnippet = poll.lastState
+        ? `last_state: ${poll.lastState.state.toUpperCase()}`
+        : 'no successful poll before failure';
+      return {
+        ok: false,
+        error:
+          `pr_merge_wait polling failed for PR #${args.number} after enrollment ` +
+          `(${lastSnippet}, queue.enforced: ${mergeResult.queue.enforced}): ${poll.error}`,
+      };
+    }
+    return {
+      ok: false,
+      error:
+        `pr_merge_wait timed out after ${args.timeout_sec ?? DEFAULT_TIMEOUT_SEC}s ` +
+        `waiting for PR #${args.number} to land on main ` +
+        `(last_state: ${poll.lastState.state.toUpperCase()}, ` +
+        `queue.enforced: ${mergeResult.queue.enforced})`,
+    };
+  }
+
+  return {
+    ...mergeResult,
+    merged: true,
+    pr_state: 'MERGED',
+    url: poll.state.url || mergeResult.url,
+    merge_commit_sha: poll.state.mergeCommitSha ?? mergeResult.merge_commit_sha,
+  };
+}
+
+// Exposed for tests so they can inject fake clock + sleep without requiring
+// real wall-clock time. Production callers go through the handler.
+export async function executeWaitForTest(
+  args: Input,
+  platform: Platform,
+  overrides: Partial<Pick<PollDeps, 'now' | 'sleep' | 'intervalMs'>>,
+): Promise<MergeAggregate | MergeFailure> {
+  return executeWait(args, platform, overrides);
+}
+
+const prMergeWaitHandler: HandlerDef = {
+  name: 'pr_merge_wait',
+  description:
+    'Merge a PR/MR and BLOCK until the commit is observable on main (or timeout). ' +
+    'Same input as pr_merge plus timeout_sec (default 600). Returns the same aggregate ' +
+    'envelope as pr_merge with merged=true, pr_state="MERGED" guaranteed on success. ' +
+    'Detects "already merged" and short-circuits without re-attempting the merge. ' +
+    'Use this when downstream work needs the commit on main; use pr_merge when ' +
+    'enrollment is enough.',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: Input;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+
+    try {
+      const platform = detectPlatform();
+      const result = await executeWait(args, platform);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
+      };
+    }
+  },
+};
+
+export default prMergeWaitHandler;

--- a/lib/merge_queue_detect.ts
+++ b/lib/merge_queue_detect.ts
@@ -1,0 +1,95 @@
+/**
+ * GitHub merge-queue detection for `pr_merge` and `pr_merge_wait`.
+ *
+ * The merge queue is a repo-level config: when a ruleset enforces it, every
+ * merge to the protected branch must enter the queue. `pr_merge`'s `skip_train`
+ * flag is meaningless on such repos — the GraphQL config tells us whether to
+ * silently drop the flag (#224) and whether to populate `queue.enforced` in
+ * the aggregate response (#225 Part A).
+ *
+ * The single-writer for queue config is GitHub itself; we treat the result as
+ * stable for the process lifetime to avoid a graphql round-trip per merge.
+ * If the config changes mid-session, the server must be restarted — but the
+ * blast radius is small (one stale "enforced" classification per session).
+ *
+ * Conservative-on-failure semantics: if the GraphQL call fails for any reason
+ * (auth, network, repo not found), assume `enabled: false`. The downstream
+ * effect is the pre-#225 behavior (skip_train honored, stderr-fallback into
+ * the queue path), which is no worse than the status quo.
+ */
+
+import { execSync } from 'child_process';
+
+export interface MergeQueueInfo {
+  enabled: boolean;
+  enforced: boolean;
+  // The queue's configured merge strategy ("SQUASH" | "MERGE" | "REBASE").
+  // Only present when enabled. Surfaced for caller introspection but not
+  // currently consumed by `pr_merge`.
+  method?: string;
+}
+
+const cache = new Map<string, MergeQueueInfo>();
+
+// Same charset as wave_previous_merged.ts:159 — GitHub's owner/repo grammar.
+// Enforcing it at the boundary prevents a maliciously-crafted slug from
+// smuggling shell metacharacters through `execSync`.
+const GITHUB_SLUG_SEGMENT = /^[A-Za-z0-9._-]+$/;
+
+export function clearMergeQueueCache(): void {
+  cache.clear();
+}
+
+const NO_QUEUE: MergeQueueInfo = { enabled: false, enforced: false };
+
+interface GraphqlResponse {
+  data?: {
+    repository?: {
+      mergeQueue?: { mergeMethod?: string } | null;
+    };
+  };
+}
+
+// `repo` is `owner/name`. If the slug is malformed or the GraphQL call fails,
+// returns `{enabled:false, enforced:false}` and caches that result for the
+// process lifetime — the caller does not need to handle errors.
+//
+// We currently treat `enabled` and `enforced` as the same boolean: GitHub's
+// `mergeQueue` is non-null iff the queue is configured AND ruleset-enforced
+// for the protected branch. Future refinement (separate detection via the
+// rulesets API) can split them without changing the call site.
+export function detectMergeQueue(repo: string): MergeQueueInfo {
+  const cached = cache.get(repo);
+  if (cached !== undefined) return cached;
+
+  const [owner, name] = repo.split('/', 2);
+  if (
+    owner === undefined ||
+    name === undefined ||
+    !GITHUB_SLUG_SEGMENT.test(owner) ||
+    !GITHUB_SLUG_SEGMENT.test(name)
+  ) {
+    cache.set(repo, NO_QUEUE);
+    return NO_QUEUE;
+  }
+
+  try {
+    const query =
+      'query($owner:String!,$name:String!)' +
+      '{repository(owner:$owner,name:$name){mergeQueue{mergeMethod}}}';
+    const raw = execSync(
+      `gh api graphql -f 'query=${query}' -F owner=${owner} -F name=${name}`,
+      { encoding: 'utf8' },
+    );
+    const parsed = JSON.parse(raw) as GraphqlResponse;
+    const mq = parsed.data?.repository?.mergeQueue;
+    const result: MergeQueueInfo = mq
+      ? { enabled: true, enforced: true, method: mq.mergeMethod }
+      : NO_QUEUE;
+    cache.set(repo, result);
+    return result;
+  } catch {
+    cache.set(repo, NO_QUEUE);
+    return NO_QUEUE;
+  }
+}

--- a/lib/pr_state.ts
+++ b/lib/pr_state.ts
@@ -1,0 +1,104 @@
+/**
+ * Slim cross-platform PR/MR state fetcher.
+ *
+ * Used by `pr_merge` (for post-merge URL + sha lookup) and `pr_merge_wait`
+ * (for polling until `state === 'merged'`). Intentionally narrower than
+ * `handlers/pr_status.ts` — that handler returns rich check + mergeability
+ * data; this lib returns only what the merge flow needs (state, url, sha).
+ *
+ * Why a separate lib instead of calling `pr_status` from `pr_merge_wait`:
+ * - One exec call vs two (pr_status fetches checks separately).
+ * - No JSON-of-JSON unwrap: handler responses are MCP envelopes wrapping
+ *   JSON strings, awkward to consume from inside another handler.
+ * - Decouples polling from rich-status concerns.
+ *
+ * Handlers that need the full status (`pr_status`, `pr_wait_ci`) keep their
+ * existing wider queries; this module is the minimal-surface alternative for
+ * the merge-confirmation use case.
+ */
+
+import { execSync } from 'child_process';
+import { gitlabApiMr } from './glab.js';
+
+export type PrState = 'open' | 'merged' | 'closed';
+
+export interface PrStateInfo {
+  state: PrState;
+  url: string;
+  mergeCommitSha?: string;
+}
+
+interface GithubPrViewResponse {
+  state?: string;
+  url?: string;
+  mergeCommit?: { oid?: string } | null;
+}
+
+// Same charset as merge_queue_detect.ts and wave_previous_merged.ts — GitHub's
+// owner/repo grammar. Defended at the lib boundary (not just at handler entry)
+// so any future caller of fetchGithubPrState gets the same protection without
+// having to remember to validate themselves.
+const GITHUB_REPO_SLUG = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
+function repoFlag(repo: string | undefined): string {
+  if (repo === undefined) return '';
+  if (!GITHUB_REPO_SLUG.test(repo)) {
+    throw new Error(`fetchGithubPrState: invalid repo slug ${JSON.stringify(repo)}`);
+  }
+  return ` --repo ${repo}`;
+}
+
+function parseSlugOpts(
+  slug: string | undefined,
+): { owner?: string; repo?: string } | undefined {
+  if (slug === undefined) return undefined;
+  const idx = slug.indexOf('/');
+  if (idx <= 0 || idx === slug.length - 1) return undefined;
+  return { owner: slug.slice(0, idx), repo: slug.slice(idx + 1) };
+}
+
+function normalizeGithubState(raw: string): PrState {
+  const upper = raw.toUpperCase();
+  if (upper === 'MERGED') return 'merged';
+  if (upper === 'CLOSED') return 'closed';
+  return 'open';
+}
+
+function normalizeGitlabState(raw: string): PrState {
+  const lower = raw.toLowerCase();
+  if (lower === 'merged') return 'merged';
+  if (lower === 'closed') return 'closed';
+  return 'open';
+}
+
+export function fetchGithubPrState(num: number, repo?: string): PrStateInfo {
+  const raw = execSync(
+    `gh pr view ${num} --json state,url,mergeCommit${repoFlag(repo)}`,
+    { encoding: 'utf8' },
+  );
+  const parsed = JSON.parse(raw) as GithubPrViewResponse;
+  return {
+    state: normalizeGithubState(parsed.state ?? ''),
+    url: parsed.url ?? '',
+    mergeCommitSha: parsed.mergeCommit?.oid,
+  };
+}
+
+export function fetchGitlabMrState(num: number, repo?: string): PrStateInfo {
+  const mr = gitlabApiMr(num, parseSlugOpts(repo));
+  return {
+    state: normalizeGitlabState(mr.state ?? ''),
+    url: mr.web_url ?? '',
+    mergeCommitSha: mr.merge_commit_sha ?? undefined,
+  };
+}
+
+export function fetchPrState(
+  platform: 'github' | 'gitlab',
+  num: number,
+  repo?: string,
+): PrStateInfo {
+  return platform === 'github'
+    ? fetchGithubPrState(num, repo)
+    : fetchGitlabMrState(num, repo);
+}

--- a/tests/merge_queue_detect.test.ts
+++ b/tests/merge_queue_detect.test.ts
@@ -1,0 +1,116 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+let execCalls: string[] = [];
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string) => {
+  execCalls.push(cmd);
+  return execMockFn(cmd);
+});
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { detectMergeQueue, clearMergeQueueCache } = await import(
+  '../lib/merge_queue_detect.ts'
+);
+
+function reset() {
+  execCalls = [];
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+  clearMergeQueueCache();
+}
+
+describe('merge_queue_detect', () => {
+  beforeEach(() => reset());
+
+  test('returns enabled+enforced when GraphQL reports a merge queue', () => {
+    execMockFn = () =>
+      JSON.stringify({ data: { repository: { mergeQueue: { mergeMethod: 'SQUASH' } } } });
+    const info = detectMergeQueue('Wave-Engineering/claudecode-workflow');
+    expect(info.enabled).toBe(true);
+    expect(info.enforced).toBe(true);
+    expect(info.method).toBe('SQUASH');
+  });
+
+  test('returns disabled when GraphQL reports null mergeQueue', () => {
+    execMockFn = () => JSON.stringify({ data: { repository: { mergeQueue: null } } });
+    const info = detectMergeQueue('org/no-queue-repo');
+    expect(info.enabled).toBe(false);
+    expect(info.enforced).toBe(false);
+    expect(info.method).toBeUndefined();
+  });
+
+  test('caches result per repo for the process lifetime', () => {
+    execMockFn = () =>
+      JSON.stringify({ data: { repository: { mergeQueue: { mergeMethod: 'MERGE' } } } });
+    detectMergeQueue('org/repo-a');
+    detectMergeQueue('org/repo-a');
+    detectMergeQueue('org/repo-a');
+    // One graphql call across three lookups for the same slug
+    expect(execCalls.length).toBe(1);
+  });
+
+  test('different repos get independent cache entries', () => {
+    let n = 0;
+    execMockFn = () => {
+      n += 1;
+      return JSON.stringify({
+        data: { repository: { mergeQueue: n === 1 ? { mergeMethod: 'SQUASH' } : null } },
+      });
+    };
+    const a = detectMergeQueue('org/repo-a');
+    const b = detectMergeQueue('org/repo-b');
+    expect(a.enabled).toBe(true);
+    expect(b.enabled).toBe(false);
+    expect(execCalls.length).toBe(2);
+  });
+
+  test('clearMergeQueueCache forces a refetch', () => {
+    execMockFn = () => JSON.stringify({ data: { repository: { mergeQueue: null } } });
+    detectMergeQueue('org/repo');
+    clearMergeQueueCache();
+    detectMergeQueue('org/repo');
+    expect(execCalls.length).toBe(2);
+  });
+
+  test('GraphQL failure yields conservative {enabled:false, enforced:false}', () => {
+    execMockFn = () => {
+      throw new Error('gh: not authenticated');
+    };
+    const info = detectMergeQueue('org/repo');
+    expect(info.enabled).toBe(false);
+    expect(info.enforced).toBe(false);
+  });
+
+  test('failure result is cached (no retry storms)', () => {
+    execMockFn = () => {
+      throw new Error('boom');
+    };
+    detectMergeQueue('org/repo');
+    detectMergeQueue('org/repo');
+    expect(execCalls.length).toBe(1);
+  });
+
+  test('malformed slug (no slash) returns {enabled:false} without exec', () => {
+    const info = detectMergeQueue('not-a-slug');
+    expect(info.enabled).toBe(false);
+    expect(execCalls.length).toBe(0);
+  });
+
+  test('shell-metacharacter slug rejected without exec', () => {
+    const info = detectMergeQueue('org/repo;rm -rf /');
+    expect(info.enabled).toBe(false);
+    expect(execCalls.length).toBe(0);
+  });
+
+  test('passes owner+name as -F flags, not interpolated into the query', () => {
+    execMockFn = () => JSON.stringify({ data: { repository: { mergeQueue: null } } });
+    detectMergeQueue('Wave-Engineering/mcp-server-sdlc');
+    expect(execCalls[0]).toContain('-F owner=Wave-Engineering');
+    expect(execCalls[0]).toContain('-F name=mcp-server-sdlc');
+    // owner/name MUST NOT appear inline in the GraphQL query string —
+    // the parameterized form is the safe way to pass user-controlled values.
+    const queryFragment = execCalls[0].match(/'query=([^']+)'/)?.[1] ?? '';
+    expect(queryFragment).not.toContain('Wave-Engineering');
+    expect(queryFragment).not.toContain('mcp-server-sdlc');
+  });
+});

--- a/tests/pr_merge.test.ts
+++ b/tests/pr_merge.test.ts
@@ -30,8 +30,8 @@ mock.module('child_process', () => ({
   execSync: (cmd: string, _opts?: unknown) => mockExec(cmd),
 }));
 
-// Import AFTER the mock is registered.
 const { default: prMergeHandler } = await import('../handlers/pr_merge.ts');
+const { clearMergeQueueCache } = await import('../lib/merge_queue_detect.ts');
 
 function parseResult(result: { content: Array<{ type: string; text: string }> }) {
   return JSON.parse(result.content[0].text) as Record<string, unknown>;
@@ -50,17 +50,39 @@ function mergeQueueError(): ThrowableError {
   return err;
 }
 
+// Default GraphQL stub for queue detection: respond "no queue" so old test
+// expectations (direct path, stderr-fallback to queue) keep working without
+// per-test boilerplate. Tests that exercise enforced-queue detection override
+// this with a more specific match.
+function stubNoQueue() {
+  onExec(
+    'gh api graphql',
+    JSON.stringify({ data: { repository: { mergeQueue: null } } }),
+  );
+}
+
+function stubEnforcedQueue(method: string = 'SQUASH') {
+  onExec(
+    'gh api graphql',
+    JSON.stringify({
+      data: { repository: { mergeQueue: { mergeMethod: method } } },
+    }),
+  );
+}
+
 beforeEach(() => {
   execRegistry = [];
   execCalls = [];
+  clearMergeQueueCache();
 });
 
 afterEach(() => {
   execRegistry = [];
   execCalls = [];
+  clearMergeQueueCache();
 });
 
-describe('pr_merge handler', () => {
+describe('pr_merge handler — aggregate response (#225)', () => {
   test('handler exports valid HandlerDef shape', () => {
     expect(prMergeHandler.name).toBe('pr_merge');
     expect(typeof prMergeHandler.execute).toBe('function');
@@ -80,15 +102,20 @@ describe('pr_merge handler', () => {
     expect(data.ok).toBe(false);
   });
 
-  // --- github direct success ---
-  test('github direct squash — success path returns direct_squash + merge_commit_sha', async () => {
+  // ===========================================================================
+  // GitHub direct-merge path: synchronous reality (enrolled+merged+MERGED)
+  // ===========================================================================
+
+  test('github direct squash — aggregate envelope reports merged synchronously', async () => {
     onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubNoQueue();
     onExec('gh pr merge 42 --squash --delete-branch', '');
     onExec(
-      'gh pr view 42 --json mergeCommit,url',
+      'gh pr view 42 --json state,url,mergeCommit',
       JSON.stringify({
-        mergeCommit: { oid: 'abc123def456' },
+        state: 'MERGED',
         url: 'https://github.com/org/repo/pull/42',
+        mergeCommit: { oid: 'abc123def456' },
       }),
     );
 
@@ -97,22 +124,27 @@ describe('pr_merge handler', () => {
 
     expect(data.ok).toBe(true);
     expect(data.number).toBe(42);
+    expect(data.enrolled).toBe(true);
     expect(data.merged).toBe(true);
     expect(data.merge_method).toBe('direct_squash');
+    expect(data.pr_state).toBe('MERGED');
     expect(data.url).toBe('https://github.com/org/repo/pull/42');
     expect(data.merge_commit_sha).toBe('abc123def456');
+    expect(data.queue).toEqual({ enabled: false, position: null, enforced: false });
+    expect(data.warnings).toEqual([]);
   });
 
-  // --- gitlab direct success ---
-  test('gitlab direct squash — success path returns direct_squash + merge_commit_sha', async () => {
+  // ===========================================================================
+  // GitLab direct-merge path: aggregate envelope, no queue concept
+  // ===========================================================================
+
+  test('gitlab direct squash — aggregate envelope, queue stays empty', async () => {
     onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git\n');
     onExec('glab mr merge 17 --squash --remove-source-branch --yes', '');
     onExec(
       'glab api projects/org%2Frepo/merge_requests/17',
       JSON.stringify({
         iid: 17,
-        title: 'Test MR',
-        description: '',
         state: 'merged',
         source_branch: 'feature/test',
         target_branch: 'main',
@@ -126,16 +158,25 @@ describe('pr_merge handler', () => {
     const data = parseResult(result);
 
     expect(data.ok).toBe(true);
-    expect(data.number).toBe(17);
+    expect(data.enrolled).toBe(true);
     expect(data.merged).toBe(true);
     expect(data.merge_method).toBe('direct_squash');
+    expect(data.pr_state).toBe('MERGED');
     expect(data.url).toBe('https://gitlab.com/org/repo/-/merge_requests/17');
     expect(data.merge_commit_sha).toBe('deadbeef1234');
+    expect(data.queue).toEqual({ enabled: false, position: null, enforced: false });
+    expect(data.warnings).toEqual([]);
+    // No `gh api graphql` call should have been made on the GitLab path.
+    expect(execCalls.find(c => c.includes('gh api graphql'))).toBeUndefined();
   });
 
-  // --- merge-queue fallback ---
-  test('github merge-queue fallback — direct fails with queue stderr, --auto succeeds', async () => {
+  // ===========================================================================
+  // GitHub queue path via stderr fallback (detection misses, legacy safety net)
+  // ===========================================================================
+
+  test('github stderr-fallback into queue — aggregate reports enrolled+OPEN', async () => {
     onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubNoQueue(); // detection returns false-negative
 
     let directCalled = false;
     let autoCalled = false;
@@ -148,42 +189,59 @@ describe('pr_merge handler', () => {
       return '';
     });
     onExec(
-      'gh pr view 55 --json url',
-      JSON.stringify({ url: 'https://github.com/org/repo/pull/55' }),
+      'gh pr view 55 --json state,url,mergeCommit',
+      JSON.stringify({
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/55',
+        mergeCommit: null,
+      }),
     );
 
     const result = await prMergeHandler.execute({ number: 55 });
     const data = parseResult(result);
 
     expect(data.ok).toBe(true);
+    expect(data.enrolled).toBe(true);
+    expect(data.merged).toBe(false); // queue path is eager, PR still OPEN
+    expect(data.pr_state).toBe('OPEN');
     expect(data.merge_method).toBe('merge_queue');
-    expect(data.merged).toBe(true);
-    expect(data.url).toBe('https://github.com/org/repo/pull/55');
     expect(data.merge_commit_sha).toBeUndefined();
+    // The fallback path PROMOTES queue.enabled+enforced based on what we
+    // learned from the stderr (detection was wrong; reality says enforced).
+    expect(data.queue).toEqual({ enabled: true, position: null, enforced: true });
     expect(directCalled).toBe(true);
     expect(autoCalled).toBe(true);
-    // Confirm the second invocation carried --auto.
     const autoCall = execCalls.find(
       c => c.includes('gh pr merge 55') && c.includes('--auto'),
     );
     expect(autoCall).toBeDefined();
   });
 
-  // --- forced merge-queue ---
-  test('github forced merge-queue — use_merge_queue=true skips direct path', async () => {
+  // ===========================================================================
+  // GitHub queue path via use_merge_queue: true (forced)
+  // ===========================================================================
+
+  test('github use_merge_queue=true — skips direct path, uses --auto', async () => {
     onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubNoQueue();
     onExec('gh pr merge 99 --squash --delete-branch --auto', '');
     onExec(
-      'gh pr view 99 --json url',
-      JSON.stringify({ url: 'https://github.com/org/repo/pull/99' }),
+      'gh pr view 99 --json state,url,mergeCommit',
+      JSON.stringify({
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/99',
+        mergeCommit: null,
+      }),
     );
 
     const result = await prMergeHandler.execute({ number: 99, use_merge_queue: true });
     const data = parseResult(result);
 
     expect(data.ok).toBe(true);
+    expect(data.enrolled).toBe(true);
+    expect(data.merged).toBe(false);
     expect(data.merge_method).toBe('merge_queue');
-    // Non-auto path must NOT have been invoked.
+    // Direct (non-auto) path must not have been invoked.
     const directOnly = execCalls.find(
       c =>
         c.startsWith('gh pr merge 99 --squash --delete-branch') && !c.includes('--auto'),
@@ -191,9 +249,153 @@ describe('pr_merge handler', () => {
     expect(directOnly).toBeUndefined();
   });
 
-  // --- failed merge (conflicts) ---
-  test('github failed merge — conflict error (no merge-queue phrase) surfaces as failure', async () => {
+  // ===========================================================================
+  // GitHub queue detected upfront → skips try-direct-then-fallback dance
+  // ===========================================================================
+
+  test('github detected enforced queue — goes straight to --auto, no failed direct exec', async () => {
     onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubEnforcedQueue();
+    onExec('gh pr merge 100 --squash --delete-branch --auto', '');
+    onExec(
+      'gh pr view 100 --json state,url,mergeCommit',
+      JSON.stringify({
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/100',
+        mergeCommit: null,
+      }),
+    );
+
+    const result = await prMergeHandler.execute({ number: 100 });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.merge_method).toBe('merge_queue');
+    const queue = data.queue as { enabled: boolean; enforced: boolean };
+    expect(queue.enabled).toBe(true);
+    expect(queue.enforced).toBe(true);
+    // Critical: NO failed direct merge call before --auto. The whole point of
+    // upfront detection is to skip the wasted exec.
+    const directOnly = execCalls.find(
+      c =>
+        c.startsWith('gh pr merge 100 --squash --delete-branch') && !c.includes('--auto'),
+    );
+    expect(directOnly).toBeUndefined();
+  });
+
+  // ===========================================================================
+  // Part C — folded #224: skip_train graceful degrade on enforced queue
+  // ===========================================================================
+
+  test('skip_train + enforced queue — flag silently dropped, warning emitted, --auto used', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubEnforcedQueue();
+    onExec('gh pr merge 200 --squash --delete-branch --auto', '');
+    onExec(
+      'gh pr view 200 --json state,url,mergeCommit',
+      JSON.stringify({
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/200',
+        mergeCommit: null,
+      }),
+    );
+
+    const result = await prMergeHandler.execute({ number: 200, skip_train: true });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.merge_method).toBe('merge_queue');
+    expect(data.warnings).toBeArray();
+    expect((data.warnings as string[]).length).toBe(1);
+    expect((data.warnings as string[])[0]).toContain('skip_train ignored');
+    expect((data.warnings as string[])[0]).toContain('merge queue');
+  });
+
+  test('skip_train + non-enforced repo — flag honored, direct path used, no warning', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubNoQueue();
+    onExec('gh pr merge 201 --squash --delete-branch', '');
+    onExec(
+      'gh pr view 201 --json state,url,mergeCommit',
+      JSON.stringify({
+        state: 'MERGED',
+        url: 'https://github.com/org/repo/pull/201',
+        mergeCommit: { oid: 'skip201' },
+      }),
+    );
+
+    const result = await prMergeHandler.execute({ number: 201, skip_train: true });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.merge_method).toBe('direct_squash');
+    expect(data.merge_commit_sha).toBe('skip201');
+    expect(data.warnings).toEqual([]);
+    // No --auto call.
+    const autoCall = execCalls.find(
+      c => c.includes('gh pr merge 201') && c.includes('--auto'),
+    );
+    expect(autoCall).toBeUndefined();
+  });
+
+  test('use_merge_queue:true + skip_train:true — warning emitted, queue path used', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubNoQueue();
+    onExec('gh pr merge 250 --squash --delete-branch --auto', '');
+    onExec(
+      'gh pr view 250 --json state,url,mergeCommit',
+      JSON.stringify({
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/250',
+        mergeCommit: null,
+      }),
+    );
+
+    const result = await prMergeHandler.execute({
+      number: 250,
+      use_merge_queue: true,
+      skip_train: true,
+    });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.merge_method).toBe('merge_queue');
+    const warnings = data.warnings as string[];
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain('skip_train ignored');
+    expect(warnings[0]).toContain('use_merge_queue');
+    // Direct path must not have been attempted.
+    const directOnly = execCalls.find(
+      c => c.startsWith('gh pr merge 250 --squash --delete-branch') && !c.includes('--auto'),
+    );
+    expect(directOnly).toBeUndefined();
+  });
+
+  test('skip_train + non-enforced repo + queue stderr — surfaces error (no fallback)', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubNoQueue();
+    onExec('gh pr merge 202 --squash --delete-branch', () => {
+      throw mergeQueueError();
+    });
+
+    const result = await prMergeHandler.execute({ number: 202, skip_train: true });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(false);
+    expect((data.error as string)).toContain('skip_train');
+    const autoCall = execCalls.find(
+      c => c.includes('gh pr merge 202') && c.includes('--auto'),
+    );
+    expect(autoCall).toBeUndefined();
+  });
+
+  // ===========================================================================
+  // Failure modes
+  // ===========================================================================
+
+  test('github failed merge — conflict error (non-queue) surfaces as failure', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubNoQueue();
     onExec('gh pr merge 8 --squash --delete-branch', () => {
       const err = new Error(
         'Pull request is not mergeable: the base branch requires all conflicts to be resolved',
@@ -210,9 +412,9 @@ describe('pr_merge handler', () => {
     expect((data.error as string).toLowerCase()).toContain('mergeable');
   });
 
-  // --- invalid PR number ---
   test('github invalid PR — not-found error surfaces as failure', async () => {
     onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubNoQueue();
     onExec('gh pr merge 99999 --squash --delete-branch', () => {
       const err = new Error('could not find pull request') as ThrowableError;
       err.stderr = 'GraphQL: Could not resolve to a PullRequest with the number of 99999.\n';
@@ -226,15 +428,55 @@ describe('pr_merge handler', () => {
     expect((data.error as string)).toContain('gh pr merge failed');
   });
 
-  // --- multi-line squash message (tempfile path) ---
-  test('github multi-line squash message — written to temp file and passed via --body-file', async () => {
+  test('github stderr-fallback failure — --auto also fails reports fallback failure', async () => {
     onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubNoQueue();
+
+    let call = 0;
+    onExec('gh pr merge 77 --squash --delete-branch', () => {
+      call += 1;
+      if (call === 1) throw mergeQueueError();
+      const err = new Error('auto merge not permitted') as ThrowableError;
+      err.stderr = 'auto-merge is disabled on this repository\n';
+      throw err;
+    });
+
+    const result = await prMergeHandler.execute({ number: 77 });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(false);
+    expect((data.error as string)).toContain('merge-queue fallback');
+  });
+
+  test('gitlab failed merge — error surfaces as failure', async () => {
+    onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git\n');
+    onExec('glab mr merge 9 --squash --remove-source-branch --yes', () => {
+      const err = new Error('merge request cannot be merged') as ThrowableError;
+      err.stderr = 'merge request has conflicts\n';
+      throw err;
+    });
+
+    const result = await prMergeHandler.execute({ number: 9 });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(false);
+    expect((data.error as string)).toContain('glab mr merge failed');
+  });
+
+  // ===========================================================================
+  // Squash message handling
+  // ===========================================================================
+
+  test('github multi-line squash message — written to temp file via --body-file', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubNoQueue();
     onExec('gh pr merge 21 --squash --delete-branch', '');
     onExec(
-      'gh pr view 21 --json mergeCommit,url',
+      'gh pr view 21 --json state,url,mergeCommit',
       JSON.stringify({
-        mergeCommit: { oid: 'aaaaaaaa' },
+        state: 'MERGED',
         url: 'https://github.com/org/repo/pull/21',
+        mergeCommit: { oid: 'aaaaaaaa' },
       }),
     );
 
@@ -247,8 +489,6 @@ describe('pr_merge handler', () => {
 
     expect(data.ok).toBe(true);
     expect(data.merge_method).toBe('direct_squash');
-
-    // Confirm --body-file was used (not --body with escaped newlines).
     const mergeCall = execCalls.find(c => c.startsWith('gh pr merge 21'));
     expect(mergeCall).toBeDefined();
     expect(mergeCall!).toContain('--body-file');
@@ -257,12 +497,14 @@ describe('pr_merge handler', () => {
 
   test('github single-line squash message — passed inline via --body', async () => {
     onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubNoQueue();
     onExec('gh pr merge 33 --squash --delete-branch', '');
     onExec(
-      'gh pr view 33 --json mergeCommit,url',
+      'gh pr view 33 --json state,url,mergeCommit',
       JSON.stringify({
-        mergeCommit: { oid: 'cafebabe' },
+        state: 'MERGED',
         url: 'https://github.com/org/repo/pull/33',
+        mergeCommit: { oid: 'cafebabe' },
       }),
     );
 
@@ -274,7 +516,6 @@ describe('pr_merge handler', () => {
 
     expect(data.ok).toBe(true);
     const mergeCall = execCalls.find(c => c.startsWith('gh pr merge 33'));
-    expect(mergeCall).toBeDefined();
     expect(mergeCall!).toContain("--body 'chore: small tweak'");
     expect(mergeCall!).not.toContain('--body-file');
   });
@@ -286,8 +527,6 @@ describe('pr_merge handler', () => {
       'glab api projects/org%2Frepo/merge_requests/14',
       JSON.stringify({
         iid: 14,
-        title: 'Test MR',
-        description: '',
         state: 'merged',
         source_branch: 'feature/fix',
         target_branch: 'main',
@@ -305,151 +544,23 @@ describe('pr_merge handler', () => {
 
     expect(data.ok).toBe(true);
     const mergeCall = execCalls.find(c => c.startsWith('glab mr merge 14'));
-    expect(mergeCall).toBeDefined();
     expect(mergeCall!).toContain("--squash-message 'fix: patch'");
   });
 
-  // --- merge-queue fallback failure ---
-  test('github merge-queue fallback — if --auto also fails, reports fallback failure', async () => {
-    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+  // ===========================================================================
+  // Cross-repo routing
+  // ===========================================================================
 
-    let call = 0;
-    onExec('gh pr merge 77 --squash --delete-branch', () => {
-      call += 1;
-      if (call === 1) throw mergeQueueError();
-      // Second call (--auto) also fails.
-      const err = new Error('auto merge not permitted') as ThrowableError;
-      err.stderr = 'auto-merge is disabled on this repository\n';
-      throw err;
-    });
-
-    const result = await prMergeHandler.execute({ number: 77 });
-    const data = parseResult(result);
-
-    expect(data.ok).toBe(false);
-    expect((data.error as string)).toContain('merge-queue fallback');
-  });
-
-  // --- gitlab failure ---
-  test('gitlab failed merge — error surfaces as failure', async () => {
-    onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git\n');
-    onExec('glab mr merge 9 --squash --remove-source-branch --yes', () => {
-      const err = new Error('merge request cannot be merged') as ThrowableError;
-      err.stderr = 'merge request has conflicts\n';
-      throw err;
-    });
-
-    const result = await prMergeHandler.execute({ number: 9 });
-    const data = parseResult(result);
-
-    expect(data.ok).toBe(false);
-    expect((data.error as string)).toContain('glab mr merge failed');
-  });
-
-  // --- skip_train: true ---
-  test('github skip_train — direct merge succeeds without merge-queue fallback', async () => {
-    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
-    onExec('gh pr merge 60 --squash --delete-branch', '');
-    onExec(
-      'gh pr view 60 --json mergeCommit,url',
-      JSON.stringify({
-        mergeCommit: { oid: 'skip123' },
-        url: 'https://github.com/org/repo/pull/60',
-      }),
-    );
-
-    const result = await prMergeHandler.execute({ number: 60, skip_train: true });
-    const data = parseResult(result);
-
-    expect(data.ok).toBe(true);
-    expect(data.merge_method).toBe('direct_squash');
-    expect(data.merge_commit_sha).toBe('skip123');
-    // No --auto call should have been made.
-    const autoCall = execCalls.find(
-      c => c.includes('gh pr merge 60') && c.includes('--auto'),
-    );
-    expect(autoCall).toBeUndefined();
-  });
-
-  test('github skip_train — merge-queue rejection surfaces as error (no fallback)', async () => {
-    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
-    onExec('gh pr merge 61 --squash --delete-branch', () => {
-      throw mergeQueueError();
-    });
-
-    const result = await prMergeHandler.execute({ number: 61, skip_train: true });
-    const data = parseResult(result);
-
-    expect(data.ok).toBe(false);
-    expect((data.error as string)).toContain('skip_train');
-    // Confirm no --auto fallback was attempted.
-    const autoCall = execCalls.find(
-      c => c.includes('gh pr merge 61') && c.includes('--auto'),
-    );
-    expect(autoCall).toBeUndefined();
-  });
-
-  test('github skip_train=false — preserves normal merge-queue fallback behavior', async () => {
-    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
-
-    let directCalled = false;
-    onExec('gh pr merge 62 --squash --delete-branch', () => {
-      if (!directCalled) {
-        directCalled = true;
-        throw mergeQueueError();
-      }
-      return '';
-    });
-    onExec(
-      'gh pr view 62 --json url',
-      JSON.stringify({ url: 'https://github.com/org/repo/pull/62' }),
-    );
-
-    const result = await prMergeHandler.execute({ number: 62, skip_train: false });
-    const data = parseResult(result);
-
-    expect(data.ok).toBe(true);
-    expect(data.merge_method).toBe('merge_queue');
-    // --auto fallback WAS attempted.
-    const autoCall = execCalls.find(
-      c => c.includes('gh pr merge 62') && c.includes('--auto'),
-    );
-    expect(autoCall).toBeDefined();
-  });
-
-  test('github skip_train omitted — preserves normal merge-queue fallback behavior', async () => {
-    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
-
-    let directCalled = false;
-    onExec('gh pr merge 63 --squash --delete-branch', () => {
-      if (!directCalled) {
-        directCalled = true;
-        throw mergeQueueError();
-      }
-      return '';
-    });
-    onExec(
-      'gh pr view 63 --json url',
-      JSON.stringify({ url: 'https://github.com/org/repo/pull/63' }),
-    );
-
-    const result = await prMergeHandler.execute({ number: 63 });
-    const data = parseResult(result);
-
-    expect(data.ok).toBe(true);
-    expect(data.merge_method).toBe('merge_queue');
-  });
-
-  // --- cross-repo routing ---
-
-  test('route_with_repo — github threads --repo into gh pr merge and gh pr view', async () => {
+  test('route_with_repo — github threads --repo into merge + view AND queue detection', async () => {
     onExec('git remote get-url origin', 'https://github.com/cwd-org/cwd-repo.git\n');
+    stubNoQueue();
     onExec('gh pr merge 42 --squash --delete-branch', '');
     onExec(
-      'gh pr view 42 --json mergeCommit,url',
+      'gh pr view 42 --json state,url,mergeCommit',
       JSON.stringify({
-        mergeCommit: { oid: 'abc123' },
+        state: 'MERGED',
         url: 'https://github.com/Wave-Engineering/mcp-server-sdlc/pull/42',
+        mergeCommit: { oid: 'abc123' },
       }),
     );
 
@@ -464,17 +575,19 @@ describe('pr_merge handler', () => {
     expect(mergeCall).toContain('--repo Wave-Engineering/mcp-server-sdlc');
     const viewCall = execCalls.find((c) => c.startsWith('gh pr view 42')) ?? '';
     expect(viewCall).toContain('--repo Wave-Engineering/mcp-server-sdlc');
+    // Queue detection should also use the explicit repo, not the cwd remote.
+    const graphqlCall = execCalls.find((c) => c.includes('gh api graphql')) ?? '';
+    expect(graphqlCall).toContain('-F owner=Wave-Engineering');
+    expect(graphqlCall).toContain('-F name=mcp-server-sdlc');
   });
 
-  test('route_with_repo — gitlab threads -R into glab mr merge + forwards slug to glab api', async () => {
+  test('route_with_repo — gitlab threads -R + forwards slug to glab api', async () => {
     onExec('git remote get-url origin', 'https://gitlab.com/cwd-org/cwd-repo.git\n');
     onExec('glab mr merge 17 --squash --remove-source-branch --yes', '');
     onExec(
       'glab api projects/target-org%2Ftarget-repo/merge_requests/17',
       JSON.stringify({
         iid: 17,
-        title: 'Test MR',
-        description: '',
         state: 'merged',
         source_branch: 'feature/test',
         target_branch: 'main',
@@ -500,12 +613,14 @@ describe('pr_merge handler', () => {
 
   test('regression_without_repo — gh pr merge does not contain --repo', async () => {
     onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubNoQueue();
     onExec('gh pr merge 42 --squash --delete-branch', '');
     onExec(
-      'gh pr view 42 --json mergeCommit,url',
+      'gh pr view 42 --json state,url,mergeCommit',
       JSON.stringify({
-        mergeCommit: { oid: 'x' },
+        state: 'MERGED',
         url: 'https://github.com/org/repo/pull/42',
+        mergeCommit: { oid: 'x' },
       }),
     );
 
@@ -524,5 +639,29 @@ describe('pr_merge handler', () => {
     expect(data.ok).toBe(false);
     expect(typeof data.error).toBe('string');
     expect(execCalls).toHaveLength(0);
+  });
+
+  // ===========================================================================
+  // Queue detection caching: verify one GraphQL call for repeat invocations
+  // ===========================================================================
+
+  test('queue detection cached per repo — second pr_merge skips graphql call', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubEnforcedQueue();
+    onExec('gh pr merge ', '');  // matches both 301 and 302 since both start "gh pr merge "
+    onExec(
+      'gh pr view ',
+      JSON.stringify({
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/?',
+        mergeCommit: null,
+      }),
+    );
+
+    await prMergeHandler.execute({ number: 301 });
+    await prMergeHandler.execute({ number: 302 });
+
+    const graphqlCalls = execCalls.filter(c => c.includes('gh api graphql'));
+    expect(graphqlCalls.length).toBe(1);
   });
 });

--- a/tests/pr_merge_wait.test.ts
+++ b/tests/pr_merge_wait.test.ts
@@ -1,0 +1,446 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+type Responder = string | (() => string);
+
+let execRegistry: Array<{ match: string; respond: Responder }> = [];
+let execCalls: string[] = [];
+
+function mockExec(cmd: string): string {
+  execCalls.push(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  throw new Error(`Unexpected exec call: ${cmd}`);
+}
+
+mock.module('child_process', () => ({
+  execSync: (cmd: string, _opts?: unknown) => mockExec(cmd),
+}));
+
+const { default: prMergeWaitHandler, pollUntilMerged, executeWaitForTest } = await import(
+  '../handlers/pr_merge_wait.ts'
+);
+const { clearMergeQueueCache } = await import('../lib/merge_queue_detect.ts');
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text) as Record<string, unknown>;
+}
+
+function onExec(match: string, respond: Responder) {
+  execRegistry.push({ match, respond });
+}
+
+function stubNoQueue() {
+  onExec(
+    'gh api graphql',
+    JSON.stringify({ data: { repository: { mergeQueue: null } } }),
+  );
+}
+
+function stubEnforcedQueue() {
+  onExec(
+    'gh api graphql',
+    JSON.stringify({ data: { repository: { mergeQueue: { mergeMethod: 'SQUASH' } } } }),
+  );
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+  clearMergeQueueCache();
+});
+
+afterEach(() => {
+  execRegistry = [];
+  execCalls = [];
+  clearMergeQueueCache();
+});
+
+// Fake clock + sleep for polling tests. Each sleep advances the clock by the
+// requested interval so the timeout check fires at predictable virtual time.
+function fakeClock(startMs: number = 0) {
+  let nowMs = startMs;
+  let sleepCount = 0;
+  return {
+    now: () => nowMs,
+    sleep: async (ms: number) => {
+      nowMs += ms;
+      sleepCount += 1;
+    },
+    advance: (ms: number) => {
+      nowMs += ms;
+    },
+    sleepCount: () => sleepCount,
+  };
+}
+
+// ===========================================================================
+// pollUntilMerged — pure function unit tests
+// ===========================================================================
+
+describe('pollUntilMerged (pure)', () => {
+  test('returns success on first fetch when state is already merged', async () => {
+    const clock = fakeClock();
+    const result = await pollUntilMerged({
+      fetchState: () => ({ state: 'merged', url: 'u', mergeCommitSha: 'abc' }),
+      intervalMs: 10000,
+      timeoutMs: 60000,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.state.state).toBe('merged');
+      expect(result.state.mergeCommitSha).toBe('abc');
+    }
+    expect(clock.sleepCount()).toBe(0);
+  });
+
+  test('polls until merged appears, then returns', async () => {
+    const clock = fakeClock();
+    const states: Array<'open' | 'merged'> = ['open', 'open', 'open', 'merged'];
+    let i = 0;
+    const result = await pollUntilMerged({
+      fetchState: () => ({
+        state: states[i++] ?? 'merged',
+        url: 'u',
+        mergeCommitSha: i === states.length ? 'sha' : undefined,
+      }),
+      intervalMs: 10000,
+      timeoutMs: 600000,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+    expect(result.ok).toBe(true);
+    expect(clock.sleepCount()).toBe(3); // three polls returned 'open' before the fourth merged
+  });
+
+  test('returns timeout when budget exhausted before merge', async () => {
+    const clock = fakeClock();
+    const result = await pollUntilMerged({
+      fetchState: () => ({ state: 'open', url: 'u' }),
+      intervalMs: 10000,
+      timeoutMs: 30000,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.reason === 'timeout') {
+      expect(result.lastState.state).toBe('open');
+    } else {
+      throw new Error('expected timeout variant');
+    }
+  });
+
+  test('fetch_error variant: fetchState throws on first iteration → reason=fetch_error, lastState=null', async () => {
+    const clock = fakeClock();
+    const result = await pollUntilMerged({
+      fetchState: () => {
+        throw new Error('gh: connection refused');
+      },
+      intervalMs: 1000,
+      timeoutMs: 60000,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.reason === 'fetch_error') {
+      expect(result.error).toContain('connection refused');
+      expect(result.lastState).toBeNull();
+    } else {
+      throw new Error('expected fetch_error variant');
+    }
+  });
+
+  test('fetch_error variant: throws on later iteration → lastState preserved', async () => {
+    const clock = fakeClock();
+    let n = 0;
+    const result = await pollUntilMerged({
+      fetchState: () => {
+        n += 1;
+        if (n === 1) return { state: 'open' as const, url: 'u' };
+        if (n === 2) return { state: 'open' as const, url: 'u' };
+        throw new Error('gh: rate limited');
+      },
+      intervalMs: 1000,
+      timeoutMs: 60000,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.reason === 'fetch_error') {
+      expect(result.error).toContain('rate limited');
+      expect(result.lastState?.state).toBe('open');
+    } else {
+      throw new Error('expected fetch_error variant');
+    }
+  });
+
+  test('timeout check happens BEFORE sleep (no wasted final interval)', async () => {
+    // With timeoutMs=10000 and intervalMs=10000, after one sleep the clock is
+    // at 10000ms. The next iteration fetches, sees 'open', checks elapsed >=
+    // timeoutMs (10000>=10000) → timeout. Sleep count should be exactly 1, not 2.
+    const clock = fakeClock();
+    const result = await pollUntilMerged({
+      fetchState: () => ({ state: 'open', url: 'u' }),
+      intervalMs: 10000,
+      timeoutMs: 10000,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+    expect(result.ok).toBe(false);
+    expect(clock.sleepCount()).toBe(1);
+  });
+});
+
+// ===========================================================================
+// executeWait — full handler flow with mocked clock + execSync
+// ===========================================================================
+
+describe('pr_merge_wait — handler integration', () => {
+  test('schema rejection: missing number', async () => {
+    const result = await prMergeWaitHandler.execute({});
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+  });
+
+  test('schema rejection: timeout_sec must be positive', async () => {
+    const result = await prMergeWaitHandler.execute({ number: 1, timeout_sec: -5 });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+  });
+
+  test('detect-and-skip: PR already merged → no merge call, warning emitted', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    onExec(
+      'gh pr view 50 --json state,url,mergeCommit',
+      JSON.stringify({
+        state: 'MERGED',
+        url: 'https://github.com/org/repo/pull/50',
+        mergeCommit: { oid: 'preexisting' },
+      }),
+    );
+
+    const result = await executeWaitForTest({ number: 50 }, 'github', {
+      now: () => 0,
+      sleep: async () => {},
+      intervalMs: 10000,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.merged).toBe(true);
+      expect(result.pr_state).toBe('MERGED');
+      expect(result.merge_commit_sha).toBe('preexisting');
+      expect(result.warnings.length).toBe(1);
+      expect(result.warnings[0]).toContain('already merged');
+    }
+    // No merge call should have been issued.
+    expect(execCalls.find(c => c.includes('gh pr merge'))).toBeUndefined();
+  });
+
+  test('direct merge path → returns synchronously, no polling', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubNoQueue();
+
+    // First view = pre-merge (OPEN, triggers detect-and-skip "not merged").
+    // Second view = post-merge inside pr_merge (MERGED). Real direct merge
+    // is synchronous, so we mirror that here.
+    let viewCalls = 0;
+    onExec('gh pr view 51 --json state,url,mergeCommit', () => {
+      viewCalls += 1;
+      const merged = viewCalls >= 2;
+      return JSON.stringify({
+        state: merged ? 'MERGED' : 'OPEN',
+        url: 'https://github.com/org/repo/pull/51',
+        mergeCommit: merged ? { oid: 'direct51' } : null,
+      });
+    });
+    onExec('gh pr merge 51 --squash --delete-branch', '');
+
+    const clock = fakeClock();
+    const result = await executeWaitForTest({ number: 51 }, 'github', {
+      now: clock.now,
+      sleep: clock.sleep,
+      intervalMs: 1,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.merged).toBe(true);
+      expect(result.merge_method).toBe('direct_squash');
+      expect(result.merge_commit_sha).toBe('direct51');
+    }
+    // Critical: zero polling sleeps on the direct path.
+    expect(clock.sleepCount()).toBe(0);
+  });
+
+  test('queue path → polls until state flips to merged', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubEnforcedQueue();
+
+    // Pre-state: OPEN. Then merge call (--auto). Post-merge initial fetch
+    // (inside pr_merge): OPEN. Polling fetches: OPEN, OPEN, MERGED.
+    let viewCallCount = 0;
+    onExec('gh pr view 60 --json state,url,mergeCommit', () => {
+      viewCallCount += 1;
+      // Calls 1 (pre-state for detect-and-skip), 2 (post-merge in pr_merge):
+      // OPEN. Calls 3, 4: OPEN. Call 5+: MERGED with sha.
+      if (viewCallCount >= 5) {
+        return JSON.stringify({
+          state: 'MERGED',
+          url: 'https://github.com/org/repo/pull/60',
+          mergeCommit: { oid: 'queued-sha' },
+        });
+      }
+      return JSON.stringify({
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/60',
+        mergeCommit: null,
+      });
+    });
+    onExec('gh pr merge 60 --squash --delete-branch --auto', '');
+
+    const clock = fakeClock();
+    const result = await executeWaitForTest({ number: 60 }, 'github', {
+      now: clock.now,
+      sleep: clock.sleep,
+      intervalMs: 1000,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.merged).toBe(true);
+      expect(result.pr_state).toBe('MERGED');
+      expect(result.merge_method).toBe('merge_queue');
+      expect(result.merge_commit_sha).toBe('queued-sha');
+    }
+    expect(clock.sleepCount()).toBeGreaterThan(0);
+  });
+
+  test('queue path → timeout returns ok:false with descriptive error', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubEnforcedQueue();
+
+    onExec(
+      'gh pr view 70 --json state,url,mergeCommit',
+      JSON.stringify({
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/70',
+        mergeCommit: null,
+      }),
+    );
+    onExec('gh pr merge 70 --squash --delete-branch --auto', '');
+
+    const clock = fakeClock();
+    const result = await executeWaitForTest(
+      { number: 70, timeout_sec: 30 },
+      'github',
+      { now: clock.now, sleep: clock.sleep, intervalMs: 10000 },
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('timed out after 30s');
+      expect(result.error).toContain('PR #70');
+      expect(result.error).toContain('queue.enforced: true');
+    }
+  });
+
+  test('queue path → fetch_error mid-poll surfaces "after enrollment" context', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubEnforcedQueue();
+
+    // Pre-state: OPEN. pr_merge's post-merge fetch: OPEN. First poll fetch:
+    // OPEN. Second poll fetch: throws.
+    let viewCallCount = 0;
+    onExec('gh pr view 71 --json state,url,mergeCommit', () => {
+      viewCallCount += 1;
+      if (viewCallCount >= 4) {
+        throw new Error('gh: API rate limit exceeded');
+      }
+      return JSON.stringify({
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/71',
+        mergeCommit: null,
+      });
+    });
+    onExec('gh pr merge 71 --squash --delete-branch --auto', '');
+
+    const clock = fakeClock();
+    const result = await executeWaitForTest({ number: 71 }, 'github', {
+      now: clock.now,
+      sleep: clock.sleep,
+      intervalMs: 1000,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('after enrollment');
+      expect(result.error).toContain('PR #71');
+      expect(result.error).toContain('rate limit');
+      expect(result.error).toContain('queue.enforced: true');
+    }
+  });
+
+  test('pr_merge failure propagates unchanged', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubNoQueue();
+    onExec(
+      'gh pr view 80 --json state,url,mergeCommit',
+      JSON.stringify({
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/80',
+        mergeCommit: null,
+      }),
+    );
+    onExec('gh pr merge 80 --squash --delete-branch', () => {
+      const err = new Error('Pull request is not mergeable: conflicts') as ThrowableError;
+      err.stderr = 'Pull request is not mergeable: conflicts\n';
+      throw err;
+    });
+
+    const result = await executeWaitForTest({ number: 80 }, 'github', {
+      now: () => 0,
+      sleep: async () => {},
+      intervalMs: 1,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('gh pr merge failed');
+    }
+  });
+
+  test('initial state-fetch failure surfaces a clear error', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    onExec('gh pr view 90 --json state,url,mergeCommit', () => {
+      throw new Error('PR not found');
+    });
+
+    const result = await executeWaitForTest({ number: 90 }, 'github', {
+      now: () => 0,
+      sleep: async () => {},
+      intervalMs: 1,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('failed to read initial PR state');
+      expect(result.error).toContain('PR not found');
+    }
+  });
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(prMergeWaitHandler.name).toBe('pr_merge_wait');
+    expect(typeof prMergeWaitHandler.execute).toBe('function');
+  });
+});

--- a/tests/pr_state.test.ts
+++ b/tests/pr_state.test.ts
@@ -1,0 +1,155 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+let execCalls: string[] = [];
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string) => {
+  execCalls.push(cmd);
+  return execMockFn(cmd);
+});
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { fetchPrState, fetchGithubPrState, fetchGitlabMrState } = await import(
+  '../lib/pr_state.ts'
+);
+
+function reset() {
+  execCalls = [];
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+describe('pr_state', () => {
+  beforeEach(() => reset());
+
+  describe('fetchGithubPrState', () => {
+    test('parses MERGED state with merge commit sha', () => {
+      execMockFn = () =>
+        JSON.stringify({
+          state: 'MERGED',
+          url: 'https://github.com/org/repo/pull/42',
+          mergeCommit: { oid: 'deadbeef' },
+        });
+      const info = fetchGithubPrState(42);
+      expect(info.state).toBe('merged');
+      expect(info.url).toBe('https://github.com/org/repo/pull/42');
+      expect(info.mergeCommitSha).toBe('deadbeef');
+    });
+
+    test('parses OPEN state with no merge commit', () => {
+      execMockFn = () =>
+        JSON.stringify({
+          state: 'OPEN',
+          url: 'https://github.com/org/repo/pull/42',
+          mergeCommit: null,
+        });
+      const info = fetchGithubPrState(42);
+      expect(info.state).toBe('open');
+      expect(info.mergeCommitSha).toBeUndefined();
+    });
+
+    test('parses CLOSED state', () => {
+      execMockFn = () =>
+        JSON.stringify({
+          state: 'CLOSED',
+          url: 'https://github.com/org/repo/pull/42',
+          mergeCommit: null,
+        });
+      const info = fetchGithubPrState(42);
+      expect(info.state).toBe('closed');
+    });
+
+    test('passes --repo when supplied', () => {
+      execMockFn = () =>
+        JSON.stringify({ state: 'OPEN', url: '', mergeCommit: null });
+      fetchGithubPrState(42, 'org/other-repo');
+      expect(execCalls[0]).toContain('--repo org/other-repo');
+    });
+
+    test('omits --repo when not supplied (uses cwd)', () => {
+      execMockFn = () =>
+        JSON.stringify({ state: 'OPEN', url: '', mergeCommit: null });
+      fetchGithubPrState(42);
+      expect(execCalls[0]).not.toContain('--repo');
+    });
+
+    test('unknown state defaults to open', () => {
+      execMockFn = () =>
+        JSON.stringify({ state: 'WEIRD', url: '', mergeCommit: null });
+      expect(fetchGithubPrState(42).state).toBe('open');
+    });
+
+    test('rejects malicious repo slug at lib boundary (no exec)', () => {
+      expect(() => fetchGithubPrState(42, 'org/repo; rm -rf /')).toThrow(
+        /invalid repo slug/,
+      );
+      expect(execCalls.length).toBe(0);
+    });
+
+    test('rejects repo slug with shell metacharacter (no exec)', () => {
+      expect(() => fetchGithubPrState(42, 'org/repo`whoami`')).toThrow(
+        /invalid repo slug/,
+      );
+      expect(execCalls.length).toBe(0);
+    });
+
+    test('rejects repo with no slash (no exec)', () => {
+      expect(() => fetchGithubPrState(42, 'just-a-name')).toThrow(/invalid repo slug/);
+      expect(execCalls.length).toBe(0);
+    });
+  });
+
+  describe('fetchGitlabMrState', () => {
+    test('parses merged state via glab api', () => {
+      execMockFn = (cmd: string) => {
+        if (cmd.includes('git remote get-url')) {
+          return 'https://gitlab.com/org/repo.git\n';
+        }
+        return JSON.stringify({
+          state: 'merged',
+          web_url: 'https://gitlab.com/org/repo/-/merge_requests/7',
+          merge_commit_sha: 'cafebabe',
+        });
+      };
+      const info = fetchGitlabMrState(7);
+      expect(info.state).toBe('merged');
+      expect(info.url).toBe('https://gitlab.com/org/repo/-/merge_requests/7');
+      expect(info.mergeCommitSha).toBe('cafebabe');
+    });
+
+    test('parses opened state', () => {
+      execMockFn = (cmd: string) => {
+        if (cmd.includes('git remote get-url')) {
+          return 'https://gitlab.com/org/repo.git\n';
+        }
+        return JSON.stringify({
+          state: 'opened',
+          web_url: 'https://gitlab.com/org/repo/-/merge_requests/7',
+        });
+      };
+      const info = fetchGitlabMrState(7);
+      expect(info.state).toBe('open');
+      expect(info.mergeCommitSha).toBeUndefined();
+    });
+  });
+
+  describe('fetchPrState dispatcher', () => {
+    test('dispatches to github when platform=github', () => {
+      execMockFn = () =>
+        JSON.stringify({ state: 'OPEN', url: '', mergeCommit: null });
+      fetchPrState('github', 42);
+      expect(execCalls[0]).toContain('gh pr view 42');
+    });
+
+    test('dispatches to gitlab when platform=gitlab', () => {
+      execMockFn = (cmd: string) => {
+        if (cmd.includes('git remote get-url')) {
+          return 'https://gitlab.com/org/repo.git\n';
+        }
+        return JSON.stringify({ state: 'opened', web_url: '' });
+      };
+      fetchPrState('gitlab', 7);
+      const calls = execCalls.join('\n');
+      expect(calls).toContain('glab api');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `pr_merge` now returns the AGGREGATE state — `{ok, enrolled, merged, merge_method, queue:{enabled,position,enforced}, pr_state, url, merge_commit_sha?, warnings, error}`. Eager but honest: queue-enrolled PRs report `merged:false, pr_state:"OPEN"` instead of the old optimistic `merged:true` lie. The caller decides what "merged" means.
- New `pr_merge_wait` tool with same input + `timeout_sec` (default 600) blocks until the commit lands on main or returns a clear timeout error. Detect-and-skip short-circuits if already MERGED.
- Folds in #224: `skip_train:true` on a merge-queue-enforced repo is silently dropped (warning emitted) instead of hard-erroring.

## Changes

- **handlers/pr_merge.ts** — new aggregate response shape; up-front merge-queue detection skips the legacy try-direct-then-fallback dance when the queue is known enforced; legacy stderr fallback retained as safety net for false-negative detection.
- **handlers/pr_merge_wait.ts** (new) — blocking sibling tool. Pure injectable poller (`pollUntilMerged`) for testability.
- **lib/merge_queue_detect.ts** (new) — GraphQL detector for GitHub `mergeQueue` config; per-repo session-cached. Conservative-on-failure (caches `enabled:false` if GraphQL fails).
- **lib/pr_state.ts** (new) — slim cross-platform PR/MR state fetcher (state, url, mergeCommitSha). Used by both pr_merge (post-merge URL+sha lookup) and pr_merge_wait (polling).
- **README.md** — new "Merge tools: `pr_merge` vs `pr_merge_wait`" section explaining when to use each.

## Code-review hardenings (3 fixed before commit)

| ID | Conf | Fix |
|---|---|---|
| F1 | 95 | `lib/pr_state.ts:repoFlag` validates slug at lib boundary (no more silent shell-interpolation trust) |
| F2 | 88 | `pollUntilMerged` returns a `fetch_error` variant when `fetchState` throws mid-poll, preserving "after enrollment" context for the caller |
| F3 | 82 | `decideIntent`'s `use_merge_queue:true` branch now emits `skip_train ignored — use_merge_queue:true takes precedence` warning instead of silently dropping the flag |

## Linked Issues

Closes #225
Closes #224 (folded into Part C)

## Test Plan

- [x] `bun test` — 1378/1378 across 80 files, 3407 expects
- [x] `./scripts/ci/validate.sh` — 73/73 handlers
- [x] `trivy fs --severity HIGH,CRITICAL` — 0 findings
- [x] All 8 acceptance criteria from #225 verified against code
- [x] Code review (`feature-dev:code-reviewer`) — 3 high-confidence findings all fixed with regression tests
- [ ] Manual integration on `Wave-Engineering/claudecode-workflow` (queue-enforced repo) deferred until BJ reinstalls the binary

## Out of scope (follow-ups)

- `merge_method: "rebase" | "merge"` — needs changes to merge command flags
- `queue.position` enrichment via `mergeQueue.entries` GraphQL field — currently always `null` (a documented valid value per spec)
- Migrating `/mmr` in cc-workflow to use `pr_merge_wait` — separate cc-workflow issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)