### PR TITLE
fix(pr_merge): honest merged-state reporting + working merge-queue detection

### DIFF
--- a/handlers/pr_merge.ts
+++ b/handlers/pr_merge.ts
@@ -278,12 +278,18 @@ function mergeGithubDirect(
   );
   try {
     exec(directCmd);
+    // gh exit 0 doesn't mean "merged" — when a merge queue or auto-merge is
+    // configured at the repo/branch level, gh may have enrolled the PR rather
+    // than merged it synchronously. Read the actual state and report honestly
+    // so callers (especially pr_merge_wait) don't trust a stale "merged:true".
+    // See #258 for the regression history.
     const info = fetchGithubPrState(args.number, args.repo);
+    const actuallyMerged = info.state === 'merged';
     return aggregateOk({
       number: args.number,
       enrolled: true,
-      merged: true,
-      method: 'direct_squash',
+      merged: actuallyMerged,
+      method: actuallyMerged ? 'direct_squash' : 'merge_queue',
       queue,
       url: info.url,
       mergeCommitSha: info.mergeCommitSha,

--- a/lib/merge_queue_detect.ts
+++ b/lib/merge_queue_detect.ts
@@ -23,10 +23,6 @@ import { execSync } from 'child_process';
 export interface MergeQueueInfo {
   enabled: boolean;
   enforced: boolean;
-  // The queue's configured merge strategy ("SQUASH" | "MERGE" | "REBASE").
-  // Only present when enabled. Surfaced for caller introspection but not
-  // currently consumed by `pr_merge`.
-  method?: string;
 }
 
 const cache = new Map<string, MergeQueueInfo>();
@@ -45,7 +41,7 @@ const NO_QUEUE: MergeQueueInfo = { enabled: false, enforced: false };
 interface GraphqlResponse {
   data?: {
     repository?: {
-      mergeQueue?: { mergeMethod?: string } | null;
+      mergeQueue?: { __typename?: string } | null;
     };
   };
 }
@@ -74,9 +70,13 @@ export function detectMergeQueue(repo: string): MergeQueueInfo {
   }
 
   try {
+    // Ask only for `__typename` (always-valid built-in). Earlier versions
+    // requested `mergeMethod`, which doesn't exist on the MergeQueue type and
+    // made the entire query fail with `undefinedField` — silently caching
+    // {enabled:false} for every repo (the regression #258 documents).
     const query =
       'query($owner:String!,$name:String!)' +
-      '{repository(owner:$owner,name:$name){mergeQueue{mergeMethod}}}';
+      '{repository(owner:$owner,name:$name){mergeQueue{__typename}}}';
     const raw = execSync(
       `gh api graphql -f 'query=${query}' -F owner=${owner} -F name=${name}`,
       { encoding: 'utf8' },
@@ -84,7 +84,7 @@ export function detectMergeQueue(repo: string): MergeQueueInfo {
     const parsed = JSON.parse(raw) as GraphqlResponse;
     const mq = parsed.data?.repository?.mergeQueue;
     const result: MergeQueueInfo = mq
-      ? { enabled: true, enforced: true, method: mq.mergeMethod }
+      ? { enabled: true, enforced: true }
       : NO_QUEUE;
     cache.set(repo, result);
     return result;

--- a/tests/merge_queue_detect.test.ts
+++ b/tests/merge_queue_detect.test.ts
@@ -24,11 +24,10 @@ describe('merge_queue_detect', () => {
 
   test('returns enabled+enforced when GraphQL reports a merge queue', () => {
     execMockFn = () =>
-      JSON.stringify({ data: { repository: { mergeQueue: { mergeMethod: 'SQUASH' } } } });
+      JSON.stringify({ data: { repository: { mergeQueue: { __typename: 'MergeQueue' } } } });
     const info = detectMergeQueue('Wave-Engineering/claudecode-workflow');
     expect(info.enabled).toBe(true);
     expect(info.enforced).toBe(true);
-    expect(info.method).toBe('SQUASH');
   });
 
   test('returns disabled when GraphQL reports null mergeQueue', () => {
@@ -36,12 +35,11 @@ describe('merge_queue_detect', () => {
     const info = detectMergeQueue('org/no-queue-repo');
     expect(info.enabled).toBe(false);
     expect(info.enforced).toBe(false);
-    expect(info.method).toBeUndefined();
   });
 
   test('caches result per repo for the process lifetime', () => {
     execMockFn = () =>
-      JSON.stringify({ data: { repository: { mergeQueue: { mergeMethod: 'MERGE' } } } });
+      JSON.stringify({ data: { repository: { mergeQueue: { __typename: 'MergeQueue' } } } });
     detectMergeQueue('org/repo-a');
     detectMergeQueue('org/repo-a');
     detectMergeQueue('org/repo-a');
@@ -54,7 +52,7 @@ describe('merge_queue_detect', () => {
     execMockFn = () => {
       n += 1;
       return JSON.stringify({
-        data: { repository: { mergeQueue: n === 1 ? { mergeMethod: 'SQUASH' } : null } },
+        data: { repository: { mergeQueue: n === 1 ? { __typename: 'MergeQueue' } : null } },
       });
     };
     const a = detectMergeQueue('org/repo-a');
@@ -112,5 +110,21 @@ describe('merge_queue_detect', () => {
     const queryFragment = execCalls[0].match(/'query=([^']+)'/)?.[1] ?? '';
     expect(queryFragment).not.toContain('Wave-Engineering');
     expect(queryFragment).not.toContain('mcp-server-sdlc');
+  });
+
+  // --- Regression: #258 Bug 3 ---
+
+  test('regression #258: GraphQL query selects __typename, not undefined fields', () => {
+    execMockFn = () => JSON.stringify({ data: { repository: { mergeQueue: null } } });
+    detectMergeQueue('Wave-Engineering/mcp-server-sdlc');
+    const queryFragment = execCalls[0].match(/'query=([^']+)'/)?.[1] ?? '';
+    // The original bug requested `mergeMethod`, which doesn't exist on
+    // GitHub's MergeQueue type and made every query fail with
+    // `undefinedField` → silently caching {enabled:false} for every repo.
+    expect(queryFragment).not.toContain('mergeMethod');
+    // Selection set must contain at least one valid field. __typename is the
+    // always-available built-in scalar; any other field would also work but
+    // __typename was the chosen replacement.
+    expect(queryFragment).toContain('__typename');
   });
 });

--- a/tests/pr_merge.test.ts
+++ b/tests/pr_merge.test.ts
@@ -61,11 +61,16 @@ function stubNoQueue() {
   );
 }
 
-function stubEnforcedQueue(method: string = 'SQUASH') {
+function stubEnforcedQueue() {
+  // Match the actual GitHub GraphQL response shape: detection asks for
+  // `__typename` (always-valid built-in scalar) — see #258 fix in
+  // lib/merge_queue_detect.ts. The previous form returned a `mergeMethod`
+  // field that doesn't exist in GitHub's schema; tests passed by accident
+  // because the parser only nullness-checks the mergeQueue object.
   onExec(
     'gh api graphql',
     JSON.stringify({
-      data: { repository: { mergeQueue: { mergeMethod: method } } },
+      data: { repository: { mergeQueue: { __typename: 'MergeQueue' } } },
     }),
   );
 }
@@ -132,6 +137,39 @@ describe('pr_merge handler — aggregate response (#225)', () => {
     expect(data.merge_commit_sha).toBe('abc123def456');
     expect(data.queue).toEqual({ enabled: false, position: null, enforced: false });
     expect(data.warnings).toEqual([]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Regression #258 Bug 1: gh exits 0 doesn't mean "merged"
+  // ---------------------------------------------------------------------------
+  // When a merge queue / auto-merge is configured at the repo or branch level,
+  // `gh pr merge --squash --delete-branch` may exit 0 by enrolling the PR
+  // (queue add or auto-merge enable), NOT by performing the merge synchronously.
+  // The handler must read actual state, not assume gh-exit-0 => merged.
+  // Pre-fix behavior: line 286 hardcoded merged:true → pr_merge_wait skipped
+  // its polling loop → caller believed the merge had landed when it hadn't.
+  test('regression #258: direct exec exit 0 + state OPEN reports merged:false, merge_queue', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubNoQueue();
+    onExec('gh pr merge 99 --squash --delete-branch', ''); // exits 0
+    onExec(
+      'gh pr view 99 --json state,url,mergeCommit',
+      JSON.stringify({
+        state: 'OPEN', // gh enrolled but didn't merge synchronously
+        url: 'https://github.com/org/repo/pull/99',
+        mergeCommit: null,
+      }),
+    );
+
+    const result = await prMergeHandler.execute({ number: 99 });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(true);
+    expect(data.enrolled).toBe(true);
+    expect(data.merged).toBe(false); // honest: gh enrolled, didn't merge
+    expect(data.pr_state).toBe('OPEN');
+    expect(data.merge_method).toBe('merge_queue'); // method reflects reality
+    expect(data.merge_commit_sha).toBeUndefined();
   });
 
   // ===========================================================================

--- a/tests/pr_merge_wait.test.ts
+++ b/tests/pr_merge_wait.test.ts
@@ -46,9 +46,11 @@ function stubNoQueue() {
 }
 
 function stubEnforcedQueue() {
+  // Match the actual GitHub GraphQL response shape: detection asks for
+  // `__typename` — see #258 fix in lib/merge_queue_detect.ts.
   onExec(
     'gh api graphql',
-    JSON.stringify({ data: { repository: { mergeQueue: { mergeMethod: 'SQUASH' } } } }),
+    JSON.stringify({ data: { repository: { mergeQueue: { __typename: 'MergeQueue' } } } }),
   );
 }
 
@@ -281,6 +283,56 @@ describe('pr_merge_wait — handler integration', () => {
     }
     // Critical: zero polling sleeps on the direct path.
     expect(clock.sleepCount()).toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Regression #258 Bug 2: pr_merge_wait must NOT trust pr_merge's merged:true
+  // when the underlying gh pr merge actually only enrolled (queue / auto-merge).
+  // Pre-fix: pr_merge.ts:286 hardcoded merged:true on direct exec exit 0, then
+  // pr_merge_wait short-circuited at line 179-182 — caller saw merged:true but
+  // the PR was actually still OPEN (or in #257's case, closed without merging).
+  // Post-fix: pr_merge reports merged:false; pr_merge_wait polls until landing.
+  test('regression #258: direct path returns merged:false → pr_merge_wait polls until landing', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    stubNoQueue(); // detection misses (e.g. branch-level queue, like the real repo)
+
+    // Pre-state (detect-and-skip): OPEN.
+    // Post-direct-merge view (inside pr_merge): STILL OPEN — gh enrolled, didn't merge.
+    // Polling: OPEN, OPEN, MERGED.
+    let viewCallCount = 0;
+    onExec('gh pr view 257 --json state,url,mergeCommit', () => {
+      viewCallCount += 1;
+      if (viewCallCount >= 5) {
+        return JSON.stringify({
+          state: 'MERGED',
+          url: 'https://github.com/org/repo/pull/257',
+          mergeCommit: { oid: 'eventually-merged' },
+        });
+      }
+      return JSON.stringify({
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/257',
+        mergeCommit: null,
+      });
+    });
+    // Direct merge command exits 0 without throwing — gh decided to enroll.
+    onExec('gh pr merge 257 --squash --delete-branch', '');
+
+    const clock = fakeClock();
+    const result = await executeWaitForTest({ number: 257 }, 'github', {
+      now: clock.now,
+      sleep: clock.sleep,
+      intervalMs: 1000,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.merged).toBe(true);
+      expect(result.pr_state).toBe('MERGED');
+      expect(result.merge_commit_sha).toBe('eventually-merged');
+    }
+    // Critical: pr_merge_wait must have actually polled (not short-circuited).
+    expect(clock.sleepCount()).toBeGreaterThan(0);
   });
 
   test('queue path → polls until state flips to merged', async () => {


### PR DESCRIPTION
## Summary

Three chained bugs caused `pr_merge` / `pr_merge_wait` to silently report success on enrolled-but-not-merged PRs. **Real-world failure: PR #257** (close-without-merge `2026-04-26 02:22Z`); PR #254 worked by accident on the same code path. Wave-pattern poison pill — a flight could believe it landed, the orchestrator could advance the wave, and main would be at the prior commit.

## Changes

**Bug 1 — `handlers/pr_merge.ts:286` (`mergeGithubDirect` happy path):**
- Replaced hardcoded `merged: true` with `merged: info.state === 'merged'`.
- When a merge queue or auto-merge is configured, `gh pr merge --squash --delete-branch` may exit 0 by enrolling the PR rather than merging it synchronously. The handler now reads actual state and reports honestly, matching the queue path's pre-existing behavior at line 259.
- `merge_method` also reflects reality: `direct_squash` if state is merged, `merge_queue` if exit-0 but state still open.

**Bug 2 — `handlers/pr_merge_wait.ts:179-182` (skip-poll on lie):**
- Self-fixes once Bug 1 reports honestly. The `if (mergeResult.merged)` short-circuit now only fires when the merge actually landed synchronously; otherwise polling proceeds correctly.

**Bug 3 — `lib/merge_queue_detect.ts:78-80` (broken GraphQL query):**
- Replaced `{mergeMethod}` (field doesn't exist on GitHub's `MergeQueue` type — query failed with `undefinedField`) with `{__typename}` (always-valid built-in scalar).
- Detection has been a no-op since #225 landed, silently caching `{enabled:false}` for every repo. **Live verification against this repo confirms the queue IS enabled** — the broken query was masking it (`{"mergeQueue":{"__typename":"MergeQueue"}}`).
- Dropped the unused `MergeQueueInfo.method` field (per the pre-existing comment "not currently consumed by `pr_merge`").

**Tests (3 new regression tests, one per bug):**
- `tests/pr_merge.test.ts` — `regression #258`: direct exec exit 0 + state OPEN reports merged:false
- `tests/pr_merge_wait.test.ts` — `regression #258`: direct path returns merged:false → polls until landing
- `tests/merge_queue_detect.test.ts` — `regression #258`: query string asserts no `mergeMethod`, contains `__typename`

**Test stub fixes** (code-reviewer finding, confidence 100):
- `stubEnforcedQueue` in both `tests/pr_merge.test.ts:64` and `tests/pr_merge_wait.test.ts:48` previously emitted `{mergeMethod: 'SQUASH'}` — a field that doesn't exist in GitHub's real response. Tests passed by accident because the parser only nullness-checks. Updated both stubs to `{__typename: 'MergeQueue'}` matching the production query shape.

## Linked Issues

Closes #258

## Test Plan

- [x] `./scripts/ci/validate.sh` → **73/73 per-tool assertions pass**
- [x] `bun test` → **1382 / 0 / 80 files / 3432 expect()**
- [x] `gh api graphql` with new query against this repo → no errors, returns `{"mergeQueue":{"__typename":"MergeQueue"}}`
- [x] `trivy fs --severity HIGH,CRITICAL` → **0 findings**
- [x] Code-reviewer findings addressed: stubEnforcedQueue helpers fixed in both test files
- [x] AC #1: `handlers/pr_merge.ts:286` does NOT contain `merged: true` as a literal
- [x] AC #2: `lib/merge_queue_detect.ts` GraphQL query does NOT contain `mergeMethod`
- [x] AC #3: live GraphQL with new query returns no errors
- [x] AC #4-7: regression tests verify the new contract

## ⚠️ Critical merge-path note

**This PR was merged via direct `gh pr merge --merge-queue --squash --delete-branch`** (NOT via `pr_merge_wait`). The currently-installed binary at `~/.local/bin/sdlc-server` (Apr 25 15:54Z) has the broken version of `pr_merge_wait` this PR fixes. Using it to merge its own fix is the textbook self-deletion bug.

**After this lands:** `scripts/install-remote.sh` must be run to upgrade the local binary before relying on `pr_merge_wait` again. The fix is only in the source until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)