### PR TITLE
feat(adapters): scaffold lib/adapters/ + extract lib/shared/ + gate-greps

### DIFF
--- a/handlers/ci_failed_jobs.ts
+++ b/handlers/ci_failed_jobs.ts
@@ -5,7 +5,7 @@
 import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform } from '../lib/glab.js';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
 
 const inputSchema = z
   .object({

--- a/handlers/ci_run_logs.ts
+++ b/handlers/ci_run_logs.ts
@@ -5,7 +5,7 @@
 import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform } from '../lib/glab.js';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
 
 const HARD_MAX_LINES = 10000;
 const DEFAULT_MAX_LINES = 2000;

--- a/handlers/ci_run_status.ts
+++ b/handlers/ci_run_status.ts
@@ -5,7 +5,8 @@
 import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform, gitlabApiCiList, type GitlabPipeline } from '../lib/glab.js';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { gitlabApiCiList, type GitlabPipeline } from '../lib/glab.js';
 
 const inputSchema = z
   .object({

--- a/handlers/ci_runs_for_branch.ts
+++ b/handlers/ci_runs_for_branch.ts
@@ -5,7 +5,8 @@
 import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform, gitlabApiCiList } from '../lib/glab.js';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { gitlabApiCiList } from '../lib/glab.js';
 
 const inputSchema = z.object({
   branch: z.string().min(1, 'branch must be a non-empty string'),

--- a/handlers/ci_wait_run.ts
+++ b/handlers/ci_wait_run.ts
@@ -5,12 +5,9 @@
 import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import {
-  detectPlatform,
-  gitlabApiCiList,
-  parseRepoSlug,
-  type GitlabPipeline,
-} from '../lib/glab.js';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { parseRepoSlug } from '../lib/shared/parse-repo-slug.js';
+import { gitlabApiCiList, type GitlabPipeline } from '../lib/glab.js';
 import { log } from '../logger.js';
 
 const inputSchema = z

--- a/handlers/dod_load_manifest.ts
+++ b/handlers/dod_load_manifest.ts
@@ -1,7 +1,8 @@
 import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform, gitlabApiIssue } from '../lib/glab';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { gitlabApiIssue } from '../lib/glab.js';
 
 const inputSchema = z.object({
   path: z.string().min(1, 'path must be a non-empty string'),

--- a/handlers/epic_sub_issues.ts
+++ b/handlers/epic_sub_issues.ts
@@ -2,7 +2,9 @@ import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
 import { SUB_ISSUE_SECTION_KEYS, findSubIssueSection, parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
-import { detectPlatform, parseRepoSlug, gitlabApiIssue } from '../lib/glab';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { parseRepoSlug } from '../lib/shared/parse-repo-slug.js';
+import { gitlabApiIssue } from '../lib/glab.js';
 
 const inputSchema = z.object({
   epic_ref: z.string().min(1, 'epic_ref must be a non-empty string'),

--- a/handlers/ibm.ts
+++ b/handlers/ibm.ts
@@ -1,7 +1,8 @@
 import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform, gitlabApiIssue, gitlabApiMrList } from '../lib/glab';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { gitlabApiIssue, gitlabApiMrList } from '../lib/glab.js';
 
 const inputSchema = z.object({
   branch: z.string().optional(),

--- a/handlers/label_create.ts
+++ b/handlers/label_create.ts
@@ -5,7 +5,7 @@
 import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform } from '../lib/glab';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
 
 // 6-char hex (no leading #). Both gh and glab accept color in this form.
 const HEX_COLOR_RE = /^[0-9a-fA-F]{6}$/;

--- a/handlers/label_list.ts
+++ b/handlers/label_list.ts
@@ -5,7 +5,7 @@
 import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform } from '../lib/glab';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
 
 const inputSchema = z.object({
   limit: z.number().int().positive().optional().default(100),

--- a/handlers/pr_diff.ts
+++ b/handlers/pr_diff.ts
@@ -5,7 +5,8 @@
 import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform, gitlabApiMr } from '../lib/glab';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { gitlabApiMr } from '../lib/glab.js';
 
 const inputSchema = z.object({
   number: z.number().int().positive(),

--- a/handlers/pr_files.ts
+++ b/handlers/pr_files.ts
@@ -5,7 +5,8 @@
 import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform, gitlabApiMr } from '../lib/glab';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { gitlabApiMr } from '../lib/glab.js';
 
 const inputSchema = z.object({
   number: z.number().int().positive('number must be a positive integer'),

--- a/handlers/pr_list.ts
+++ b/handlers/pr_list.ts
@@ -5,7 +5,8 @@
 import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform, gitlabApiMrList } from '../lib/glab';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { gitlabApiMrList } from '../lib/glab.js';
 
 const inputSchema = z.object({
   head: z.string().optional(),

--- a/handlers/pr_merge.ts
+++ b/handlers/pr_merge.ts
@@ -6,7 +6,8 @@ import { execSync } from 'child_process';
 import { writeFileSync } from 'fs';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform, parseRepoSlug } from '../lib/glab.js';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { parseRepoSlug } from '../lib/shared/parse-repo-slug.js';
 import { detectMergeQueue, type MergeQueueInfo } from '../lib/merge_queue_detect.js';
 import { fetchGithubPrState, fetchGitlabMrState } from '../lib/pr_state.js';
 

--- a/handlers/pr_merge_wait.ts
+++ b/handlers/pr_merge_wait.ts
@@ -8,7 +8,8 @@
 
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform, parseRepoSlug } from '../lib/glab.js';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { parseRepoSlug } from '../lib/shared/parse-repo-slug.js';
 import { fetchPrState, type PrStateInfo } from '../lib/pr_state.js';
 import { performMerge } from './pr_merge.js';
 

--- a/handlers/pr_status.ts
+++ b/handlers/pr_status.ts
@@ -5,7 +5,8 @@
 import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform, gitlabApiMr } from '../lib/glab';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { gitlabApiMr } from '../lib/glab.js';
 
 const inputSchema = z.object({
   number: z.number().int().positive(),

--- a/handlers/pr_wait_ci.ts
+++ b/handlers/pr_wait_ci.ts
@@ -5,7 +5,8 @@
 import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform, gitlabApiMr } from '../lib/glab';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { gitlabApiMr } from '../lib/glab.js';
 import { log } from '../logger.js';
 
 const inputSchema = z

--- a/handlers/spec_acceptance_criteria.ts
+++ b/handlers/spec_acceptance_criteria.ts
@@ -2,7 +2,8 @@ import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
 import { parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
-import { detectPlatform, gitlabApiIssue } from '../lib/glab';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { gitlabApiIssue } from '../lib/glab.js';
 
 const inputSchema = z.object({
   issue_ref: z.string().min(1, 'issue_ref must be a non-empty string'),

--- a/handlers/spec_dependencies.ts
+++ b/handlers/spec_dependencies.ts
@@ -2,7 +2,9 @@ import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
 import { findBoldLabelDependencies, parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
-import { detectPlatformForRef, parseRepoSlug, gitlabApiIssue } from '../lib/glab';
+import { detectPlatformForRef } from '../lib/shared/detect-platform.js';
+import { parseRepoSlug } from '../lib/shared/parse-repo-slug.js';
+import { gitlabApiIssue } from '../lib/glab.js';
 
 const inputSchema = z.object({
   issue_ref: z.string().min(1, 'issue_ref must be a non-empty string'),

--- a/handlers/spec_get.ts
+++ b/handlers/spec_get.ts
@@ -2,7 +2,8 @@ import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
 import { parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
-import { detectPlatformForRef, gitlabApiIssue } from '../lib/glab';
+import { detectPlatformForRef } from '../lib/shared/detect-platform.js';
+import { gitlabApiIssue } from '../lib/glab.js';
 
 const inputSchema = z.object({
   issue_ref: z.string().min(1, 'issue_ref must be a non-empty string'),

--- a/handlers/spec_validate_structure.ts
+++ b/handlers/spec_validate_structure.ts
@@ -2,7 +2,8 @@ import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
 import { findBoldLabelDependencies, parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
-import { detectPlatform, gitlabApiIssue } from '../lib/glab';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { gitlabApiIssue } from '../lib/glab.js';
 
 const inputSchema = z.object({
   issue_ref: z.string().min(1, 'issue_ref must be a non-empty string'),

--- a/handlers/wave_ci_trust_level.ts
+++ b/handlers/wave_ci_trust_level.ts
@@ -1,7 +1,9 @@
 import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform, parseRepoSlug, gitlabApiRepo } from '../lib/glab';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { parseRepoSlug } from '../lib/shared/parse-repo-slug.js';
+import { gitlabApiRepo } from '../lib/glab.js';
 
 const inputSchema = z.object({}).strict();
 

--- a/handlers/wave_compute.ts
+++ b/handlers/wave_compute.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
 import { findSubIssueSection, parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
 import { computeWaves, type DepNode } from '../lib/dependency_graph';
-import { detectPlatform, parseRepoSlug, gitlabApiIssue } from '../lib/glab.js';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { parseRepoSlug } from '../lib/shared/parse-repo-slug.js';
+import { gitlabApiIssue } from '../lib/glab.js';
 import { execSync } from 'child_process';
 
 const inputSchema = z.object({

--- a/handlers/wave_dependency_graph.ts
+++ b/handlers/wave_dependency_graph.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
 import { parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
 import { buildGraph, computeWaves, type DepNode } from '../lib/dependency_graph';
-import { detectPlatform, parseRepoSlug, gitlabApiIssue } from '../lib/glab.js';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { parseRepoSlug } from '../lib/shared/parse-repo-slug.js';
+import { gitlabApiIssue } from '../lib/glab.js';
 import { execSync } from 'child_process';
 
 const inputSchema = z

--- a/handlers/wave_finalize.ts
+++ b/handlers/wave_finalize.ts
@@ -16,7 +16,7 @@ import { join, resolve } from 'path';
 // `undefined` if the offending test runs first. See lesson_mcp_gotchas.md §6.
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform } from '../lib/glab.js';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
 
 const inputSchema = z.object({
   root: z.string().optional(),

--- a/handlers/wave_init.ts
+++ b/handlers/wave_init.ts
@@ -3,7 +3,8 @@ import { writeFileSync } from 'fs';
 import { join } from 'path';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform, parseRepoSlug } from '../lib/glab.js';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { parseRepoSlug } from '../lib/shared/parse-repo-slug.js';
 
 const inputSchema = z.object({
   plan_json: z.string().min(1, 'plan_json must be a non-empty JSON string'),

--- a/handlers/wave_previous_merged.ts
+++ b/handlers/wave_previous_merged.ts
@@ -2,7 +2,9 @@ import { execSync } from 'child_process';
 import { join } from 'path';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform, gitlabApiIssue, parseRepoSlug } from '../lib/glab';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { parseRepoSlug } from '../lib/shared/parse-repo-slug.js';
+import { gitlabApiIssue } from '../lib/glab.js';
 
 const inputSchema = z.object({}).strict();
 

--- a/handlers/wave_reconcile_mrs.ts
+++ b/handlers/wave_reconcile_mrs.ts
@@ -2,7 +2,7 @@ import { execSync } from 'child_process';
 import { join } from 'path';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform } from '../lib/glab';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
 
 const inputSchema = z.object({
   wave_id: z.string().optional(),

--- a/handlers/wave_topology.ts
+++ b/handlers/wave_topology.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
 import { parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
 import { computeWaves, type DepNode } from '../lib/dependency_graph';
-import { detectPlatform, parseRepoSlug, gitlabApiIssue } from '../lib/glab.js';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { parseRepoSlug } from '../lib/shared/parse-repo-slug.js';
+import { gitlabApiIssue } from '../lib/glab.js';
 import { execSync } from 'child_process';
 
 const inputSchema = z

--- a/handlers/work_item.ts
+++ b/handlers/work_item.ts
@@ -2,7 +2,7 @@ import { execSync } from 'child_process';
 import { writeFileSync } from 'fs';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform } from '../lib/glab.js';
+import { detectPlatform } from '../lib/shared/detect-platform.js';
 
 const inputSchema = z.object({
   type: z.enum(['epic', 'story', 'bug', 'chore', 'docs', 'pr', 'mr']),

--- a/lib/adapters/github.ts
+++ b/lib/adapters/github.ts
@@ -1,0 +1,48 @@
+/**
+ * GitHub adapter — assembles per-method `<method>-github.ts` implementations
+ * into a single `PlatformAdapter` object.
+ *
+ * Story 1.2 ships this as an empty assembler: every method returns
+ * `{platform_unsupported: true, hint: 'not yet migrated'}`. As each migration
+ * story (Story 1.3 onward) lands, it replaces one method with the real
+ * `<method>-github.ts` implementation and removes the corresponding
+ * `'not yet migrated'` stub.
+ *
+ * The contract test (`types.test.ts`) enforces — at runtime — that every
+ * method listed in `PLATFORM_ADAPTER_METHODS` is present on this object. The
+ * `: PlatformAdapter` type annotation enforces the same at compile time.
+ */
+
+import type { PlatformAdapter } from './types.js';
+
+const stubMethod = async (_args: unknown) => ({
+  platform_unsupported: true as const,
+  hint: 'not yet migrated',
+});
+
+export const githubAdapter: PlatformAdapter = {
+  prCreate: stubMethod,
+  prMerge: stubMethod,
+  prMergeWait: stubMethod,
+  prStatus: stubMethod,
+  prDiff: stubMethod,
+  prComment: stubMethod,
+  prFiles: stubMethod,
+  prList: stubMethod,
+  prWaitCi: stubMethod,
+  ciWaitRun: stubMethod,
+  ciRunStatus: stubMethod,
+  ciRunLogs: stubMethod,
+  ciFailedJobs: stubMethod,
+  ciRunsForBranch: stubMethod,
+  labelCreate: stubMethod,
+  labelList: stubMethod,
+  workItem: stubMethod,
+  ibm: stubMethod,
+  epicSubIssues: stubMethod,
+  specGet: stubMethod,
+  specValidateStructure: stubMethod,
+  specAcceptanceCriteria: stubMethod,
+  specDependencies: stubMethod,
+  fetchIssue: stubMethod,
+};

--- a/lib/adapters/gitlab.ts
+++ b/lib/adapters/gitlab.ts
@@ -1,0 +1,49 @@
+/**
+ * GitLab adapter — assembles per-method `<method>-gitlab.ts` implementations
+ * into a single `PlatformAdapter` object.
+ *
+ * Story 1.2 ships this as an empty assembler: every method returns
+ * `{platform_unsupported: true, hint: 'not yet migrated'}`. As each migration
+ * story (Story 1.3 onward) lands, it replaces one method with the real
+ * `<method>-gitlab.ts` implementation and removes the corresponding
+ * `'not yet migrated'` stub.
+ *
+ * Some methods may stay as `platform_unsupported` permanently when the
+ * underlying concept doesn't translate (e.g., `skip_train` semantics differ
+ * between GitHub merge queues and GitLab merge trains). Those will return a
+ * descriptive `hint` rather than a generic `'not yet migrated'`.
+ */
+
+import type { PlatformAdapter } from './types.js';
+
+const stubMethod = async (_args: unknown) => ({
+  platform_unsupported: true as const,
+  hint: 'not yet migrated',
+});
+
+export const gitlabAdapter: PlatformAdapter = {
+  prCreate: stubMethod,
+  prMerge: stubMethod,
+  prMergeWait: stubMethod,
+  prStatus: stubMethod,
+  prDiff: stubMethod,
+  prComment: stubMethod,
+  prFiles: stubMethod,
+  prList: stubMethod,
+  prWaitCi: stubMethod,
+  ciWaitRun: stubMethod,
+  ciRunStatus: stubMethod,
+  ciRunLogs: stubMethod,
+  ciFailedJobs: stubMethod,
+  ciRunsForBranch: stubMethod,
+  labelCreate: stubMethod,
+  labelList: stubMethod,
+  workItem: stubMethod,
+  ibm: stubMethod,
+  epicSubIssues: stubMethod,
+  specGet: stubMethod,
+  specValidateStructure: stubMethod,
+  specAcceptanceCriteria: stubMethod,
+  specDependencies: stubMethod,
+  fetchIssue: stubMethod,
+};

--- a/lib/adapters/index.ts
+++ b/lib/adapters/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Public surface for handlers — the only adapter module handlers should
+ * import from. Re-exports `getAdapter`, the `PlatformAdapter` interface, and
+ * the `AdapterResult` discriminated union.
+ *
+ * Importing the per-method `<method>-<platform>.ts` files directly from
+ * handlers is a code smell: handlers should remain platform-agnostic and
+ * dispatch through `getAdapter()`.
+ */
+
+export { getAdapter } from './route.js';
+export type {
+  PlatformAdapter,
+  AdapterResult,
+  PlatformAdapterMethod,
+} from './types.js';
+export { PLATFORM_ADAPTER_METHODS } from './types.js';

--- a/lib/adapters/route.test.ts
+++ b/lib/adapters/route.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string) => execMockFn(cmd));
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { getAdapter } = await import('./route.ts');
+const { githubAdapter } = await import('./github.ts');
+const { gitlabAdapter } = await import('./gitlab.ts');
+
+function reset() {
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+describe('getAdapter dispatch', () => {
+  beforeEach(() => reset());
+
+  test('returns githubAdapter for github.com origin', () => {
+    execMockFn = () => 'https://github.com/owner/repo.git';
+    expect(getAdapter()).toBe(githubAdapter);
+  });
+
+  test('returns gitlabAdapter for gitlab.com origin', () => {
+    execMockFn = () => 'https://gitlab.com/owner/repo.git';
+    expect(getAdapter()).toBe(gitlabAdapter);
+  });
+
+  test('returns gitlabAdapter for self-hosted GitLab origin', () => {
+    execMockFn = () => 'https://gitlab.acme.com/owner/repo.git';
+    expect(getAdapter()).toBe(gitlabAdapter);
+  });
+
+  test('falls back to github when origin is unreadable', () => {
+    execMockFn = () => {
+      throw new Error('not a git repository');
+    };
+    expect(getAdapter()).toBe(githubAdapter);
+  });
+
+  test('accepts {repo} arg without throwing (forward-compat for cross-repo dispatch)', () => {
+    execMockFn = () => 'https://github.com/owner/repo.git';
+    expect(getAdapter({ repo: 'org/somewhere-else' })).toBe(githubAdapter);
+  });
+});

--- a/lib/adapters/route.ts
+++ b/lib/adapters/route.ts
@@ -1,0 +1,22 @@
+/**
+ * Dispatch layer — `getAdapter()` returns the `PlatformAdapter` for the
+ * current execution context (cwd-based detection by default; an optional
+ * `repo` arg is reserved for future cross-repo dispatch).
+ *
+ * Sync because `detectPlatform()` is sync (CT-03 — current behavior preserved
+ * during the retrofit).
+ */
+
+import { detectPlatform } from '../shared/detect-platform.js';
+import { githubAdapter } from './github.js';
+import { gitlabAdapter } from './gitlab.js';
+import type { PlatformAdapter } from './types.js';
+
+// `args.repo` is accepted today for forward-compat with the §5.4 spec but
+// not yet consumed — current behavior delegates to cwd-based `detectPlatform()`.
+// Cross-repo dispatch lands when an upcoming story (Phase 2) extends
+// `detectPlatform` to accept a repo slug; this signature won't change.
+export function getAdapter(_args?: { repo?: string }): PlatformAdapter {
+  const platform = detectPlatform();
+  return platform === 'gitlab' ? gitlabAdapter : githubAdapter;
+}

--- a/lib/adapters/types.test.ts
+++ b/lib/adapters/types.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from 'bun:test';
+
+import { PLATFORM_ADAPTER_METHODS } from './types.ts';
+import { githubAdapter } from './github.ts';
+import { gitlabAdapter } from './gitlab.ts';
+
+// Contract test (R-04): every method listed in PLATFORM_ADAPTER_METHODS must
+// be implemented by both adapters. Story 1.2's empty assemblers satisfy this
+// vacuously — every method is the same `stubMethod` returning
+// `{platform_unsupported: true, hint: 'not yet migrated'}`. As migration
+// stories land real implementations, this test continues to enforce that no
+// platform falls behind.
+//
+// The compile-time exhaustiveness check in `types.ts` (`_methodsExhaustive`)
+// catches drift between PLATFORM_ADAPTER_METHODS and `keyof PlatformAdapter`.
+// This runtime test catches the runtime case: the type system can be
+// satisfied with `as` casts that lie about object shape.
+
+describe('PlatformAdapter contract', () => {
+  for (const method of PLATFORM_ADAPTER_METHODS) {
+    test(`every method has GitHub impl — ${method}`, () => {
+      const fn = (githubAdapter as unknown as Record<string, unknown>)[method];
+      expect(typeof fn).toBe('function');
+    });
+  }
+
+  for (const method of PLATFORM_ADAPTER_METHODS) {
+    test(`every method has GitLab impl — ${method}`, () => {
+      const fn = (gitlabAdapter as unknown as Record<string, unknown>)[method];
+      expect(typeof fn).toBe('function');
+    });
+  }
+
+  test('Story 1.2 vacuous-pass: every method returns platform_unsupported', async () => {
+    // When a real implementation lands (Story 1.3+), it removes that method
+    // from this list. By Phase 3 close, this test should iterate zero methods.
+    for (const method of PLATFORM_ADAPTER_METHODS) {
+      const fn = (githubAdapter as unknown as Record<string, (args: unknown) => Promise<unknown>>)[method];
+      const result = (await fn({})) as { platform_unsupported?: true; hint?: string };
+      expect(result.platform_unsupported).toBe(true);
+      expect(result.hint).toBe('not yet migrated');
+    }
+  });
+});

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -1,0 +1,192 @@
+/**
+ * `PlatformAdapter` contract — the typed interface every platform-specific
+ * adapter (`github.ts`, `gitlab.ts`) must implement.
+ *
+ * One method per platform-aware tool. Method signatures use placeholder
+ * `unknown` arg/response types that each migration story (Story 1.3 onward)
+ * tightens to its concrete handler shape.
+ *
+ * The `AdapterResult<T>` discriminated union (per R-02 / §5.2) forces callers
+ * to handle three distinct outcomes:
+ *
+ *   - `{ ok: true, data }`            — success
+ *   - `{ ok: false, error, code }`    — runtime failure
+ *   - `{ platform_unsupported: true, hint }` — structural asymmetry
+ *
+ * Today's silent-ignore pattern (e.g., `skip_train` on GitLab) collapses the
+ * third case into "fake success" — the bug R-03 closes. The discriminator
+ * makes the asymmetry a typed signal rather than a thrown exception or a
+ * misleading boolean.
+ *
+ * Story 1.2 ships with empty assemblers — every method returns
+ * `{platform_unsupported: true, hint: 'not yet migrated'}`. Each subsequent
+ * migration story replaces one method-pair with real implementations and
+ * refines that method's arg/response types.
+ */
+
+// ---------------------------------------------------------------------------
+// Result discriminator (R-02, §5.2)
+// ---------------------------------------------------------------------------
+
+export type AdapterResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: string; code: string }
+  | { platform_unsupported: true; hint: string };
+
+// ---------------------------------------------------------------------------
+// Placeholder arg/response types
+//
+// All start as `unknown` and are tightened to concrete shapes by each
+// migration story (Story 1.3 = pr_create, Story 1.4 = pr_diff, etc.).
+// Keeping them named (rather than inline `unknown`) lets each story refine
+// just one type without re-touching the interface body.
+// ---------------------------------------------------------------------------
+
+export type PrCreateArgs = unknown;
+export type PrCreateResponse = unknown;
+export type PrMergeArgs = unknown;
+export type PrMergeResponse = unknown;
+export type PrMergeWaitArgs = unknown;
+export type PrMergeWaitResponse = unknown;
+export type PrStatusArgs = unknown;
+export type PrStatusResponse = unknown;
+export type PrDiffArgs = unknown;
+export type PrDiffResponse = unknown;
+export type PrCommentArgs = unknown;
+export type PrCommentResponse = unknown;
+export type PrFilesArgs = unknown;
+export type PrFilesResponse = unknown;
+export type PrListArgs = unknown;
+export type PrListResponse = unknown;
+export type PrWaitCiArgs = unknown;
+export type PrWaitCiResponse = unknown;
+
+export type CiWaitRunArgs = unknown;
+export type CiWaitRunResponse = unknown;
+export type CiRunStatusArgs = unknown;
+export type CiRunStatusResponse = unknown;
+export type CiRunLogsArgs = unknown;
+export type CiRunLogsResponse = unknown;
+export type CiFailedJobsArgs = unknown;
+export type CiFailedJobsResponse = unknown;
+export type CiRunsForBranchArgs = unknown;
+export type CiRunsForBranchResponse = unknown;
+
+export type LabelCreateArgs = unknown;
+export type LabelCreateResponse = unknown;
+export type LabelListArgs = unknown;
+export type LabelListResponse = unknown;
+export type WorkItemArgs = unknown;
+export type WorkItemResponse = unknown;
+export type IbmArgs = unknown;
+export type IbmResponse = unknown;
+export type EpicSubIssuesArgs = unknown;
+export type EpicSubIssuesResponse = unknown;
+
+export type SpecGetArgs = unknown;
+export type SpecGetResponse = unknown;
+export type SpecValidateStructureArgs = unknown;
+export type SpecValidateStructureResponse = unknown;
+export type SpecAcceptanceCriteriaArgs = unknown;
+export type SpecAcceptanceCriteriaResponse = unknown;
+export type SpecDependenciesArgs = unknown;
+export type SpecDependenciesResponse = unknown;
+
+// Hybrid sub-call placeholder (per §5.1, §5.5). The Phase 1 survey (Story
+// 1.12) produces the authoritative list of hybrid sub-calls; `fetchIssue` is
+// included here as the illustrative example. Adding/removing sub-calls is
+// expected during Phase 2 implementation.
+export type FetchIssueArgs = unknown;
+export type IssueData = unknown;
+
+// ---------------------------------------------------------------------------
+// The interface
+// ---------------------------------------------------------------------------
+
+export interface PlatformAdapter {
+  // PR/MR family (Stories 1.3 – 1.11)
+  prCreate(args: PrCreateArgs): Promise<AdapterResult<PrCreateResponse>>;
+  prMerge(args: PrMergeArgs): Promise<AdapterResult<PrMergeResponse>>;
+  prMergeWait(args: PrMergeWaitArgs): Promise<AdapterResult<PrMergeWaitResponse>>;
+  prStatus(args: PrStatusArgs): Promise<AdapterResult<PrStatusResponse>>;
+  prDiff(args: PrDiffArgs): Promise<AdapterResult<PrDiffResponse>>;
+  prComment(args: PrCommentArgs): Promise<AdapterResult<PrCommentResponse>>;
+  prFiles(args: PrFilesArgs): Promise<AdapterResult<PrFilesResponse>>;
+  prList(args: PrListArgs): Promise<AdapterResult<PrListResponse>>;
+  prWaitCi(args: PrWaitCiArgs): Promise<AdapterResult<PrWaitCiResponse>>;
+
+  // CI family
+  ciWaitRun(args: CiWaitRunArgs): Promise<AdapterResult<CiWaitRunResponse>>;
+  ciRunStatus(args: CiRunStatusArgs): Promise<AdapterResult<CiRunStatusResponse>>;
+  ciRunLogs(args: CiRunLogsArgs): Promise<AdapterResult<CiRunLogsResponse>>;
+  ciFailedJobs(args: CiFailedJobsArgs): Promise<AdapterResult<CiFailedJobsResponse>>;
+  ciRunsForBranch(args: CiRunsForBranchArgs): Promise<AdapterResult<CiRunsForBranchResponse>>;
+
+  // Label & issue CRUD
+  labelCreate(args: LabelCreateArgs): Promise<AdapterResult<LabelCreateResponse>>;
+  labelList(args: LabelListArgs): Promise<AdapterResult<LabelListResponse>>;
+  workItem(args: WorkItemArgs): Promise<AdapterResult<WorkItemResponse>>;
+  ibm(args: IbmArgs): Promise<AdapterResult<IbmResponse>>;
+  epicSubIssues(args: EpicSubIssuesArgs): Promise<AdapterResult<EpicSubIssuesResponse>>;
+
+  // Spec operations
+  specGet(args: SpecGetArgs): Promise<AdapterResult<SpecGetResponse>>;
+  specValidateStructure(args: SpecValidateStructureArgs): Promise<AdapterResult<SpecValidateStructureResponse>>;
+  specAcceptanceCriteria(args: SpecAcceptanceCriteriaArgs): Promise<AdapterResult<SpecAcceptanceCriteriaResponse>>;
+  specDependencies(args: SpecDependenciesArgs): Promise<AdapterResult<SpecDependenciesResponse>>;
+
+  // Hybrid sub-calls (illustrative; final set determined by Story 1.12 survey)
+  fetchIssue(args: FetchIssueArgs): Promise<AdapterResult<IssueData>>;
+}
+
+// ---------------------------------------------------------------------------
+// Runtime method-name registry (powers the contract test, R-04)
+//
+// The interface above is erased at runtime; the test in `types.test.ts` uses
+// this constant to assert each adapter object exposes a function for every
+// listed method. Drift between this list and `PlatformAdapter` is caught at
+// compile time by the assertion below.
+// ---------------------------------------------------------------------------
+
+export const PLATFORM_ADAPTER_METHODS = [
+  'prCreate',
+  'prMerge',
+  'prMergeWait',
+  'prStatus',
+  'prDiff',
+  'prComment',
+  'prFiles',
+  'prList',
+  'prWaitCi',
+  'ciWaitRun',
+  'ciRunStatus',
+  'ciRunLogs',
+  'ciFailedJobs',
+  'ciRunsForBranch',
+  'labelCreate',
+  'labelList',
+  'workItem',
+  'ibm',
+  'epicSubIssues',
+  'specGet',
+  'specValidateStructure',
+  'specAcceptanceCriteria',
+  'specDependencies',
+  'fetchIssue',
+] as const;
+
+export type PlatformAdapterMethod = (typeof PLATFORM_ADAPTER_METHODS)[number];
+
+// Compile-time check — catches methods added to `PlatformAdapter` without a
+// corresponding entry in `PLATFORM_ADAPTER_METHODS` (one direction only). The
+// reverse — extra entries in the list that don't match any interface key —
+// is caught by the runtime contract test in `types.test.ts`: the adapter
+// objects are typed as `: PlatformAdapter`, so they cannot carry an extra
+// method, and the test's `typeof fn === 'function'` assertion fails.
+type _MethodsExhaustive =
+  keyof PlatformAdapter extends PlatformAdapterMethod
+    ? true
+    : { missingFromList: Exclude<keyof PlatformAdapter, PlatformAdapterMethod> };
+
+const _methodsExhaustive: _MethodsExhaustive = true;
+void _methodsExhaustive;

--- a/lib/glab.ts
+++ b/lib/glab.ts
@@ -18,73 +18,17 @@
  */
 
 import { execSync } from 'child_process';
-import type { IssueRef } from './spec_parser.js';
+import { parseRepoSlug } from './shared/parse-repo-slug.js';
 
 // ---------------------------------------------------------------------------
-// Helpers — platform detection and repo slug parsing
+// Re-exports — `detectPlatform`, `detectPlatformForRef`, and `parseRepoSlug`
+// moved to `lib/shared/` per Story 1.2 (R-17). These re-exports keep existing
+// importers working during the transition; they are deleted in Phase 3 once
+// every importer is updated to point at the new location directly.
 // ---------------------------------------------------------------------------
 
-/**
- * Detect whether the current repo's origin is a GitLab or GitHub remote.
- *
- * Returns `'gitlab'` if the origin URL contains `'gitlab'` (matches gitlab.com
- * and any self-hosted `gitlab.<company>.com`), otherwise `'github'`. Falls
- * back to `'github'` if the origin cannot be read.
- *
- * This function is the canonical source of cwd-based platform detection.
- * Handlers must import this rather than rolling their own (a local copy in
- * `pr_list.ts` previously inverted the check — `url.includes('github')` —
- * which gives the wrong answer for self-hosted enterprise deployments).
- */
-export function detectPlatform(): 'github' | 'gitlab' {
-  try {
-    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
-    return url.includes('gitlab') ? 'gitlab' : 'github';
-  } catch {
-    return 'github';
-  }
-}
-
-/**
- * Detect platform for a qualified issue ref (`owner/repo#N`).
- *
- * When a ref includes an owner path, we can infer the platform:
- * - If the owner has multiple segments (e.g. `org/sub/group`), it MUST be
- *   GitLab — GitHub only supports single-segment owners.
- * - Otherwise, fall back to cwd-based detection (ambiguous).
- *
- * When a ref is local (no owner/repo), falls back to cwd-based detection.
- */
-export function detectPlatformForRef(ref: IssueRef): 'github' | 'gitlab' {
-  if (ref.owner && ref.owner.includes('/')) {
-    // Multi-segment owner path → must be GitLab (nested groups)
-    return 'gitlab';
-  }
-  return detectPlatform();
-}
-
-/**
- * Parse the project slug from the current repo's origin URL.
- *
- * Handles both SSH (`git@host:path.git`) and HTTPS
- * (`https://host/path(.git)?`) remote formats, including deeply nested
- * GitLab group paths (e.g. `org/sub/group/repo`). Returns `null` if the
- * origin cannot be read or the URL does not match the expected pattern.
- *
- * This function is the canonical source of slug parsing.
- */
-export function parseRepoSlug(): string | null {
-  try {
-    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
-    // SSH: git@host:path/to/repo.git → capture everything after ':'
-    // HTTPS: https://host/path/to/repo.git → capture everything after host '/'
-    const m = /(?:git@[^:]+:|https?:\/\/[^/]+\/)(.+?)(?:\.git)?$/.exec(url);
-    if (m) return m[1];
-    return null;
-  } catch {
-    return null;
-  }
-}
+export { detectPlatform, detectPlatformForRef, type Platform } from './shared/detect-platform.js';
+export { parseRepoSlug } from './shared/parse-repo-slug.js';
 
 /**
  * URL-encoded project path suitable for `glab api projects/<path>/...`
@@ -93,6 +37,9 @@ export function parseRepoSlug(): string | null {
  *
  * Throws if the origin URL cannot be parsed. Callers that want a graceful
  * fallback should catch the error and fall through to the GitHub code path.
+ *
+ * Stays in `lib/glab.ts` (not `lib/shared/`) because it's a GitLab-specific
+ * helper; it folds into the GitLab adapter during Phase 2 migration.
  */
 export function gitlabProjectPath(): string {
   const slug = parseRepoSlug();

--- a/lib/shared/detect-platform.test.ts
+++ b/lib/shared/detect-platform.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string) => execMockFn(cmd));
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { detectPlatform, detectPlatformForRef } = await import('./detect-platform.ts');
+
+function reset() {
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+describe('detectPlatform (lib/shared/)', () => {
+  beforeEach(() => reset());
+
+  test('returns "gitlab" for gitlab.com origin', () => {
+    execMockFn = () => 'https://gitlab.com/owner/repo.git';
+    expect(detectPlatform()).toBe('gitlab');
+  });
+
+  test('returns "gitlab" for self-hosted GitLab origin', () => {
+    execMockFn = () => 'https://gitlab.company.com/owner/repo.git';
+    expect(detectPlatform()).toBe('gitlab');
+  });
+
+  test('returns "gitlab" for SSH GitLab origin', () => {
+    execMockFn = () => 'git@gitlab.com:owner/repo.git';
+    expect(detectPlatform()).toBe('gitlab');
+  });
+
+  test('returns "github" for github.com origin', () => {
+    execMockFn = () => 'https://github.com/owner/repo.git';
+    expect(detectPlatform()).toBe('github');
+  });
+
+  test('returns "github" for GitHub Enterprise origin', () => {
+    execMockFn = () => 'https://github.acme.com/owner/repo.git';
+    expect(detectPlatform()).toBe('github');
+  });
+
+  test('falls back to "github" when origin cannot be read', () => {
+    execMockFn = () => {
+      throw new Error('not a git repository');
+    };
+    expect(detectPlatform()).toBe('github');
+  });
+});
+
+describe('detectPlatformForRef (lib/shared/)', () => {
+  beforeEach(() => reset());
+
+  test('returns "gitlab" for multi-segment owner path (nested groups)', () => {
+    expect(
+      detectPlatformForRef({ owner: 'org/sub/group', repo: 'repo', number: 1 }),
+    ).toBe('gitlab');
+  });
+
+  test('falls back to cwd detection for single-segment owner', () => {
+    execMockFn = () => 'https://github.com/owner/repo.git';
+    expect(detectPlatformForRef({ owner: 'owner', repo: 'repo', number: 1 })).toBe(
+      'github',
+    );
+  });
+
+  test('falls back to cwd detection for local refs (no owner)', () => {
+    execMockFn = () => 'https://gitlab.com/owner/repo.git';
+    expect(detectPlatformForRef({ owner: null, repo: null, number: 42 })).toBe(
+      'gitlab',
+    );
+  });
+});

--- a/lib/shared/detect-platform.ts
+++ b/lib/shared/detect-platform.ts
@@ -1,0 +1,51 @@
+/**
+ * Platform detection — cwd-based and ref-based.
+ *
+ * The single source of truth for whether the current repo (or a qualified
+ * issue ref) lives on GitHub or GitLab. Handlers and adapters import from
+ * here rather than rolling local copies — a prior local copy in `pr_list.ts`
+ * inverted the check (`url.includes('github')`) which gives the wrong answer
+ * for self-hosted enterprise deployments.
+ *
+ * Moved from `lib/glab.ts` per R-17 (Story 1.2). `lib/glab.ts` re-exports
+ * these functions during the transition; final deletion of the re-exports
+ * happens in Phase 3.
+ */
+
+import { execSync } from 'child_process';
+import type { IssueRef } from '../spec_parser.js';
+
+export type Platform = 'github' | 'gitlab';
+
+/**
+ * Detect whether the current repo's origin is a GitLab or GitHub remote.
+ *
+ * Returns `'gitlab'` if the origin URL contains `'gitlab'` (matches gitlab.com
+ * and any self-hosted `gitlab.<company>.com`), otherwise `'github'`. Falls
+ * back to `'github'` if the origin cannot be read.
+ */
+export function detectPlatform(): Platform {
+  try {
+    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    return url.includes('gitlab') ? 'gitlab' : 'github';
+  } catch {
+    return 'github';
+  }
+}
+
+/**
+ * Detect platform for a qualified issue ref (`owner/repo#N`).
+ *
+ * When a ref includes an owner path, we can infer the platform:
+ * - If the owner has multiple segments (e.g. `org/sub/group`), it MUST be
+ *   GitLab — GitHub only supports single-segment owners.
+ * - Otherwise, fall back to cwd-based detection (ambiguous).
+ *
+ * When a ref is local (no owner/repo), falls back to cwd-based detection.
+ */
+export function detectPlatformForRef(ref: IssueRef): Platform {
+  if (ref.owner && ref.owner.includes('/')) {
+    return 'gitlab';
+  }
+  return detectPlatform();
+}

--- a/lib/shared/parse-repo-slug.test.ts
+++ b/lib/shared/parse-repo-slug.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string) => execMockFn(cmd));
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { parseRepoSlug } = await import('./parse-repo-slug.ts');
+
+function reset() {
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+}
+
+describe('parseRepoSlug (lib/shared/)', () => {
+  beforeEach(() => reset());
+
+  test('parses HTTPS GitHub URL', () => {
+    execMockFn = () => 'https://github.com/owner/repo.git';
+    expect(parseRepoSlug()).toBe('owner/repo');
+  });
+
+  test('parses HTTPS GitLab URL', () => {
+    execMockFn = () => 'https://gitlab.com/owner/repo.git';
+    expect(parseRepoSlug()).toBe('owner/repo');
+  });
+
+  test('parses SSH GitHub URL', () => {
+    execMockFn = () => 'git@github.com:owner/repo.git';
+    expect(parseRepoSlug()).toBe('owner/repo');
+  });
+
+  test('parses SSH GitLab URL', () => {
+    execMockFn = () => 'git@gitlab.com:owner/repo.git';
+    expect(parseRepoSlug()).toBe('owner/repo');
+  });
+
+  test('parses URL without .git suffix', () => {
+    execMockFn = () => 'https://github.com/owner/repo';
+    expect(parseRepoSlug()).toBe('owner/repo');
+  });
+
+  test('parses deeply nested GitLab group path', () => {
+    execMockFn = () => 'https://gitlab.com/org/sub/group/repo.git';
+    expect(parseRepoSlug()).toBe('org/sub/group/repo');
+  });
+
+  test('parses self-hosted GitLab SSH with nested path', () => {
+    execMockFn = () => 'git@gitlab.company.com:team/project/sub/repo.git';
+    expect(parseRepoSlug()).toBe('team/project/sub/repo');
+  });
+
+  test('returns null when origin cannot be read', () => {
+    execMockFn = () => {
+      throw new Error('not a git repository');
+    };
+    expect(parseRepoSlug()).toBeNull();
+  });
+
+  test('returns null when URL does not match expected pattern', () => {
+    execMockFn = () => 'this-is-not-a-git-url';
+    expect(parseRepoSlug()).toBeNull();
+  });
+
+  // Helper-move regression test (per Story 1.2 AC):
+  // proves the function still works when imported from its new lib/shared/
+  // location — the goal of the move was to share without coupling to lib/glab.ts.
+  test('helper-move regression: import works from lib/shared/', () => {
+    execMockFn = () => 'https://github.com/Wave-Engineering/mcp-server-sdlc.git';
+    expect(parseRepoSlug()).toBe('Wave-Engineering/mcp-server-sdlc');
+  });
+});

--- a/lib/shared/parse-repo-slug.ts
+++ b/lib/shared/parse-repo-slug.ts
@@ -1,0 +1,32 @@
+/**
+ * Repo slug parsing from the cwd's git remote.
+ *
+ * Handles SSH and HTTPS remote formats, including deeply nested GitLab group
+ * paths. The single source of truth for slug parsing — handlers and adapters
+ * import from here rather than rolling local copies.
+ *
+ * Moved from `lib/glab.ts` per R-17 (Story 1.2). `lib/glab.ts` re-exports
+ * these functions during the transition; final deletion of the re-exports
+ * happens in Phase 3.
+ */
+
+import { execSync } from 'child_process';
+
+/**
+ * Parse the project slug from the current repo's origin URL.
+ *
+ * Handles both SSH (`git@host:path.git`) and HTTPS
+ * (`https://host/path(.git)?`) remote formats, including deeply nested
+ * GitLab group paths (e.g. `org/sub/group/repo`). Returns `null` if the
+ * origin cannot be read or the URL does not match the expected pattern.
+ */
+export function parseRepoSlug(): string | null {
+  try {
+    const url = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    const m = /(?:git@[^:]+:|https?:\/\/[^/]+\/)(.+?)(?:\.git)?$/.exec(url);
+    if (m) return m[1];
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/scripts/ci/gate-greps.sh
+++ b/scripts/ci/gate-greps.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Adapter-retrofit gate-greps (R-09, R-10).
+#
+# Two greps run against handlers/*.ts MINUS the entries in
+# scripts/ci/migration-allowlist.txt:
+#
+#   1. `if (platform === 'github'|'gitlab')` — inline platform branching
+#   2. `execSync('gh ...'|'glab ...')` or `Bun.spawnSync(...)` — direct
+#       subprocess invocation
+#
+# The allowlist is the EXCLUDE list: handlers in it are exempt from the gate
+# until their migration story removes them. Handlers NOT in the allowlist must
+# stay clean — adding inline platform branching or a direct subprocess call to
+# any non-allowlisted handler fails the build.
+#
+# By Phase 3 close (Story 3.6) the allowlist file is empty (or deleted) and
+# the gates enforce against every handler globally.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+ALLOWLIST=scripts/ci/migration-allowlist.txt
+HANDLERS_DIR=handlers
+
+if [[ ! -f $ALLOWLIST ]]; then
+    echo "FAIL: $ALLOWLIST not found"
+    exit 1
+fi
+
+# Build the set of allowed (exempt) basenames.
+declare -A allowed_set=()
+while IFS= read -r line; do
+    # Strip leading/trailing whitespace and skip blanks/comments.
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z $line || ${line:0:1} == "#" ]] && continue
+    allowed_set["$line"]=1
+done < "$ALLOWLIST"
+
+# Build the list of handlers to check — every handlers/*.ts whose basename is
+# NOT in the allowlist.
+handlers_to_check=()
+shopt -s nullglob
+for path in "$HANDLERS_DIR"/*.ts; do
+    base=$(basename "$path")
+    # Skip the codegen-generated registry — never platform-aware by design.
+    [[ $base == "_registry.ts" ]] && continue
+    if [[ -z ${allowed_set[$base]:-} ]]; then
+        handlers_to_check+=("$path")
+    fi
+done
+shopt -u nullglob
+
+if [[ ${#handlers_to_check[@]} -eq 0 ]]; then
+    echo "gate-greps: zero handlers to check (all handlers are allowlisted)"
+    exit 0
+fi
+
+echo "gate-greps: checking ${#handlers_to_check[@]} non-allowlisted handler(s)"
+
+failed=0
+
+# Gate-grep #1 — inline platform branching (R-09).
+# Match any direct `platform === 'github'|'gitlab'` comparison, not just the
+# `if (platform === ...)` statement form: ternaries and assignments
+# (`const x = platform === 'github' ? ...`) violate the same constraint.
+if grep -nE "platform === '(github|gitlab)'" "${handlers_to_check[@]}"; then
+    echo ""
+    echo "GATE FAIL [R-09]: inline platform branching found in non-allowlisted handler(s)."
+    echo "  These handlers must dispatch through getAdapter() rather than branch on platform."
+    failed=1
+fi
+
+# Gate-grep #2 — direct subprocess to gh/glab/Bun.spawnSync (R-10).
+if grep -nE "execSync\(['\"\`](gh|glab) |Bun\.spawnSync" "${handlers_to_check[@]}"; then
+    echo ""
+    echo "GATE FAIL [R-10]: direct subprocess to gh/glab/Bun.spawnSync in non-allowlisted handler(s)."
+    echo "  Subprocess invocation lives in lib/adapters/<method>-<platform>.ts files only."
+    failed=1
+fi
+
+if [[ $failed -ne 0 ]]; then
+    exit 1
+fi
+
+echo "gate-greps: OK"

--- a/scripts/ci/migration-allowlist.txt
+++ b/scripts/ci/migration-allowlist.txt
@@ -1,0 +1,43 @@
+# Platform-aware handlers EXEMPT from the gate-grep until they're migrated to
+# the adapter pattern (Phase 1 Stories 1.3-1.11, Phase 2). Each migration
+# story removes its handler from this list as part of its acceptance criteria.
+#
+# Phase 3 closing story (Story 3.6) verifies this file is empty (or deletes it
+# entirely) — at which point the gate-greps enforce against ALL handlers.
+#
+# Truth on disk at Story 1.2 land time: 32 handlers (the dev spec said 31; an
+# off-by-one that was reconciled to disk reality).
+#
+# Format: one basename per line. Comments (#) and blank lines ignored.
+ci_failed_jobs.ts
+ci_run_logs.ts
+ci_run_status.ts
+ci_runs_for_branch.ts
+ci_wait_run.ts
+dod_load_manifest.ts
+epic_sub_issues.ts
+ibm.ts
+label_create.ts
+label_list.ts
+pr_comment.ts
+pr_create.ts
+pr_diff.ts
+pr_files.ts
+pr_list.ts
+pr_merge.ts
+pr_merge_wait.ts
+pr_status.ts
+pr_wait_ci.ts
+spec_acceptance_criteria.ts
+spec_dependencies.ts
+spec_get.ts
+spec_validate_structure.ts
+wave_ci_trust_level.ts
+wave_compute.ts
+wave_dependency_graph.ts
+wave_finalize.ts
+wave_init.ts
+wave_previous_merged.ts
+wave_reconcile_mrs.ts
+wave_topology.ts
+work_item.ts

--- a/scripts/ci/validate.sh
+++ b/scripts/ci/validate.sh
@@ -12,6 +12,9 @@ echo "--- codegen ---"
 echo "--- TypeScript lint ---"
 bun run lint
 
+echo "--- adapter-retrofit gate-greps ---"
+./scripts/ci/gate-greps.sh
+
 echo "--- shellcheck ---"
 shopt -s nullglob
 scripts=( scripts/ci/*.sh )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "declaration": true,
     "types": ["bun"]
   },
-  "include": ["*.ts", "handlers/**/*.ts", "tests/**/*.ts"],
+  "include": ["*.ts", "handlers/**/*.ts", "lib/**/*.ts", "tests/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

Story 1.2 of the platform-adapter retrofit. Builds the empty `lib/adapters/` scaffolding (interface, dispatch, GitHub/GitLab assemblers), extracts platform-agnostic helpers from `lib/glab.ts` into `lib/shared/`, and lands the CI gate-greps that prevent regression as Stories 1.3–1.11 migrate handlers.

## Changes

**Adapter scaffold (`lib/adapters/`)**
- `types.ts` — `PlatformAdapter` interface (24 methods: pr/ci/label/issue/spec/hybrid families) + `AdapterResult<T>` discriminated union (R-01, R-02). Runtime `PLATFORM_ADAPTER_METHODS` constant + compile-time exhaustiveness check (catches keys-not-in-list; reverse caught by the runtime contract test).
- `route.ts` — `getAdapter()` sync dispatch (R-06, CT-03). Accepts optional `{repo}` arg for forward-compat with cross-repo dispatch.
- `github.ts` + `gitlab.ts` — empty assemblers; every method returns `{platform_unsupported: true, hint: 'not yet migrated'}`. Each migration story replaces one entry with a real impl.
- `index.ts` — public surface (R-08).
- `types.test.ts` — contract test (R-04, 49 cases iterating `PLATFORM_ADAPTER_METHODS` for both adapters + vacuous-pass behavior check).
- `route.test.ts` — dispatch correctness (5 cases).

**Shared helpers (`lib/shared/`)**
- `detect-platform.ts` — `detectPlatform`, `detectPlatformForRef` lifted from `lib/glab.ts`. Pure code move — behavior unchanged.
- `parse-repo-slug.ts` — `parseRepoSlug` lifted from `lib/glab.ts`.
- `lib/glab.ts` no longer DEFINES the moved helpers — re-exports from `lib/shared/` for the transition; final deletion in Phase 3.

**Gate-greps (`scripts/ci/`)**
- `migration-allowlist.txt` — 32 platform-aware handler basenames seeded as exempt (the dev spec said 31; reconciled to disk truth — `pr_create` + `pr_comment` have local `detectPlatform` helpers that the spec count missed). Each migration story removes its handler from this list as part of its AC; Phase 3 closing story empties the file.
- `gate-greps.sh` — runs against `handlers/*.ts` MINUS the allowlist. **R-09**: zero `platform === 'github'|'gitlab'` (statement OR ternary form). **R-10**: zero `execSync('gh '|'glab ')` or `Bun.spawnSync`.
- `validate.sh` — new `--- adapter-retrofit gate-greps ---` step before shellcheck.

**Importer rewrites** — 30 handlers updated to import `detectPlatform`/`detectPlatformForRef`/`parseRepoSlug` from `lib/shared/...` instead of `lib/glab.js`. Mechanical scripted regex rewrite — no logic change. Verified by full suite (1466/0 vs prior 1393/0).

**Config** — `tsconfig.json` adds `lib/**/*.ts` to `include` so colocated tests get type-checked.

## Linked Issues

Closes #239

## Test Plan

- [x] `bun test` — **1466 / 0** (was 1393; +73 from new tests across 5 new files)
- [x] `bun run lint` — `tsc --noEmit` clean
- [x] `./scripts/ci/validate.sh` — codegen, lint, gate-greps (NEW), shellcheck, tests, smoke 73/73 — all green
- [x] `./scripts/ci/gate-greps.sh` standalone — checks 41 non-allowlisted handlers, all clean
- [x] Sanity check: appended `if (platform === 'github')` + `execSync('gh ...')` + ternary form to `wave_show.ts`; confirmed all three forms fired the gate with file:line; reverted
- [x] `trivy fs --severity HIGH,CRITICAL` — 0 findings on `bun.lock`
- [x] Code review: 2 HIGH-confidence findings fixed in-PR
  - Misleading `_MethodsExhaustive` comment ("bidirectional" → corrected to describe unidirectional + runtime safety net)
  - R-09 ternary blind spot (regex was `if \(platform === ...\)` → broadened to `platform === '(github|gitlab)'`)
- [ ] CI green on the PR (in flight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)