### PR TITLE
chore(handlers): sweep Bun.spawnSync from remaining 4 handlers

### DIFF
--- a/handlers/dod_run_test_suite.ts
+++ b/handlers/dod_run_test_suite.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
 
@@ -5,10 +6,26 @@ const inputSchema = z.object({
   command: z.string().optional(),
 });
 
+interface ExecError extends Error {
+  stdout?: Buffer | string;
+  stderr?: Buffer | string;
+  status?: number;
+}
+
+function bufToString(b: unknown): string {
+  if (b === undefined || b === null) return '';
+  if (typeof b === 'string') return b;
+  if (typeof (b as Buffer).toString === 'function') return (b as Buffer).toString();
+  return String(b);
+}
+
 function projectDir(): string {
   return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
 }
 
+// Discovery uses Bun.file (filesystem probe, not subprocess) so it stays
+// outside the child_process mock surface. Tests cover discovery via real
+// fixture directories.
 async function fileExists(path: string): Promise<boolean> {
   return await Bun.file(path).exists();
 }
@@ -80,19 +97,22 @@ function parseTestOutput(command: string, output: string): TestResult {
 
 function runCommand(cmd: string, cwd: string): { exitCode: number; output: string; durationMs: number } {
   const start = Date.now();
-  const proc = Bun.spawnSync({
-    cmd: ['sh', '-c', cmd],
-    cwd,
-    stdout: 'pipe',
-    stderr: 'pipe',
-  });
-  const out =
-    new TextDecoder().decode(proc.stdout) + new TextDecoder().decode(proc.stderr);
-  return {
-    exitCode: proc.exitCode ?? -1,
-    output: out,
-    durationMs: Date.now() - start,
-  };
+  // `cmd` is a full shell command string (e.g. `npm test`, `./scripts/ci/test.sh`,
+  // user-supplied), NOT an argv array — so per-token shellEscape would break it.
+  // Append `2>&1` so the merged stream lands in execSync's stdout return value
+  // (execSync only surfaces stdout). On non-zero exit the merged content is in
+  // err.stdout; err.stderr is empty after the shell-level redirect.
+  const shellCmd = `${cmd} 2>&1`;
+  let exitCode = 0;
+  let output = '';
+  try {
+    output = execSync(shellCmd, { cwd, encoding: 'utf8' });
+  } catch (err) {
+    const e = err as ExecError;
+    exitCode = typeof e.status === 'number' ? e.status : -1;
+    output = bufToString(e.stdout) + bufToString(e.stderr);
+  }
+  return { exitCode, output, durationMs: Date.now() - start };
 }
 
 const dodRunTestSuiteHandler: HandlerDef = {

--- a/handlers/dod_verify_deliverable.ts
+++ b/handlers/dod_verify_deliverable.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
 
@@ -14,19 +15,19 @@ interface FsInfo {
   last_modified: string | null;
 }
 
-/**
- * Use Bun.spawnSync('stat', ...) to probe a path. Avoids node:fs so we
- * dodge mock.module('fs') pollution from sibling test files, and avoids
- * child_process so we dodge mock.module('child_process') pollution from
- * sibling test files that mock execSync.
- */
-function probePath(path: string): FsInfo {
-  const proc = Bun.spawnSync({
-    cmd: ['stat', '-c', '%F|%s|%Y', path],
-    stderr: 'pipe',
-  });
+function shellEscape(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
 
-  if (proc.exitCode !== 0) {
+function probePath(path: string): FsInfo {
+  // `stat -c '%F|%s|%Y'` prints "<kind>|<size_bytes>|<mtime_secs>".
+  // execSync throws on non-zero exit (missing path) — catch and report
+  // exists:false so callers see a clean envelope rather than an exception.
+  const statCmd = ['stat', '-c', '%F|%s|%Y', path].map(shellEscape).join(' ');
+  let statOut: string;
+  try {
+    statOut = execSync(statCmd, { encoding: 'utf8' });
+  } catch {
     return {
       exists: false,
       is_directory: false,
@@ -36,8 +37,7 @@ function probePath(path: string): FsInfo {
     };
   }
 
-  const out = new TextDecoder().decode(proc.stdout).trim();
-  const parts = out.split('|');
+  const parts = statOut.trim().split('|');
   const kind = parts[0] ?? '';
   const sizeBytes = parseInt(parts[1] ?? '0', 10) || 0;
   const mtimeSecs = parseInt(parts[2] ?? '0', 10) || 0;
@@ -45,13 +45,18 @@ function probePath(path: string): FsInfo {
 
   let empty: boolean;
   if (isDirectory) {
-    // For a directory, "empty" means no entries.
-    const ls = Bun.spawnSync({
-      cmd: ['sh', '-c', `ls -A ${JSON.stringify(path)}`],
-      stderr: 'pipe',
-    });
-    const lsOut = new TextDecoder().decode(ls.stdout).trim();
-    empty = lsOut.length === 0;
+    // For a directory, "empty" means no entries. `ls -A` lists everything
+    // except '.' and '..'; empty stdout means an empty dir. If `ls` fails
+    // for any reason (permissions, race), preserve the original semantics
+    // by treating it as empty.
+    const lsCmd = ['ls', '-A', path].map(shellEscape).join(' ');
+    let lsOut = '';
+    try {
+      lsOut = execSync(lsCmd, { encoding: 'utf8' });
+    } catch {
+      lsOut = '';
+    }
+    empty = lsOut.trim().length === 0;
   } else {
     empty = sizeBytes === 0;
   }

--- a/handlers/drift_check_path_exists.ts
+++ b/handlers/drift_check_path_exists.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'child_process';
 import { isAbsolute, join } from 'path';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
@@ -15,18 +16,22 @@ function resolvePath(path: string): string {
   return isAbsolute(path) ? path : join(projectDir(), path);
 }
 
-async function probe(absPath: string): Promise<{ exists: boolean; kind: 'file' | 'directory' | null }> {
-  // Use Bun.spawnSync('stat', ...) to distinguish file vs directory
-  // without touching node:fs or child_process (both have mock collisions
-  // with sibling tests).
-  const proc = Bun.spawnSync({
-    cmd: ['stat', '-c', '%F', absPath],
-    stderr: 'pipe',
-  });
-  if (proc.exitCode !== 0) {
+function shellEscape(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function probe(absPath: string): { exists: boolean; kind: 'file' | 'directory' | null } {
+  // `stat -c %F` prints "regular file" / "directory" / "symbolic link" / etc.
+  // execSync throws on non-zero exit (i.e. path missing) — catch and report
+  // exists:false so callers don't need to distinguish missing from error.
+  const cmd = ['stat', '-c', '%F', absPath].map(shellEscape).join(' ');
+  let stdout: string;
+  try {
+    stdout = execSync(cmd, { encoding: 'utf8' });
+  } catch {
     return { exists: false, kind: null };
   }
-  const out = new TextDecoder().decode(proc.stdout).trim();
+  const out = stdout.trim();
   if (out === 'directory') return { exists: true, kind: 'directory' };
   // 'regular file', 'regular empty file', 'symbolic link' (resolved), etc.
   return { exists: true, kind: 'file' };
@@ -49,7 +54,7 @@ const driftCheckPathExistsHandler: HandlerDef = {
 
     try {
       const abs = resolvePath(args.path);
-      const result = await probe(abs);
+      const result = probe(abs);
 
       let exists = result.exists;
       if (exists && args.kind !== 'any' && result.kind !== args.kind) {

--- a/handlers/pr_comment.ts
+++ b/handlers/pr_comment.ts
@@ -2,8 +2,14 @@
 // See docs/handlers/origin-operations-guide.md for the canonical pattern,
 // gh ↔ glab field mappings, and normalized response schemas.
 
+import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
+
+// Codebase convention: child_process.execSync (29/36 handlers, including
+// pr_merge / pr_create). Tests mock it via `mock.module('child_process', ...)`.
+// This handler was migrated from Bun's spawn API for uniformity (#253) so the
+// adapter retrofit can stub the subprocess boundary in one place.
 
 const inputSchema = z.object({
   number: z.number().int().positive('number must be a positive integer'),
@@ -20,33 +26,49 @@ function projectDir(): string {
   return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
 }
 
-interface SpawnResult {
+interface RunResult {
   exitCode: number;
   stdout: string;
   stderr: string;
 }
 
-function runCommand(cmd: string[], cwd: string): SpawnResult {
-  // Bun.spawnSync with an arg array preserves unicode, code fences, and
-  // multi-line markdown verbatim — no shell quoting required.
-  // Passing `env: process.env` explicitly ensures we honour any PATH
-  // mutations the caller has made since Bun startup.
-  const proc = Bun.spawnSync({
-    cmd,
-    cwd,
-    env: process.env as Record<string, string>,
-    stdout: 'pipe',
-    stderr: 'pipe',
-  });
-  return {
-    exitCode: proc.exitCode ?? -1,
-    stdout: new TextDecoder().decode(proc.stdout),
-    stderr: new TextDecoder().decode(proc.stderr),
-  };
+interface ExecError extends Error {
+  stdout?: Buffer | string;
+  stderr?: Buffer | string;
+  status?: number;
+}
+
+function bufToString(b: unknown): string {
+  if (b === undefined || b === null) return '';
+  if (typeof b === 'string') return b;
+  if (typeof (b as Buffer).toString === 'function') return (b as Buffer).toString();
+  return String(b);
+}
+
+function shellEscape(value: string): string {
+  // Single-quote the arg and escape any embedded single quotes — same form
+  // as pr_merge.ts / pr_create.ts. Safe for arbitrary user-supplied strings
+  // (markdown bodies, branch names) when the shell is invoked.
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function run(cmd: string[], cwd: string): RunResult {
+  const shellCmd = cmd.map(shellEscape).join(' ');
+  try {
+    const stdout = execSync(shellCmd, { cwd, encoding: 'utf8' });
+    return { exitCode: 0, stdout, stderr: '' };
+  } catch (err) {
+    const e = err as ExecError;
+    return {
+      exitCode: typeof e.status === 'number' ? e.status : -1,
+      stdout: bufToString(e.stdout),
+      stderr: bufToString(e.stderr) || (err instanceof Error ? err.message : String(err)),
+    };
+  }
 }
 
 function detectPlatform(cwd: string): 'github' | 'gitlab' {
-  const proc = runCommand(['git', 'remote', 'get-url', 'origin'], cwd);
+  const proc = run(['git', 'remote', 'get-url', 'origin'], cwd);
   if (proc.exitCode !== 0) return 'github';
   const url = proc.stdout.trim();
   return url.includes('gitlab') ? 'gitlab' : 'github';
@@ -80,7 +102,7 @@ function postGithubComment(num: number, body: string, cwd: string, repo?: string
   if (repo !== undefined) {
     cmd.push('--repo', repo);
   }
-  const proc = runCommand(cmd, cwd);
+  const proc = run(cmd, cwd);
   if (proc.exitCode !== 0) {
     throw new Error(`gh pr comment failed: ${proc.stderr.trim() || proc.stdout.trim()}`);
   }
@@ -97,7 +119,7 @@ function postGitlabComment(num: number, body: string, cwd: string, repo?: string
   if (repo !== undefined) {
     cmd.push('-R', repo);
   }
-  const proc = runCommand(cmd, cwd);
+  const proc = run(cmd, cwd);
   if (proc.exitCode !== 0) {
     throw new Error(`glab mr note failed: ${proc.stderr.trim() || proc.stdout.trim()}`);
   }

--- a/tests/dod_run_test_suite.test.ts
+++ b/tests/dod_run_test_suite.test.ts
@@ -1,12 +1,57 @@
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
 
-// This handler uses Bun.spawnSync + Bun.file (native APIs), so tests
-// work against real tempdirs and real shell commands. No module mocks.
+// dod_run_test_suite now uses child_process.execSync for the actual command
+// execution (story #253). Discovery still uses Bun.file (not subprocess) so it
+// stays outside the mock surface and works against real fixture dirs.
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+type Responder = string | (() => string);
+
+let execRegistry: Array<{ match: string; respond: Responder }> = [];
+let execCalls: string[] = [];
+
+function mockExec(cmd: string): string {
+  execCalls.push(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec call: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec call: ${cmd}`;
+  err.status = 127;
+  throw err;
+}
+
+mock.module('child_process', () => ({
+  execSync: (cmd: string, _opts?: unknown) => mockExec(cmd),
+}));
 
 const { default: handler } = await import('../handlers/dod_run_test_suite.ts');
 
 function parseResult(result: { content: Array<{ type: string; text: string }> }) {
   return JSON.parse(result.content[0].text);
+}
+
+function onExec(match: string, respond: Responder) {
+  execRegistry.push({ match, respond });
+}
+
+function failExec(match: string, stdout: string, status: number = 1): void {
+  // For dod_run_test_suite the runner appends `2>&1`, so on failure the merged
+  // stream lands in err.stdout (not err.stderr). Mirror that here.
+  onExec(match, () => {
+    const err = new Error('command failed') as ThrowableError;
+    err.stdout = stdout;
+    err.stderr = '';
+    err.status = status;
+    throw err;
+  });
 }
 
 let fixtureDir = '';
@@ -28,15 +73,20 @@ async function makeFixture(files: Record<string, string>): Promise<string> {
   return dir;
 }
 
-describe('dod_run_test_suite handler', () => {
-  beforeEach(() => {
-    fixtureDir = '';
-  });
-  afterEach(() => {
-    fixtureDir = '';
-    restoreEnv();
-  });
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+  fixtureDir = '';
+});
 
+afterEach(() => {
+  execRegistry = [];
+  execCalls = [];
+  fixtureDir = '';
+  restoreEnv();
+});
+
+describe('dod_run_test_suite handler', () => {
   test('handler exports valid HandlerDef shape', () => {
     expect(handler.name).toBe('dod_run_test_suite');
     expect(typeof handler.execute).toBe('function');
@@ -47,6 +97,8 @@ describe('dod_run_test_suite handler', () => {
       'package.json': JSON.stringify({ scripts: { test: 'echo should-not-run' } }),
     });
     process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+    onExec('echo "1 passed, 0 failed"', '1 passed, 0 failed\n');
+
     const result = await handler.execute({ command: 'echo "1 passed, 0 failed"' });
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
@@ -54,6 +106,9 @@ describe('dod_run_test_suite handler', () => {
     expect(parsed.exit_code).toBe(0);
     expect(parsed.passed).toBe(1);
     expect(parsed.failed).toBe(0);
+
+    // The override path means discovery never reached package.json's script.
+    expect(execCalls.some((c) => c.includes('should-not-run'))).toBe(false);
   });
 
   test('discovers_scripts_ci_test — prefers scripts/ci/test.sh when present', async () => {
@@ -61,21 +116,52 @@ describe('dod_run_test_suite handler', () => {
       'scripts/ci/test.sh': '#!/bin/sh\necho "5 pass\\n0 fail"\n',
       'package.json': JSON.stringify({ scripts: { test: 'should-not-see' } }),
     });
-    // Make it executable.
-    Bun.spawnSync({ cmd: ['chmod', '+x', `${fixtureDir}/scripts/ci/test.sh`] });
+    // Discovery uses Bun.file().exists() — doesn't actually need execute bit.
     process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+    onExec('./scripts/ci/test.sh', '5 pass\n0 fail\n');
+
     const result = await handler.execute({});
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
     expect(parsed.command).toBe('./scripts/ci/test.sh');
+    expect(parsed.passed).toBe(5);
+    expect(parsed.failed).toBe(0);
+    // Discovery picked scripts/ci/test.sh, not the package.json fallback.
+    expect(execCalls.some((c) => c.includes('npm test'))).toBe(false);
+  });
+
+  test('discovers_npm_test — falls back to npm test when only package.json present', async () => {
+    fixtureDir = await makeFixture({
+      'package.json': JSON.stringify({ scripts: { test: 'jest' } }),
+    });
+    process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+    onExec('npm test', '7 pass\n0 fail\n');
+
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.command).toBe('npm test');
+    expect(parsed.passed).toBe(7);
+  });
+
+  test('discovers_pytest — uses pytest when only pyproject.toml present', async () => {
+    fixtureDir = await makeFixture({ 'pyproject.toml': '[project]\nname="x"\n' });
+    process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+    onExec('pytest', '===== 4 passed in 1s =====\n');
+
+    const result = await handler.execute({});
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.command).toBe('pytest');
+    expect(parsed.passed).toBe(4);
   });
 
   test('parses_bun_test_output', async () => {
     fixtureDir = await makeFixture({ 'noop.txt': 'x' });
     process.env.CLAUDE_PROJECT_DIR = fixtureDir;
-    const result = await handler.execute({
-      command: 'echo " 42 pass\\n 3 fail\\n 1 skip"',
-    });
+    onExec('bun test simulated', ' 42 pass\n 3 fail\n 1 skip\n');
+
+    const result = await handler.execute({ command: 'bun test simulated' });
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
     expect(parsed.passed).toBe(42);
@@ -86,9 +172,12 @@ describe('dod_run_test_suite handler', () => {
   test('parses_pytest_output', async () => {
     fixtureDir = await makeFixture({ 'noop.txt': 'x' });
     process.env.CLAUDE_PROJECT_DIR = fixtureDir;
-    const result = await handler.execute({
-      command: 'echo "===== 10 passed, 2 failed, 1 skipped in 3.21s ====="',
-    });
+    onExec(
+      'pytest -q',
+      '===== 10 passed, 2 failed, 1 skipped in 3.21s =====\n',
+    );
+
+    const result = await handler.execute({ command: 'pytest -q' });
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
     expect(parsed.passed).toBe(10);
@@ -99,24 +188,42 @@ describe('dod_run_test_suite handler', () => {
   test('exit_code_nonzero_sets_failed — command fails, structured response not thrown', async () => {
     fixtureDir = await makeFixture({ 'noop.txt': 'x' });
     process.env.CLAUDE_PROJECT_DIR = fixtureDir;
-    const result = await handler.execute({
-      command: 'sh -c "echo \\"0 passed, 5 failed\\"; exit 1"',
-    });
+    failExec('failing-tests', '0 passed, 5 failed\n', 1);
+
+    const result = await handler.execute({ command: 'failing-tests' });
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
     expect(parsed.exit_code).not.toBe(0);
     expect(parsed.failed).toBe(5);
+    expect(parsed.raw_output).toContain('0 passed, 5 failed');
   });
 
   test('no_test_command_found_returns_error', async () => {
+    // A nonexistent root yields false from every Bun.file().exists() probe,
+    // which is functionally identical to "exists but contains no manifest"
+    // for the discovery code path. Skips the create-then-rm fixture dance.
     fixtureDir = `/tmp/dod-test-suite-empty-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
-    // Ensure dir exists.
-    await Bun.write(`${fixtureDir}/.keep`, '');
-    Bun.spawnSync({ cmd: ['rm', `${fixtureDir}/.keep`] });
     process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+
     const result = await handler.execute({});
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain('no test command found');
+    // No subprocess should be invoked when discovery returns null.
+    expect(execCalls.length).toBe(0);
+  });
+
+  // --- boundary test (per #253 / Story 1.1 test-procedure ledger) ---
+
+  test('execSync invocation appends 2>&1 to merge stderr into stdout', async () => {
+    fixtureDir = await makeFixture({ 'noop.txt': 'x' });
+    process.env.CLAUDE_PROJECT_DIR = fixtureDir;
+    onExec('shape-check-cmd', '1 pass\n');
+
+    await handler.execute({ command: 'shape-check-cmd' });
+
+    expect(execCalls.length).toBe(1);
+    // The literal command + the 2>&1 redirect for merged-stream capture.
+    expect(execCalls[0]).toBe('shape-check-cmd 2>&1');
   });
 });

--- a/tests/dod_verify_deliverable.test.ts
+++ b/tests/dod_verify_deliverable.test.ts
@@ -1,7 +1,42 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
 
-// This handler uses Bun.spawnSync('stat', ...) directly rather than any
-// mockable module, so tests operate against real files/directories in /tmp.
+// dod_verify_deliverable now uses child_process.execSync (story #253). Tests
+// intercept the boundary via `mock.module('child_process', ...)`. Each test
+// populates `execRegistry` with substring → responder mappings; an unmatched
+// call throws so missing stubs surface loudly.
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+type Responder = string | (() => string);
+
+let execRegistry: Array<{ match: string; respond: Responder }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+function mockExec(cmd: string): string {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec call: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec call: ${cmd}`;
+  err.status = 127;
+  throw err;
+}
+
+mock.module('child_process', () => ({
+  execSync: (cmd: string, _opts?: unknown) => mockExec(cmd),
+}));
 
 const { default: handler } = await import('../handlers/dod_verify_deliverable.ts');
 
@@ -9,32 +44,29 @@ function parseResult(result: { content: Array<{ type: string; text: string }> })
   return JSON.parse(result.content[0].text);
 }
 
-async function tempFile(content: string): Promise<string> {
-  const path = `/tmp/dod-verify-${Date.now()}-${Math.floor(Math.random() * 1e9)}.txt`;
-  await Bun.write(path, content);
-  return path;
+function onExec(match: string, respond: Responder) {
+  execRegistry.push({ match, respond });
 }
 
-async function tempEmptyFile(): Promise<string> {
-  const path = `/tmp/dod-verify-empty-${Date.now()}-${Math.floor(Math.random() * 1e9)}.txt`;
-  await Bun.write(path, '');
-  return path;
+function failExec(match: string, stderr: string = 'No such file or directory', status: number = 1): void {
+  onExec(match, () => {
+    const err = new Error(stderr) as ThrowableError;
+    err.stderr = stderr;
+    err.stdout = '';
+    err.status = status;
+    throw err;
+  });
 }
 
-async function tempDirWithFile(): Promise<string> {
-  const dir = `/tmp/dod-verify-dir-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
-  await Bun.write(`${dir}/inner.txt`, 'hello');
-  return dir;
-}
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
 
-async function tempEmptyDir(): Promise<string> {
-  const dir = `/tmp/dod-verify-empty-dir-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
-  // Create the directory by writing and removing a sentinel via Bun shell.
-  await Bun.write(`${dir}/.keep`, '');
-  // Now delete the file but keep the directory.
-  Bun.spawnSync({ cmd: ['rm', `${dir}/.keep`] });
-  return dir;
-}
+afterEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
 
 describe('dod_verify_deliverable handler', () => {
   test('handler exports valid HandlerDef shape', () => {
@@ -43,41 +75,53 @@ describe('dod_verify_deliverable handler', () => {
   });
 
   test('existing_file — returns exists=true, empty=false, size>0', async () => {
-    const path = await tempFile('some content');
+    const path = '/tmp/dod-evidence-1.txt';
+    // mtime: 1700000000s → 2023-11-14T22:13:20.000Z
+    onExec(`stat -c %F|%s|%Y ${path}`, 'regular file|123|1700000000\n');
+
     const result = await handler.execute({ id: 'D-01', evidence_path: path });
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
     expect(parsed.exists).toBe(true);
     expect(parsed.empty).toBe(false);
-    expect(parsed.size_bytes).toBeGreaterThan(0);
+    expect(parsed.size_bytes).toBe(123);
     expect(parsed.is_directory).toBe(false);
     expect(parsed.id).toBe('D-01');
+    expect(parsed.last_modified).toBe('2023-11-14T22:13:20.000Z');
   });
 
-  test('existing_empty_file — exists=true, empty=true', async () => {
-    const path = await tempEmptyFile();
+  test('existing_empty_file — exists=true, empty=true, size=0', async () => {
+    const path = '/tmp/dod-evidence-empty.txt';
+    onExec(`stat -c %F|%s|%Y ${path}`, 'regular file|0|1700000000\n');
+
     const result = await handler.execute({ id: 'D-02', evidence_path: path });
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
     expect(parsed.exists).toBe(true);
     expect(parsed.empty).toBe(true);
     expect(parsed.size_bytes).toBe(0);
+    expect(parsed.is_directory).toBe(false);
   });
 
-  test('missing_path — exists=false', async () => {
-    const result = await handler.execute({
-      id: 'D-03',
-      evidence_path: '/tmp/definitely-nonexistent-path-xyz-987654321',
-    });
+  test('missing_path — exists=false, empty=true', async () => {
+    const path = '/tmp/definitely-nonexistent-path-xyz-987654321';
+    failExec(`stat -c %F|%s|%Y ${path}`);
+
+    const result = await handler.execute({ id: 'D-03', evidence_path: path });
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
     expect(parsed.exists).toBe(false);
     expect(parsed.empty).toBe(true);
+    expect(parsed.size_bytes).toBe(0);
+    expect(parsed.last_modified).toBe(null);
   });
 
-  test('directory_with_contents — exists=true, is_directory=true, empty=false', async () => {
-    const dir = await tempDirWithFile();
-    const result = await handler.execute({ id: 'D-04', evidence_path: dir });
+  test('directory_with_contents — is_directory=true, empty=false', async () => {
+    const path = '/tmp/dod-dir-with-files';
+    onExec(`stat -c %F|%s|%Y ${path}`, 'directory|4096|1700000000\n');
+    onExec(`ls -A ${path}`, 'inner.txt\nsibling.md\n');
+
+    const result = await handler.execute({ id: 'D-04', evidence_path: path });
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
     expect(parsed.exists).toBe(true);
@@ -85,9 +129,26 @@ describe('dod_verify_deliverable handler', () => {
     expect(parsed.empty).toBe(false);
   });
 
-  test('empty_directory — exists=true, is_directory=true, empty=true', async () => {
-    const dir = await tempEmptyDir();
-    const result = await handler.execute({ id: 'D-05', evidence_path: dir });
+  test('empty_directory — is_directory=true, empty=true', async () => {
+    const path = '/tmp/dod-empty-dir';
+    onExec(`stat -c %F|%s|%Y ${path}`, 'directory|4096|1700000000\n');
+    onExec(`ls -A ${path}`, '\n');
+
+    const result = await handler.execute({ id: 'D-05', evidence_path: path });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.exists).toBe(true);
+    expect(parsed.is_directory).toBe(true);
+    expect(parsed.empty).toBe(true);
+  });
+
+  test('directory_with_failed_ls — preserves original semantics: empty=true', async () => {
+    // Original handler swallows ls errors and treats as empty. Preserved post-refactor.
+    const path = '/tmp/dod-perm-denied';
+    onExec(`stat -c %F|%s|%Y ${path}`, 'directory|4096|1700000000\n');
+    failExec(`ls -A ${path}`, 'Permission denied');
+
+    const result = await handler.execute({ id: 'D-06', evidence_path: path });
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
     expect(parsed.exists).toBe(true);
@@ -99,11 +160,37 @@ describe('dod_verify_deliverable handler', () => {
     const result = await handler.execute({ evidence_path: '/tmp/x' });
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(false);
+    expect(execCalls.length).toBe(0);
   });
 
   test('schema_validation — rejects missing evidence_path', async () => {
     const result = await handler.execute({ id: 'D-01' });
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(false);
+    expect(execCalls.length).toBe(0);
+  });
+
+  // --- boundary test (per #253 / Story 1.1 test-procedure ledger) ---
+
+  test('execSync invocation matches stat CLI shape (file path)', async () => {
+    const path = '/tmp/shape-check';
+    onExec(`stat -c %F|%s|%Y ${path}`, 'regular file|10|1700000000\n');
+
+    await handler.execute({ id: 'D-X', evidence_path: path });
+
+    expect(execCalls.length).toBe(1);
+    expect(execCalls[0]).toBe(`'stat' '-c' '%F|%s|%Y' '${path}'`);
+  });
+
+  test('execSync invocation matches ls CLI shape (directory path)', async () => {
+    const path = '/tmp/shape-check-dir';
+    onExec(`stat -c %F|%s|%Y ${path}`, 'directory|4096|1700000000\n');
+    onExec(`ls -A ${path}`, 'a\n');
+
+    await handler.execute({ id: 'D-X', evidence_path: path });
+
+    expect(execCalls.length).toBe(2);
+    expect(execCalls[0]).toBe(`'stat' '-c' '%F|%s|%Y' '${path}'`);
+    expect(execCalls[1]).toBe(`'ls' '-A' '${path}'`);
   });
 });

--- a/tests/drift_check_path_exists.test.ts
+++ b/tests/drift_check_path_exists.test.ts
@@ -1,7 +1,42 @@
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
 
-// Uses Bun.spawnSync('stat', ...) in the handler, so no module mocks.
-// Tests operate on real files/directories in /tmp.
+// drift_check_path_exists now uses child_process.execSync (story #253). Tests
+// intercept the boundary via `mock.module('child_process', ...)`. Each test
+// populates `execRegistry` with substring → responder mappings; an unmatched
+// call throws so missing stubs surface loudly.
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+type Responder = string | (() => string);
+
+let execRegistry: Array<{ match: string; respond: Responder }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+function mockExec(cmd: string): string {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec call: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec call: ${cmd}`;
+  err.status = 127;
+  throw err;
+}
+
+mock.module('child_process', () => ({
+  execSync: (cmd: string, _opts?: unknown) => mockExec(cmd),
+}));
 
 const { default: handler } = await import('../handlers/drift_check_path_exists.ts');
 
@@ -9,8 +44,30 @@ function parseResult(result: { content: Array<{ type: string; text: string }> })
   return JSON.parse(result.content[0].text);
 }
 
-let fixtureDir = '';
+function onExec(match: string, respond: Responder) {
+  execRegistry.push({ match, respond });
+}
+
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+}
+
+function failExec(match: string, stderr: string = 'No such file or directory', status: number = 1): void {
+  onExec(match, () => {
+    const err = new Error(stderr) as ThrowableError;
+    err.stderr = stderr;
+    err.stdout = '';
+    err.status = status;
+    throw err;
+  });
+}
+
 const ORIGINAL_ENV = process.env.CLAUDE_PROJECT_DIR;
+const FIXTURE_ROOT = '/tmp/drift-fixture-root';
+
+function setProjectDir() {
+  process.env.CLAUDE_PROJECT_DIR = FIXTURE_ROOT;
+}
 
 function restoreEnv() {
   if (ORIGINAL_ENV === undefined) {
@@ -20,30 +77,27 @@ function restoreEnv() {
   }
 }
 
-async function setupProject(files: Record<string, string>) {
-  fixtureDir = `/tmp/drift-path-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
-  for (const [name, content] of Object.entries(files)) {
-    await Bun.write(`${fixtureDir}/${name}`, content);
-  }
-  process.env.CLAUDE_PROJECT_DIR = fixtureDir;
-}
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+  setProjectDir();
+});
+
+afterEach(() => {
+  execRegistry = [];
+  execCalls = [];
+  restoreEnv();
+});
 
 describe('drift_check_path_exists handler', () => {
-  beforeEach(() => {
-    fixtureDir = '';
-  });
-  afterEach(() => {
-    fixtureDir = '';
-    restoreEnv();
-  });
-
   test('handler exports valid HandlerDef shape', () => {
     expect(handler.name).toBe('drift_check_path_exists');
     expect(typeof handler.execute).toBe('function');
   });
 
   test('file_exists — returns exists=true, actual_kind=file', async () => {
-    await setupProject({ 'src/foo.ts': 'export const x = 1;' });
+    onExec(`stat -c %F ${FIXTURE_ROOT}/src/foo.ts`, 'regular file\n');
+
     const result = await handler.execute({ path: 'src/foo.ts' });
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
@@ -52,7 +106,8 @@ describe('drift_check_path_exists handler', () => {
   });
 
   test('file_missing — exists=false', async () => {
-    await setupProject({ 'a.txt': 'hi' });
+    failExec(`stat -c %F ${FIXTURE_ROOT}/nonexistent.txt`);
+
     const result = await handler.execute({ path: 'nonexistent.txt' });
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
@@ -61,7 +116,8 @@ describe('drift_check_path_exists handler', () => {
   });
 
   test('directory_exists_as_directory', async () => {
-    await setupProject({ 'handlers/inner.ts': 'x' });
+    onExec(`stat -c %F ${FIXTURE_ROOT}/handlers`, 'directory\n');
+
     const result = await handler.execute({ path: 'handlers', kind: 'directory' });
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
@@ -70,40 +126,71 @@ describe('drift_check_path_exists handler', () => {
   });
 
   test('kind_mismatch — file exists but kind=directory → exists=false', async () => {
-    await setupProject({ 'file.txt': 'hi' });
+    onExec(`stat -c %F ${FIXTURE_ROOT}/file.txt`, 'regular file\n');
+
     const result = await handler.execute({ path: 'file.txt', kind: 'directory' });
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
     expect(parsed.exists).toBe(false);
+    // actual_kind reports what was found, even when the kind filter rejects it.
     expect(parsed.actual_kind).toBe('file');
   });
 
   test('relative_path_anchoring — resolved against CLAUDE_PROJECT_DIR', async () => {
-    await setupProject({ 'nested/deep/file.ts': 'x' });
+    onExec(`stat -c %F ${FIXTURE_ROOT}/nested/deep/file.ts`, 'regular file\n');
+
     const result = await handler.execute({ path: 'nested/deep/file.ts' });
     const parsed = parseResult(result);
     expect(parsed.exists).toBe(true);
-    expect(parsed.resolved).toContain(fixtureDir);
+    expect(parsed.resolved).toBe(`${FIXTURE_ROOT}/nested/deep/file.ts`);
   });
 
   test('absolute_path_preserved', async () => {
-    await setupProject({ 'a.txt': 'x' });
-    const absPath = `${fixtureDir}/a.txt`;
+    const absPath = '/tmp/some-absolute/file.txt';
+    onExec(`stat -c %F ${absPath}`, 'regular file\n');
+
     const result = await handler.execute({ path: absPath });
     const parsed = parseResult(result);
     expect(parsed.exists).toBe(true);
     expect(parsed.resolved).toBe(absPath);
   });
 
+  test('symbolic_link_reported_as_file', async () => {
+    onExec(`stat -c %F ${FIXTURE_ROOT}/link`, 'symbolic link\n');
+
+    const result = await handler.execute({ path: 'link' });
+    const parsed = parseResult(result);
+    expect(parsed.exists).toBe(true);
+    // Per handler: anything not 'directory' falls into 'file' bucket.
+    expect(parsed.actual_kind).toBe('file');
+  });
+
   test('schema_validation — rejects missing path', async () => {
     const result = await handler.execute({});
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(false);
+    // No execSync should have been called.
+    expect(execCalls.length).toBe(0);
   });
 
   test('schema_validation — rejects invalid kind', async () => {
     const result = await handler.execute({ path: 'x', kind: 'bogus' });
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(false);
+    expect(execCalls.length).toBe(0);
+  });
+
+  // --- boundary test (per #253 / Story 1.1 test-procedure ledger) ---
+
+  test('execSync invocation matches stat CLI shape', async () => {
+    onExec(`stat -c %F ${FIXTURE_ROOT}/probe.ts`, 'regular file\n');
+
+    await handler.execute({ path: 'probe.ts' });
+
+    expect(execCalls.length).toBe(1);
+    // Fully shell-escaped: every token wrapped in '...'.
+    expect(execCalls[0]).toMatch(
+      new RegExp(`^'stat' '-c' '%F' '${FIXTURE_ROOT}/probe\\.ts'$`),
+    );
   });
 });

--- a/tests/pr_comment.test.ts
+++ b/tests/pr_comment.test.ts
@@ -1,8 +1,47 @@
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
 
-// This handler uses Bun.spawnSync directly (no child_process, no node:fs),
-// so tests run against real fixture shell scripts placed on a scoped PATH.
-// No module mocks.
+// pr_comment now uses child_process.execSync (story #253 — sweep follow-up to
+// #238). Tests intercept the boundary via `mock.module('child_process', ...)`
+// — same pattern as pr_create.test.ts and pr_merge.test.ts. Each test populates
+// `execRegistry` with substring → responder mappings; an unmatched call throws
+// so missing stubs surface loudly.
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+type Responder = string | (() => string);
+
+let execRegistry: Array<{ match: string; respond: Responder }> = [];
+let execCalls: string[] = [];
+
+// Strip the shell-quoting layer the handler applies so test match-keys can be
+// authored as plain `gh pr comment` rather than `'gh' 'pr' 'comment'`. We only
+// remove single-quotes that surround whole tokens — argument values that
+// happen to contain quoted substrings still match correctly.
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+function mockExec(cmd: string): string {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec call: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec call: ${cmd}`;
+  err.status = 127;
+  throw err;
+}
+
+mock.module('child_process', () => ({
+  execSync: (cmd: string, _opts?: unknown) => mockExec(cmd),
+}));
 
 const { default: handler } = await import('../handlers/pr_comment.ts');
 
@@ -10,167 +49,81 @@ function parseResult(result: { content: Array<{ type: string; text: string }> })
   return JSON.parse(result.content[0].text) as Record<string, unknown>;
 }
 
-const ORIGINAL_PATH = process.env.PATH;
-const ORIGINAL_PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR;
-
-let fixtureDir = '';
-
-function restoreEnv() {
-  process.env.PATH = ORIGINAL_PATH;
-  if (ORIGINAL_PROJECT_DIR === undefined) {
-    delete process.env.CLAUDE_PROJECT_DIR;
-  } else {
-    process.env.CLAUDE_PROJECT_DIR = ORIGINAL_PROJECT_DIR;
-  }
+function onExec(match: string, respond: Responder) {
+  execRegistry.push({ match, respond });
 }
 
-/**
- * Build a fixture directory with:
- *   - bin/gh, bin/glab, bin/git shell scripts (made executable)
- *   - a dummy working tree
- * Returns the absolute fixture path and updates PATH + CLAUDE_PROJECT_DIR.
- *
- * The shell scripts log their invocations to `bin/.calls` (one JSON line each)
- * so tests can assert the exact body the handler passed via argv.
- */
-async function makeFixture(bins: Record<string, string>): Promise<string> {
-  const dir = `/tmp/pr-comment-test-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
-  await Bun.write(`${dir}/.keep`, '');
-  for (const [name, script] of Object.entries(bins)) {
-    const path = `${dir}/bin/${name}`;
-    await Bun.write(path, script);
-    Bun.spawnSync({ cmd: ['chmod', '+x', path] });
-  }
-  process.env.PATH = `${dir}/bin:${ORIGINAL_PATH}`;
-  process.env.CLAUDE_PROJECT_DIR = dir;
-  return dir;
+// Locate a recorded call whose unquoted form contains `needle`. Returns the
+// raw (still-quoted) call so flag-presence assertions still see the literal
+// argv (e.g. `--repo`, `-R`).
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
 }
 
-/**
- * A fake `git` that answers `git remote get-url origin` with the given URL
- * and errors on anything else. Used to steer platform detection.
- */
-function fakeGit(originUrl: string): string {
-  return `#!/bin/sh
-if [ "$1" = "remote" ] && [ "$2" = "get-url" ] && [ "$3" = "origin" ]; then
-  echo "${originUrl}"
-  exit 0
-fi
-echo "unexpected git call: $*" >&2
-exit 1
-`;
+function failExec(match: string, stderr: string, status: number = 1): void {
+  onExec(match, () => {
+    const err = new Error(stderr) as ThrowableError;
+    err.stderr = stderr;
+    err.stdout = '';
+    err.status = status;
+    throw err;
+  });
 }
 
-/**
- * A fake `gh` that records its argv to $FIXTURE/bin/.calls and prints a
- * canned URL so the handler can parse the comment ID. The PR number and
- * comment ID come from env so each test can customize them.
- */
-function fakeGh(prNum: number, commentId: number): string {
-  // Record args separated by \x1f (unit separator), calls separated by \x1e
-  // (record separator) — neither collides with markdown content.
-  return `#!/bin/sh
-{
-  printf '\\036'
-  first=1
-  for a in "$@"; do
-    if [ $first -eq 1 ]; then
-      first=0
-    else
-      printf '\\037'
-    fi
-    printf '%s' "$a"
-  done
-} >> "$(dirname "$0")/.calls"
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
 
-if [ "$1" = "pr" ] && [ "$2" = "comment" ]; then
-  echo "https://github.com/org/repo/pull/${prNum}#issuecomment-${commentId}"
-  exit 0
-fi
-echo "unexpected gh call" >&2
-exit 1
-`;
-}
-
-/**
- * A fake `glab` that records its argv and prints a canned MR note URL.
- */
-function fakeGlab(mrNum: number, noteId: number): string {
-  return `#!/bin/sh
-{
-  printf '\\036'
-  first=1
-  for a in "$@"; do
-    if [ $first -eq 1 ]; then
-      first=0
-    else
-      printf '\\037'
-    fi
-    printf '%s' "$a"
-  done
-} >> "$(dirname "$0")/.calls"
-
-if [ "$1" = "mr" ] && [ "$2" = "note" ]; then
-  echo "https://gitlab.com/org/repo/-/merge_requests/${mrNum}#note_${noteId}"
-  exit 0
-fi
-echo "unexpected glab call" >&2
-exit 1
-`;
-}
-
-async function readCalls(dir: string): Promise<string[][]> {
-  const file = Bun.file(`${dir}/bin/.calls`);
-  if (!(await file.exists())) return [];
-  const text = await file.text();
-  // Records separated by \x1e, fields within a record by \x1f.
-  return text
-    .split('\x1e')
-    .filter((rec) => rec.length > 0)
-    .map((rec) => rec.split('\x1f'));
-}
+afterEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
 
 describe('pr_comment handler', () => {
-  beforeEach(() => {
-    fixtureDir = '';
-  });
-  afterEach(() => {
-    fixtureDir = '';
-    restoreEnv();
-  });
-
   test('handler exports valid HandlerDef shape', () => {
     expect(handler.name).toBe('pr_comment');
     expect(typeof handler.execute).toBe('function');
     expect(handler.description.length).toBeGreaterThan(0);
   });
 
+  // --- schema validation ---
+
   test('rejects missing number', async () => {
-    fixtureDir = await makeFixture({
-      git: fakeGit('https://github.com/org/repo.git'),
-      gh: fakeGh(1, 1),
-    });
     const result = await handler.execute({ body: 'hi' });
     const data = parseResult(result);
     expect(data.ok).toBe(false);
   });
 
   test('rejects empty body', async () => {
-    fixtureDir = await makeFixture({
-      git: fakeGit('https://github.com/org/repo.git'),
-      gh: fakeGh(1, 1),
-    });
     const result = await handler.execute({ number: 12, body: '' });
     const data = parseResult(result);
     expect(data.ok).toBe(false);
-    expect((data.error as string)).toContain('body');
+    expect(data.error as string).toContain('body');
   });
 
-  test('github — plain text comment returns numeric comment_id and url', async () => {
-    fixtureDir = await makeFixture({
-      git: fakeGit('https://github.com/org/repo.git'),
-      gh: fakeGh(42, 1001),
+  test('invalid_slug_early_error — returns ok:false without spawning gh/glab', async () => {
+    // No execRegistry entries — any spawn would throw 'Unexpected exec call'.
+    const result = await handler.execute({
+      number: 1,
+      body: 'x',
+      repo: 'not-a-slug',
     });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+    expect(String(data.error)).toContain('repo');
+    // No execSync calls should have been made.
+    expect(execCalls.length).toBe(0);
+  });
+
+  // --- github happy paths ---
+
+  test('github — plain text comment returns numeric comment_id and url', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    onExec(
+      'gh pr comment 42',
+      'https://github.com/org/repo/pull/42#issuecomment-1001\n',
+    );
 
     const result = await handler.execute({ number: 42, body: 'looks good' });
     const data = parseResult(result);
@@ -180,18 +133,22 @@ describe('pr_comment handler', () => {
     expect(data.comment_id).toBe(1001);
     expect(data.url).toBe('https://github.com/org/repo/pull/42#issuecomment-1001');
 
-    const calls = await readCalls(fixtureDir);
-    // One git call (platform detect) + one gh call (comment)
-    const ghCall = calls.find((c) => c[0] === 'pr' && c[1] === 'comment');
-    expect(ghCall).toBeDefined();
-    expect(ghCall).toEqual(['pr', 'comment', '42', '--body', 'looks good']);
+    // Argv-shape: gh pr comment <num> --body <body>
+    const ghCall = findCall('gh pr comment');
+    expect(ghCall).toContain("'gh'");
+    expect(ghCall).toContain("'pr'");
+    expect(ghCall).toContain("'comment'");
+    expect(ghCall).toContain("'42'");
+    expect(ghCall).toContain("'--body'");
+    expect(ghCall).toContain("'looks good'");
   });
 
   test('github — markdown body (code fence, bold, link, list) round-trips verbatim', async () => {
-    fixtureDir = await makeFixture({
-      git: fakeGit('git@github.com:org/repo.git'),
-      gh: fakeGh(7, 2002),
-    });
+    onExec('git remote get-url origin', 'git@github.com:org/repo.git\n');
+    onExec(
+      'gh pr comment 7',
+      'https://github.com/org/repo/pull/7#issuecomment-2002\n',
+    );
 
     const body = [
       '**heads up** — see [issue](https://example.com/x)',
@@ -211,18 +168,26 @@ describe('pr_comment handler', () => {
     expect(data.ok).toBe(true);
     expect(data.comment_id).toBe(2002);
 
-    const calls = await readCalls(fixtureDir);
-    const ghCall = calls.find((c) => c[0] === 'pr' && c[1] === 'comment');
-    expect(ghCall).toBeDefined();
-    // The 5th arg is the full body — assert verbatim preservation.
-    expect(ghCall?.[4]).toBe(body);
+    // Body survives shell-escaping: assert each non-trivial line is present
+    // verbatim in the unquoted command. (Newlines inside single-quoted shell
+    // strings are preserved literally — no escaping needed.)
+    const ghCall = findCall('gh pr comment');
+    const flat = unquote(ghCall);
+    expect(flat).toContain('**heads up**');
+    expect(flat).toContain('[issue](https://example.com/x)');
+    expect(flat).toContain('```ts');
+    expect(flat).toContain('const x: number = 1;');
+    expect(flat).toContain('console.log(`hello ${x}`);');
+    expect(flat).toContain('- item one');
+    expect(flat).toContain('- item two');
   });
 
   test('github — unicode and emoji body preserved verbatim', async () => {
-    fixtureDir = await makeFixture({
-      git: fakeGit('https://github.com/org/repo.git'),
-      gh: fakeGh(3, 3003),
-    });
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    onExec(
+      'gh pr comment 3',
+      'https://github.com/org/repo/pull/3#issuecomment-3003\n',
+    );
 
     const body = 'LGTM — 🚀 中文 тест αβγ';
 
@@ -232,16 +197,18 @@ describe('pr_comment handler', () => {
     expect(data.ok).toBe(true);
     expect(data.comment_id).toBe(3003);
 
-    const calls = await readCalls(fixtureDir);
-    const ghCall = calls.find((c) => c[0] === 'pr' && c[1] === 'comment');
-    expect(ghCall?.[4]).toBe(body);
+    const ghCall = findCall('gh pr comment');
+    expect(unquote(ghCall)).toContain(body);
   });
 
+  // --- gitlab happy paths ---
+
   test('gitlab — plain text comment returns numeric comment_id and url', async () => {
-    fixtureDir = await makeFixture({
-      git: fakeGit('https://gitlab.com/org/repo.git'),
-      glab: fakeGlab(55, 9090),
-    });
+    onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git\n');
+    onExec(
+      'glab mr note 55',
+      'https://gitlab.com/org/repo/-/merge_requests/55#note_9090\n',
+    );
 
     const result = await handler.execute({ number: 55, body: 'ship it' });
     const data = parseResult(result);
@@ -251,16 +218,21 @@ describe('pr_comment handler', () => {
     expect(data.comment_id).toBe(9090);
     expect(data.url).toBe('https://gitlab.com/org/repo/-/merge_requests/55#note_9090');
 
-    const calls = await readCalls(fixtureDir);
-    const glabCall = calls.find((c) => c[0] === 'mr' && c[1] === 'note');
-    expect(glabCall).toEqual(['mr', 'note', '55', '--message', 'ship it']);
+    const glabCall = findCall('glab mr note');
+    expect(glabCall).toContain("'glab'");
+    expect(glabCall).toContain("'mr'");
+    expect(glabCall).toContain("'note'");
+    expect(glabCall).toContain("'55'");
+    expect(glabCall).toContain("'--message'");
+    expect(glabCall).toContain("'ship it'");
   });
 
   test('gitlab — markdown body with code fence preserved verbatim', async () => {
-    fixtureDir = await makeFixture({
-      git: fakeGit('git@gitlab.com:org/repo.git'),
-      glab: fakeGlab(88, 7070),
-    });
+    onExec('git remote get-url origin', 'git@gitlab.com:org/repo.git\n');
+    onExec(
+      'glab mr note 88',
+      'https://gitlab.com/org/repo/-/merge_requests/88#note_7070\n',
+    );
 
     const body = [
       '### Review findings',
@@ -277,16 +249,20 @@ describe('pr_comment handler', () => {
     expect(data.ok).toBe(true);
     expect(data.comment_id).toBe(7070);
 
-    const calls = await readCalls(fixtureDir);
-    const glabCall = calls.find((c) => c[0] === 'mr' && c[1] === 'note');
-    expect(glabCall?.[4]).toBe(body);
+    const glabCall = findCall('glab mr note');
+    const flat = unquote(glabCall);
+    expect(flat).toContain('### Review findings');
+    expect(flat).toContain('```python');
+    expect(flat).toContain('def hello():');
+    expect(flat).toContain('print("world")');
   });
 
   test('gitlab — unicode body preserved', async () => {
-    fixtureDir = await makeFixture({
-      git: fakeGit('https://gitlab.example.com/team/proj.git'),
-      glab: fakeGlab(11, 2222),
-    });
+    onExec('git remote get-url origin', 'https://gitlab.example.com/team/proj.git\n');
+    onExec(
+      'glab mr note 11',
+      'https://gitlab.example.com/team/proj/-/merge_requests/11#note_2222\n',
+    );
 
     const body = '✅ passed: 42 ❌ failed: 0 — 完了';
 
@@ -296,51 +272,67 @@ describe('pr_comment handler', () => {
     expect(data.ok).toBe(true);
     expect(data.comment_id).toBe(2222);
 
-    const calls = await readCalls(fixtureDir);
-    const glabCall = calls.find((c) => c[0] === 'mr' && c[1] === 'note');
-    expect(glabCall?.[4]).toBe(body);
+    const glabCall = findCall('glab mr note');
+    expect(unquote(glabCall)).toContain(body);
   });
 
+  // --- error paths ---
+
   test('github — gh failure is returned as structured error, not thrown', async () => {
-    fixtureDir = await makeFixture({
-      git: fakeGit('https://github.com/org/repo.git'),
-      gh: `#!/bin/sh
-echo "HTTP 404: Not Found" >&2
-exit 1
-`,
-    });
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    failExec('gh pr comment 9999', 'HTTP 404: Not Found', 1);
 
     const result = await handler.execute({ number: 9999, body: 'nope' });
     const data = parseResult(result);
 
     expect(data.ok).toBe(false);
-    expect((data.error as string)).toContain('gh pr comment failed');
+    expect(data.error as string).toContain('gh pr comment failed');
+    expect(data.error as string).toContain('HTTP 404');
   });
 
   test('github — unparseable stdout (no issuecomment id) returns structured error', async () => {
-    fixtureDir = await makeFixture({
-      git: fakeGit('https://github.com/org/repo.git'),
-      gh: `#!/bin/sh
-echo "posted comment ok"
-exit 0
-`,
-    });
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    onExec('gh pr comment 1', 'posted comment ok\n');
 
     const result = await handler.execute({ number: 1, body: 'x' });
     const data = parseResult(result);
 
     expect(data.ok).toBe(false);
-    expect((data.error as string)).toContain('failed to parse comment ID');
+    expect(data.error as string).toContain('failed to parse comment ID');
+  });
+
+  test('gitlab — glab failure is returned as structured error, not thrown', async () => {
+    onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git\n');
+    failExec('glab mr note 9999', 'permission denied', 1);
+
+    const result = await handler.execute({ number: 9999, body: 'nope' });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(false);
+    expect(data.error as string).toContain('glab mr note failed');
+    expect(data.error as string).toContain('permission denied');
+  });
+
+  test('gitlab — unparseable stdout (no note id) returns structured error', async () => {
+    onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git\n');
+    onExec('glab mr note 1', 'posted note ok\n');
+
+    const result = await handler.execute({ number: 1, body: 'x' });
+    const data = parseResult(result);
+
+    expect(data.ok).toBe(false);
+    expect(data.error as string).toContain('failed to parse note ID');
   });
 
   // --- cross-repo routing ---
 
   test('route_with_repo — github appends --repo and slug to gh argv', async () => {
     // cwd remote is a DIFFERENT repo than the target.
-    fixtureDir = await makeFixture({
-      git: fakeGit('https://github.com/cwd-org/cwd-repo.git'),
-      gh: fakeGh(42, 1001),
-    });
+    onExec('git remote get-url origin', 'https://github.com/cwd-org/cwd-repo.git\n');
+    onExec(
+      'gh pr comment 42',
+      'https://github.com/Wave-Engineering/mcp-server-sdlc/pull/42#issuecomment-1001\n',
+    );
 
     const result = await handler.execute({
       number: 42,
@@ -350,18 +342,17 @@ exit 0
     const data = parseResult(result);
     expect(data.ok).toBe(true);
 
-    const calls = await readCalls(fixtureDir);
-    const ghCall = calls.find((c) => c[0] === 'pr' && c[1] === 'comment');
-    expect(ghCall).toBeDefined();
-    expect(ghCall).toContain('--repo');
-    expect(ghCall).toContain('Wave-Engineering/mcp-server-sdlc');
+    const ghCall = findCall('gh pr comment');
+    expect(ghCall).toContain("'--repo'");
+    expect(ghCall).toContain("'Wave-Engineering/mcp-server-sdlc'");
   });
 
   test('route_with_repo — gitlab appends -R and slug to glab argv', async () => {
-    fixtureDir = await makeFixture({
-      git: fakeGit('https://gitlab.com/cwd-org/cwd-repo.git'),
-      glab: fakeGlab(55, 9090),
-    });
+    onExec('git remote get-url origin', 'https://gitlab.com/cwd-org/cwd-repo.git\n');
+    onExec(
+      'glab mr note 55',
+      'https://gitlab.com/target-org/target-repo/-/merge_requests/55#note_9090\n',
+    );
 
     const result = await handler.execute({
       number: 55,
@@ -371,51 +362,44 @@ exit 0
     const data = parseResult(result);
     expect(data.ok).toBe(true);
 
-    const calls = await readCalls(fixtureDir);
-    const glabCall = calls.find((c) => c[0] === 'mr' && c[1] === 'note');
-    expect(glabCall).toBeDefined();
-    expect(glabCall).toContain('-R');
-    expect(glabCall).toContain('target-org/target-repo');
+    const glabCall = findCall('glab mr note');
+    expect(glabCall).toContain("'-R'");
+    expect(glabCall).toContain("'target-org/target-repo'");
   });
 
   test('regression_without_repo — gh argv does NOT contain --repo', async () => {
-    fixtureDir = await makeFixture({
-      git: fakeGit('https://github.com/org/repo.git'),
-      gh: fakeGh(42, 1001),
-    });
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    onExec(
+      'gh pr comment 42',
+      'https://github.com/org/repo/pull/42#issuecomment-1001\n',
+    );
 
     const result = await handler.execute({ number: 42, body: 'hi' });
     const data = parseResult(result);
     expect(data.ok).toBe(true);
 
-    const calls = await readCalls(fixtureDir);
-    const ghCall = calls.find((c) => c[0] === 'pr' && c[1] === 'comment');
-    expect(ghCall).toBeDefined();
-    expect(ghCall).not.toContain('--repo');
+    const ghCall = findCall('gh pr comment');
+    expect(ghCall).not.toContain("'--repo'");
   });
 
-  test('invalid_slug_early_error — returns ok:false without spawning gh/glab', async () => {
-    // Fixture has no gh/glab stubs — any spawn attempt would fail with a
-    // different error. Empty bin dir; only git stub present (which shouldn't
-    // even be reached because zod rejects first).
-    const dir = `/tmp/pr-comment-invalid-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
-    await Bun.write(`${dir}/.keep`, '');
-    await Bun.write(`${dir}/bin/.keep`, '');
-    process.env.PATH = `${dir}/bin:${ORIGINAL_PATH}`;
-    process.env.CLAUDE_PROJECT_DIR = dir;
-    fixtureDir = dir;
+  // --- boundary test (per #253 / Story 1.1 test-procedure ledger) ---
 
-    const result = await handler.execute({
-      number: 1,
-      body: 'x',
-      repo: 'not-a-slug',
-    });
-    const data = parseResult(result);
-    expect(data.ok).toBe(false);
-    expect(String(data.error)).toContain('repo');
+  test('execSync invocation matches gh CLI shape', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
+    onExec(
+      'gh pr comment 42',
+      'https://github.com/org/repo/pull/42#issuecomment-1001\n',
+    );
 
-    // Calls file should not exist (no gh/glab was spawned).
-    const callsFile = Bun.file(`${dir}/bin/.calls`);
-    expect(await callsFile.exists()).toBe(false);
+    await handler.execute({ number: 42, body: 'shape-check' });
+
+    // Exactly one gh call (the comment) and one git call (platform detect).
+    const ghCalls = execCalls.filter((c) => c.includes("'gh'"));
+    expect(ghCalls.length).toBe(1);
+    const gitCalls = execCalls.filter((c) => c.includes("'git'"));
+    expect(gitCalls.length).toBe(1);
+
+    // The single gh call is fully shell-escaped: every token wrapped in '...'.
+    expect(ghCalls[0]).toMatch(/^'gh' 'pr' 'comment' '42' '--body' 'shape-check'$/);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #238 (Story 1.1, which normalized `pr_create.ts`). Migrates the four remaining handlers off `Bun.spawnSync` onto the project-standard `child_process.execSync` + `shellEscape`/`bufToString`/`ExecError` pattern from `pr_merge.ts` / `pr_create.ts`. Eliminates the special-case carve-outs the platform-adapter retrofit's gate-grep would otherwise need to whitelist; future Phase-2 flights touching disjoint handler+test pairs are now strictly additive-safe under the single subprocess convention.

**Note:** This is a re-attempt — the original PR #257 was destroyed by the buggy `pr_merge_wait` (closed without merging) before the #258 fix landed. The work itself is unchanged from what was approved at the precheck gate; this PR is the same commit rebased onto the post-#258 main HEAD.

## Changes

**Handlers refactored:**
- `pr_comment.ts` — origin-ops family (gh/glab routing, markdown/unicode bodies survive shell-escape verbatim via single-quote wrap)
- `drift_check_path_exists.ts` — stat probe; catch-on-throw → `exists:false`
- `dod_verify_deliverable.ts` — stat + ls; ls failure preserves treat-as-empty semantics from the original
- `dod_run_test_suite.ts` — `runCommand` passes user-supplied shell command through with appended `2>&1` to merge stderr into `execSync`'s stdout return value; `Bun.file` discovery stays outside the mock surface (correctly, since it's not subprocess)

**Test files rewritten** from PATH-stub fixtures (real subprocess execution into shell scripts) to `mock.module('child_process', ...)` registry pattern matching `tests/pr_create.test.ts` / `tests/pr_merge.test.ts`. Each test file installs its own factory closing over a file-local `execRegistry`, keeping the codebase's mock-pollution convention intact (56+ of 80 test files now follow this pattern). Each handler+test pair gets a new `execSync invocation matches CLI shape` boundary test per the Story 1.1 test-procedure ledger.

## Linked Issues

Closes #253

## Test Plan

- [x] `grep -n "Bun.spawnSync" handlers/` → **ZERO matches** (AC #1)
- [x] All 4 test files use `mock.module('child_process', ...)` pattern (AC #2)
- [x] `./scripts/ci/validate.sh` → **73/73 per-tool assertions pass**
- [x] `bun test` → **1393 / 0 / 80 files / 3490 expect()** (was 1382 post-#258 baseline; +11 from new boundary + edge tests)
- [x] No external behavior change to any of the 4 tools (AC #4)
- [x] Code-reviewer findings addressed at original precheck (Bun.spawnSync leftover in test fixture removed; runCommand passthrough comment added)

## Notes

**This PR will validate the #258 fix end-to-end.** The merge will use `pr_merge_wait` (the now-fixed v1.7.1 binary). If reporting is honest, the response should reflect actual merge state; if the queue holds the PR for CI, the tool should poll until landing rather than short-circuit on a false `merged:true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)