### PR TITLE
feat(adapters): migrate pr_create to PlatformAdapter pair

### DIFF
--- a/handlers/pr_create.ts
+++ b/handlers/pr_create.ts
@@ -1,22 +1,17 @@
-// Origin Operations family handler.
-// See docs/handlers/origin-operations-guide.md for the canonical pattern,
-// gh ↔ glab field mappings, and normalized response schemas.
+// Origin Operations family handler — adapter-dispatching shell.
+// Subprocess + platform branching live in lib/adapters/pr-create-{github,gitlab}.ts;
+// see docs/handlers/origin-operations-guide.md for the canonical pattern and
+// docs/platform-adapter-retrofit-devspec.md §5 for the contract.
 
-import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-
-// Codebase convention: child_process.execSync (29/36 handlers, including
-// pr_merge). Tests mock it via `mock.module('child_process', ...)`. This
-// handler was migrated from Bun's spawn API for uniformity (#238) so the
-// adapter retrofit can stub the subprocess boundary in one place.
+import { getAdapter } from '../lib/adapters/index.js';
 
 const inputSchema = z.object({
   title: z.string().min(1, 'title must be a non-empty string'),
   body: z.string().min(1, 'body must be a non-empty string'),
-  // base is optional — when omitted, the handler queries the platform for
-  // the repo's default branch. /scp + sibling skills can stop probing for
-  // it themselves. See #159.
+  // base is optional — when omitted, the adapter resolves the repo's
+  // default branch so /scp + sibling skills don't need to probe it (#159).
   base: z.string().min(1).optional(),
   head: z.string().optional(),
   draft: z.boolean().optional().default(false),
@@ -26,310 +21,8 @@ const inputSchema = z.object({
     .optional(),
 });
 
-type Input = z.infer<typeof inputSchema>;
-
-function projectDir(): string {
-  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
-}
-
-interface RunResult {
-  exitCode: number;
-  stdout: string;
-  stderr: string;
-}
-
-interface ExecError extends Error {
-  stdout?: Buffer | string;
-  stderr?: Buffer | string;
-  status?: number;
-}
-
-function bufToString(b: unknown): string {
-  if (b === undefined || b === null) return '';
-  if (typeof b === 'string') return b;
-  if (typeof (b as Buffer).toString === 'function') return (b as Buffer).toString();
-  return String(b);
-}
-
-function shellEscape(value: string): string {
-  // Single-quote the arg and escape any embedded single quotes — same form
-  // as pr_merge.ts / pr_list.ts. Safe for arbitrary user-supplied strings
-  // (titles, bodies, branch names) when the shell is invoked.
-  return `'${value.replace(/'/g, `'\\''`)}'`;
-}
-
-// Convert execSync's exception-on-non-zero contract into the result-bag
-// shape the rest of the handler already consumes. Keeps downstream branching
-// (which checks exitCode and stdout/stderr) untouched after the migration.
-function run(cmd: string[], cwd: string): RunResult {
-  const shellCmd = cmd.map(shellEscape).join(' ');
-  try {
-    const stdout = execSync(shellCmd, { cwd, encoding: 'utf8' });
-    return { exitCode: 0, stdout, stderr: '' };
-  } catch (err) {
-    const e = err as ExecError;
-    return {
-      exitCode: typeof e.status === 'number' ? e.status : -1,
-      stdout: bufToString(e.stdout),
-      stderr: bufToString(e.stderr) || (err instanceof Error ? err.message : String(err)),
-    };
-  }
-}
-
-// Platform detection from the project's git remote. The .claude-project.md
-// approach was too fragile — a mention of "GitLab CI" in a GitHub project
-// would misroute to glab. Use the git remote URL as the source of truth.
-async function detectPlatform(cwd: string): Promise<'github' | 'gitlab'> {
-  const remote = run(['git', 'remote', '-v'], cwd);
-  const firstLine = remote.stdout.split('\n')[0] ?? '';
-  if (/gitlab/i.test(firstLine)) return 'gitlab';
-  return 'github';
-}
-
-function getCurrentBranch(cwd: string): string {
-  const result = run(['git', 'branch', '--show-current'], cwd);
-  if (result.exitCode !== 0) {
-    throw new Error(`git branch --show-current failed: ${result.stderr.trim()}`);
-  }
-  return result.stdout.trim();
-}
-
-/**
- * Query the platform for the repo's default branch name. Used when the
- * caller omits `base` so /scp + sibling skills can stop probing for it
- * themselves (#159).
- *
- * GitHub: `gh repo view <slug?> --json defaultBranchRef --jq .defaultBranchRef.name`
- * GitLab: `glab api projects/<encoded> --jq .default_branch` (or `glab repo view`
- *         when no explicit slug is provided — the porcelain command resolves
- *         from the cwd's remote).
- */
-function getDefaultBranch(
-  platform: 'github' | 'gitlab',
-  repo: string | undefined,
-  cwd: string,
-): string {
-  if (platform === 'github') {
-    const cmd = ['gh', 'repo', 'view'];
-    if (repo !== undefined) cmd.push(repo);
-    cmd.push('--json', 'defaultBranchRef', '--jq', '.defaultBranchRef.name');
-    const result = run(cmd, cwd);
-    if (result.exitCode !== 0 || result.stdout.trim().length === 0) {
-      throw new Error(
-        `failed to resolve GitHub default branch: ${result.stderr.trim() || 'empty response'}`,
-      );
-    }
-    return result.stdout.trim();
-  }
-  // GitLab — `glab repo view` doesn't expose default_branch reliably across
-  // versions; the API path does. Use `glab api projects/<encoded>` when an
-  // explicit slug is provided, fall back to `:id` (which glab resolves from
-  // the cwd remote) when not. NB: `glab api` has NO `--jq` flag (unlike
-  // `gh api`); we parse the JSON in-process.
-  const project = repo !== undefined ? repo.replace(/\//g, '%2F') : ':id';
-  const result = run(['glab', 'api', `projects/${project}`], cwd);
-  if (result.exitCode !== 0 || result.stdout.trim().length === 0) {
-    throw new Error(
-      `failed to resolve GitLab default branch: ${result.stderr.trim() || 'empty response'}`,
-    );
-  }
-  try {
-    const parsed = JSON.parse(result.stdout) as { default_branch?: string };
-    if (typeof parsed.default_branch !== 'string' || parsed.default_branch.length === 0) {
-      throw new Error('default_branch missing or empty in glab api response');
-    }
-    return parsed.default_branch;
-  } catch (err) {
-    throw new Error(
-      `failed to resolve GitLab default branch: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
-}
-
-interface NormalizedPr {
-  number: number;
-  url: string;
-  state: 'open';
-  head: string;
-  base: string;
-  created: boolean;
-}
-
-function lookupGithubPr(head: string, cwd: string, repo?: string): NormalizedPr | null {
-  const cmd = ['gh', 'pr', 'list', '--head', head, '--state', 'open', '--json', 'number,url,state,headRefName,baseRefName', '--limit', '1'];
-  if (repo !== undefined) cmd.push('--repo', repo);
-  const list = run(cmd, cwd);
-  if (list.exitCode !== 0) return null;
-  const prs = JSON.parse(list.stdout) as Array<{
-    number: number;
-    url: string;
-    state: string;
-    headRefName: string;
-    baseRefName: string;
-  }>;
-  if (prs.length === 0) return null;
-  return {
-    number: prs[0].number,
-    url: prs[0].url,
-    state: 'open',
-    head: prs[0].headRefName,
-    base: prs[0].baseRefName,
-    created: false,
-  };
-}
-
-function createGithubPr(args: Input, head: string, cwd: string): NormalizedPr {
-  // Caller guarantees base is resolved (default-branch lookup happens in
-  // execute() before dispatch). Assert here to satisfy the type narrower —
-  // a missing base at this point indicates a logic bug in the caller.
-  if (args.base === undefined) {
-    throw new Error('createGithubPr called without resolved base — caller bug');
-  }
-  const createCmd = [
-    'gh',
-    'pr',
-    'create',
-    '--title',
-    args.title,
-    '--body',
-    args.body,
-    '--base',
-    args.base,
-    '--head',
-    head,
-  ];
-  if (args.draft) createCmd.push('--draft');
-  if (args.repo !== undefined) createCmd.push('--repo', args.repo);
-
-  const result = run(createCmd, cwd);
-  if (result.exitCode !== 0) {
-    const errText = (result.stderr + result.stdout).toLowerCase();
-    // gh says "a pull request for branch ... already exists" on duplicate
-    if (errText.includes('already exists')) {
-      const existing = lookupGithubPr(head, cwd, args.repo);
-      if (existing) return existing;
-      // Lookup failed (PR may have been closed between create and lookup)
-      throw new Error(`gh pr create: PR already exists for branch '${head}' but could not be found via lookup`);
-    }
-    throw new Error(`gh pr create failed: ${result.stderr.trim() || result.stdout.trim()}`);
-  }
-
-  // gh pr create prints the PR URL on stdout. Parse the number from the URL.
-  const url = result.stdout.trim().split('\n').pop() ?? '';
-  const numMatch = /\/pull\/(\d+)/.exec(url);
-  if (!numMatch) {
-    throw new Error(`gh pr create: could not parse PR number from output: ${url}`);
-  }
-  const prNumber = parseInt(numMatch[1], 10);
-
-  // Fetch canonical details to normalize the response.
-  const viewCmd = ['gh', 'pr', 'view', String(prNumber), '--json', 'number,url,state,headRefName,baseRefName'];
-  if (args.repo !== undefined) viewCmd.push('--repo', args.repo);
-  const view = run(viewCmd, cwd);
-  if (view.exitCode !== 0) {
-    throw new Error(`gh pr view failed: ${view.stderr.trim() || view.stdout.trim()}`);
-  }
-  const parsed = JSON.parse(view.stdout) as {
-    number: number;
-    url: string;
-    state: string;
-    headRefName: string;
-    baseRefName: string;
-  };
-  return {
-    number: parsed.number,
-    url: parsed.url,
-    state: 'open',
-    head: parsed.headRefName,
-    base: parsed.baseRefName,
-    created: true,
-  };
-}
-
-function lookupGitlabMr(head: string, cwd: string, repo?: string): NormalizedPr | null {
-  const cmd = ['glab', 'mr', 'view', head, '-F', 'json'];
-  if (repo !== undefined) cmd.push('-R', repo);
-  const view = run(cmd, cwd);
-  if (view.exitCode !== 0) return null;
-  try {
-    const parsed = JSON.parse(view.stdout) as {
-      iid: number;
-      web_url: string;
-      state: string;
-      source_branch: string;
-      target_branch: string;
-    };
-    if (parsed.state !== 'opened') return null;
-    return {
-      number: parsed.iid,
-      url: parsed.web_url,
-      state: 'open',
-      head: parsed.source_branch,
-      base: parsed.target_branch,
-      created: false,
-    };
-  } catch {
-    return null;
-  }
-}
-
-function createGitlabMr(args: Input, head: string, cwd: string): NormalizedPr {
-  // Caller guarantees base is resolved — see comment in createGithubPr.
-  if (args.base === undefined) {
-    throw new Error('createGitlabMr called without resolved base — caller bug');
-  }
-  const createCmd = [
-    'glab',
-    'mr',
-    'create',
-    '--title',
-    args.title,
-    '--description',
-    args.body,
-    '--target-branch',
-    args.base,
-    '--source-branch',
-    head,
-    '--yes',
-  ];
-  if (args.draft) createCmd.push('--draft');
-  if (args.repo !== undefined) createCmd.push('-R', args.repo);
-
-  const result = run(createCmd, cwd);
-  if (result.exitCode !== 0) {
-    const errText = (result.stderr + result.stdout).toLowerCase();
-    // glab says "Another open merge request already exists" on duplicate
-    if (errText.includes('already exists')) {
-      const existing = lookupGitlabMr(head, cwd, args.repo);
-      if (existing) return existing;
-      // Lookup failed (MR may have been closed between create and lookup)
-      throw new Error(`glab mr create: MR already exists for branch '${head}' but could not be found via lookup`);
-    }
-    throw new Error(`glab mr create failed: ${result.stderr.trim() || result.stdout.trim()}`);
-  }
-
-  // Normalize by fetching the MR we just created via `glab mr view <head> -F json`.
-  const viewCmd = ['glab', 'mr', 'view', head, '-F', 'json'];
-  if (args.repo !== undefined) viewCmd.push('-R', args.repo);
-  const view = run(viewCmd, cwd);
-  if (view.exitCode !== 0) {
-    throw new Error(`glab mr view failed: ${view.stderr.trim() || view.stdout.trim()}`);
-  }
-  const parsed = JSON.parse(view.stdout) as {
-    iid: number;
-    web_url: string;
-    state: string;
-    source_branch: string;
-    target_branch: string;
-  };
-  return {
-    number: parsed.iid,
-    url: parsed.web_url,
-    state: 'open',
-    head: parsed.source_branch,
-    base: parsed.target_branch,
-    created: true,
-  };
+function envelope(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] };
 }
 
 const prCreateHandler: HandlerDef = {
@@ -338,45 +31,25 @@ const prCreateHandler: HandlerDef = {
     'Create a pull request (GitHub) or merge request (GitLab) for the current branch. Returns the normalized {number, url, state, head, base}.',
   inputSchema,
   async execute(rawArgs: unknown) {
-    let args: Input;
+    let args;
     try {
       args = inputSchema.parse(rawArgs);
     } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
 
-    try {
-      const cwd = projectDir();
-      const head = args.head ?? getCurrentBranch(cwd);
-      const platform = await detectPlatform(cwd);
-      // Resolve `base` from the repo's default branch when omitted (#159).
-      // `createGithub*/createGitlab*` both read from `args.base`, so we
-      // mutate the parsed args in place — keeps both downstream paths simple.
-      if (args.base === undefined || args.base.length === 0) {
-        args.base = getDefaultBranch(platform, args.repo, cwd);
-      }
-      const pr =
-        platform === 'github'
-          ? createGithubPr(args, head, cwd)
-          : createGitlabMr(args, head, cwd);
+    const adapter = getAdapter({ repo: args.repo });
+    const result = await adapter.prCreate(args);
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({ ok: true, ...pr }),
-          },
-        ],
-      };
-    } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+    // Per dev spec §4.4 step 4: surface `platform_unsupported` as a typed
+    // signal alongside `ok: true` — NOT as an error. The dispatch succeeded;
+    // the platform just doesn't have the concept. Callers branch on the
+    // discriminator instead of confusing it with a runtime failure.
+    if ('platform_unsupported' in result) {
+      return envelope({ ok: true, platform_unsupported: true, hint: result.hint });
     }
+    if (!result.ok) return envelope({ ok: false, error: result.error });
+    return envelope({ ok: true, ...result.data });
   },
 };
 

--- a/lib/adapters/github.ts
+++ b/lib/adapters/github.ts
@@ -14,6 +14,7 @@
  */
 
 import type { PlatformAdapter } from './types.js';
+import { prCreateGithub } from './pr-create-github.js';
 
 const stubMethod = async (_args: unknown) => ({
   platform_unsupported: true as const,
@@ -21,7 +22,7 @@ const stubMethod = async (_args: unknown) => ({
 });
 
 export const githubAdapter: PlatformAdapter = {
-  prCreate: stubMethod,
+  prCreate: prCreateGithub,
   prMerge: stubMethod,
   prMergeWait: stubMethod,
   prStatus: stubMethod,

--- a/lib/adapters/gitlab.ts
+++ b/lib/adapters/gitlab.ts
@@ -15,6 +15,7 @@
  */
 
 import type { PlatformAdapter } from './types.js';
+import { prCreateGitlab } from './pr-create-gitlab.js';
 
 const stubMethod = async (_args: unknown) => ({
   platform_unsupported: true as const,
@@ -22,7 +23,7 @@ const stubMethod = async (_args: unknown) => ({
 });
 
 export const gitlabAdapter: PlatformAdapter = {
-  prCreate: stubMethod,
+  prCreate: prCreateGitlab,
   prMerge: stubMethod,
   prMergeWait: stubMethod,
   prStatus: stubMethod,

--- a/lib/adapters/pr-create-github.test.ts
+++ b/lib/adapters/pr-create-github.test.ts
@@ -1,0 +1,247 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { AdapterResult, PrCreateResponse } from './types.ts';
+
+// Subprocess-boundary tests for the GitHub pr_create adapter (R-15).
+// Integration-level coverage (handler dispatch, error envelope, idempotency)
+// stays in tests/pr_create.test.ts; this file owns the argv-shape and
+// response-parsing assertions that prove the adapter speaks `gh` correctly.
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { prCreateGithub } = await import('./pr-create-github.ts');
+
+function on(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
+// Narrow AdapterResult into the success branch — throws if it's an error or
+// platform_unsupported variant. Lets test bodies access `.data` directly
+// without nested `if ('ok' in r && r.ok)` ceremony at every assertion.
+function expectOk(
+  r: AdapterResult<PrCreateResponse>,
+): asserts r is { ok: true; data: PrCreateResponse } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectErr(
+  r: AdapterResult<PrCreateResponse>,
+): asserts r is { ok: false; error: string; code: string } {
+  if (!('ok' in r) || r.ok) {
+    throw new Error(`expected error result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('prCreateGithub — subprocess boundary', () => {
+  test('gh CLI invocation matches expected argv shape (happy path)', async () => {
+    on('git branch --show-current', 'feature/x\n');
+    on(
+      'gh pr create',
+      'https://github.com/owner/repo/pull/42\n',
+    );
+    on(
+      'gh pr view',
+      JSON.stringify({
+        number: 42,
+        url: 'https://github.com/owner/repo/pull/42',
+        state: 'OPEN',
+        headRefName: 'feature/x',
+        baseRefName: 'main',
+      }),
+    );
+
+    const result = await prCreateGithub({
+      title: 'a title',
+      body: 'a body',
+      base: 'main',
+    });
+
+    expectOk(result);
+    expect(result.data.number).toBe(42);
+
+    const createCall = findCall('gh pr create');
+    expect(createCall).toContain('--title');
+    expect(createCall).toContain('a title');
+    expect(createCall).toContain('--body');
+    expect(createCall).toContain('a body');
+    expect(createCall).toContain('--base');
+    expect(createCall).toContain('main');
+    expect(createCall).toContain('--head');
+    expect(createCall).toContain('feature/x');
+    // Draft flag absent when not requested.
+    expect(createCall).not.toContain('--draft');
+  });
+
+  test('parses gh pr view response into PrCreateResponse', async () => {
+    on('git branch --show-current', 'feature/y\n');
+    on('gh pr create', 'https://github.com/o/r/pull/7\n');
+    on(
+      'gh pr view',
+      JSON.stringify({
+        number: 7,
+        url: 'https://github.com/o/r/pull/7',
+        state: 'OPEN',
+        headRefName: 'feature/y',
+        baseRefName: 'develop',
+      }),
+    );
+
+    const result = await prCreateGithub({ title: 't', body: 'b', base: 'develop' });
+    expectOk(result);
+    expect(result.data).toEqual({
+      number: 7,
+      url: 'https://github.com/o/r/pull/7',
+      state: 'open',
+      head: 'feature/y',
+      base: 'develop',
+      created: true,
+    });
+  });
+
+  test('returns AdapterResult{ok:false, code} on gh failure (not thrown)', async () => {
+    on('git branch --show-current', 'feature/z\n');
+    on('gh pr create', () => {
+      const err = new Error('gh: auth required') as ThrowableError;
+      err.stderr = 'gh: auth required';
+      err.status = 4;
+      throw err;
+    });
+
+    const result = await prCreateGithub({ title: 't', body: 'b', base: 'main' });
+    expectErr(result);
+    expect(result.code).toBe('gh_pr_create_failed');
+    expect(result.error).toContain('gh pr create failed');
+  });
+
+  test('idempotent path: "already exists" → looks up existing PR and returns created:false', async () => {
+    on('git branch --show-current', 'feature/dup\n');
+    on('gh pr create', () => {
+      const err = new Error('a pull request for branch already exists') as ThrowableError;
+      err.stderr = 'a pull request for branch already exists';
+      err.status = 1;
+      throw err;
+    });
+    on(
+      'gh pr list',
+      JSON.stringify([
+        {
+          number: 99,
+          url: 'https://github.com/o/r/pull/99',
+          state: 'OPEN',
+          headRefName: 'feature/dup',
+          baseRefName: 'main',
+        },
+      ]),
+    );
+
+    const result = await prCreateGithub({ title: 't', body: 'b', base: 'main' });
+    expectOk(result);
+    expect(result.data.number).toBe(99);
+    expect(result.data.created).toBe(false);
+  });
+
+  test('--draft flag added when args.draft=true', async () => {
+    on('git branch --show-current', 'draft-branch\n');
+    on('gh pr create', 'https://github.com/o/r/pull/3\n');
+    on(
+      'gh pr view',
+      JSON.stringify({
+        number: 3,
+        url: 'https://github.com/o/r/pull/3',
+        state: 'OPEN',
+        headRefName: 'draft-branch',
+        baseRefName: 'main',
+      }),
+    );
+
+    await prCreateGithub({ title: 't', body: 'b', base: 'main', draft: true });
+    expect(findCall('gh pr create')).toContain('--draft');
+  });
+
+  test('--repo flag forwarded when args.repo provided', async () => {
+    on('git branch --show-current', 'feature/cross\n');
+    on('gh pr create', 'https://github.com/Org/Other/pull/12\n');
+    on(
+      'gh pr view',
+      JSON.stringify({
+        number: 12,
+        url: 'https://github.com/Org/Other/pull/12',
+        state: 'OPEN',
+        headRefName: 'feature/cross',
+        baseRefName: 'main',
+      }),
+    );
+
+    await prCreateGithub({ title: 't', body: 'b', base: 'main', repo: 'Org/Other' });
+    const create = findCall('gh pr create');
+    expect(create).toContain('--repo');
+    expect(create).toContain('Org/Other');
+    const view = findCall('gh pr view');
+    expect(view).toContain('--repo');
+    expect(view).toContain('Org/Other');
+  });
+
+  test('default-branch resolution via gh repo view when args.base is undefined', async () => {
+    on('git branch --show-current', 'feature/no-base\n');
+    on('gh repo view', 'develop\n');
+    on('gh pr create', 'https://github.com/o/r/pull/55\n');
+    on(
+      'gh pr view',
+      JSON.stringify({
+        number: 55,
+        url: 'https://github.com/o/r/pull/55',
+        state: 'OPEN',
+        headRefName: 'feature/no-base',
+        baseRefName: 'develop',
+      }),
+    );
+
+    const result = await prCreateGithub({ title: 't', body: 'b' });
+    expectOk(result);
+    const probe = findCall('gh repo view');
+    expect(probe).toContain('--json');
+    expect(probe).toContain('defaultBranchRef');
+    expect(probe).toContain('--jq');
+    // Confirm the resolved value flowed into the create call's --base.
+    const create = findCall('gh pr create');
+    expect(create).toContain('--base');
+    expect(create).toContain('develop');
+  });
+});

--- a/lib/adapters/pr-create-github.ts
+++ b/lib/adapters/pr-create-github.ts
@@ -1,0 +1,189 @@
+/**
+ * GitHub `pr_create` adapter implementation.
+ *
+ * Lifted from `handlers/pr_create.ts` per Story 1.3. The handler is now a
+ * thin dispatcher; this module owns the GitHub-specific subprocess work and
+ * normalizes the response into `AdapterResult<PrCreateResponse>`.
+ *
+ * Errors that come back from `gh` are converted into `{ok: false, error, code}`
+ * — never thrown — so the handler doesn't need a try/catch around the dispatch.
+ */
+
+import { execSync } from 'child_process';
+import { runArgv, type RunResult } from '../shared/error-norm.js';
+import type {
+  AdapterResult,
+  PrCreateArgs,
+  PrCreateResponse,
+} from './types.js';
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function getCurrentBranch(cwd: string): string {
+  const result = runArgv(['git', 'branch', '--show-current'], cwd);
+  if (result.exitCode !== 0) {
+    throw new Error(`git branch --show-current failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout.trim();
+}
+
+/**
+ * Resolve the repo's default branch via `gh repo view`.
+ * GitHub-specific path; mirror in `pr-create-gitlab.ts` uses `glab api projects/<encoded>`.
+ */
+function getDefaultBranch(repo: string | undefined, cwd: string): string {
+  const cmd = ['gh', 'repo', 'view'];
+  if (repo !== undefined) cmd.push(repo);
+  cmd.push('--json', 'defaultBranchRef', '--jq', '.defaultBranchRef.name');
+  const result = runArgv(cmd, cwd);
+  if (result.exitCode !== 0 || result.stdout.trim().length === 0) {
+    throw new Error(
+      `failed to resolve GitHub default branch: ${result.stderr.trim() || 'empty response'}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+function lookupGithubPr(
+  head: string,
+  cwd: string,
+  repo: string | undefined,
+): PrCreateResponse | null {
+  const cmd = [
+    'gh', 'pr', 'list',
+    '--head', head,
+    '--state', 'open',
+    '--json', 'number,url,state,headRefName,baseRefName',
+    '--limit', '1',
+  ];
+  if (repo !== undefined) cmd.push('--repo', repo);
+  const list = runArgv(cmd, cwd);
+  if (list.exitCode !== 0) return null;
+  const prs = JSON.parse(list.stdout) as Array<{
+    number: number;
+    url: string;
+    state: string;
+    headRefName: string;
+    baseRefName: string;
+  }>;
+  if (prs.length === 0) return null;
+  return {
+    number: prs[0].number,
+    url: prs[0].url,
+    state: 'open',
+    head: prs[0].headRefName,
+    base: prs[0].baseRefName,
+    created: false,
+  };
+}
+
+function viewGithubPr(
+  prNumber: number,
+  cwd: string,
+  repo: string | undefined,
+): RunResult {
+  const cmd = [
+    'gh', 'pr', 'view', String(prNumber),
+    '--json', 'number,url,state,headRefName,baseRefName',
+  ];
+  if (repo !== undefined) cmd.push('--repo', repo);
+  return runArgv(cmd, cwd);
+}
+
+export async function prCreateGithub(
+  args: PrCreateArgs,
+): Promise<AdapterResult<PrCreateResponse>> {
+  // Bound any exception that escapes the helpers below into a typed result —
+  // adapter callers must not have to try/catch.
+  try {
+    const cwd = projectDir();
+    const head = args.head ?? getCurrentBranch(cwd);
+    const base = args.base && args.base.length > 0
+      ? args.base
+      : getDefaultBranch(args.repo, cwd);
+
+    const createCmd = [
+      'gh', 'pr', 'create',
+      '--title', args.title,
+      '--body', args.body,
+      '--base', base,
+      '--head', head,
+    ];
+    if (args.draft) createCmd.push('--draft');
+    if (args.repo !== undefined) createCmd.push('--repo', args.repo);
+
+    const result = runArgv(createCmd, cwd);
+    if (result.exitCode !== 0) {
+      const errText = (result.stderr + result.stdout).toLowerCase();
+      // gh says "a pull request for branch ... already exists" on duplicate.
+      // Treat as the idempotent path: look up + return the existing PR.
+      if (errText.includes('already exists')) {
+        const existing = lookupGithubPr(head, cwd, args.repo);
+        if (existing) return { ok: true, data: existing };
+        return {
+          ok: false,
+          code: 'pr_exists_lookup_failed',
+          error: `gh pr create: PR already exists for branch '${head}' but could not be found via lookup`,
+        };
+      }
+      return {
+        ok: false,
+        code: 'gh_pr_create_failed',
+        error: `gh pr create failed: ${result.stderr.trim() || result.stdout.trim()}`,
+      };
+    }
+
+    // gh prints the PR URL on stdout. Parse the number from the URL.
+    const url = result.stdout.trim().split('\n').pop() ?? '';
+    const numMatch = /\/pull\/(\d+)/.exec(url);
+    if (!numMatch) {
+      return {
+        ok: false,
+        code: 'gh_url_parse_failed',
+        error: `gh pr create: could not parse PR number from output: ${url}`,
+      };
+    }
+    const prNumber = parseInt(numMatch[1], 10);
+
+    // Fetch canonical details so the response shape matches the lookup path.
+    const view = viewGithubPr(prNumber, cwd, args.repo);
+    if (view.exitCode !== 0) {
+      return {
+        ok: false,
+        code: 'gh_pr_view_failed',
+        error: `gh pr view failed: ${view.stderr.trim() || view.stdout.trim()}`,
+      };
+    }
+    const parsed = JSON.parse(view.stdout) as {
+      number: number;
+      url: string;
+      state: string;
+      headRefName: string;
+      baseRefName: string;
+    };
+    return {
+      ok: true,
+      data: {
+        number: parsed.number,
+        url: parsed.url,
+        state: 'open',
+        head: parsed.headRefName,
+        base: parsed.baseRefName,
+        created: true,
+      },
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'unexpected_error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// `execSync` is intentionally re-imported above so that adapter-level test
+// files can `mock.module('child_process', ...)` and intercept this module's
+// subprocess calls without needing access to the handler's mock setup.
+void execSync;

--- a/lib/adapters/pr-create-gitlab.test.ts
+++ b/lib/adapters/pr-create-gitlab.test.ts
@@ -1,0 +1,223 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { AdapterResult, PrCreateResponse } from './types.ts';
+
+// Subprocess-boundary tests for the GitLab pr_create adapter (R-15).
+// Integration-level coverage stays in tests/pr_create.test.ts.
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { prCreateGitlab } = await import('./pr-create-gitlab.ts');
+
+function on(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
+// Narrow AdapterResult into the success branch — throws if it's an error or
+// platform_unsupported variant. Lets test bodies access `.data` directly.
+function expectOk(
+  r: AdapterResult<PrCreateResponse>,
+): asserts r is { ok: true; data: PrCreateResponse } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectErr(
+  r: AdapterResult<PrCreateResponse>,
+): asserts r is { ok: false; error: string; code: string } {
+  if (!('ok' in r) || r.ok) {
+    throw new Error(`expected error result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('prCreateGitlab — subprocess boundary', () => {
+  test('glab CLI invocation matches expected argv shape (happy path)', async () => {
+    on('git branch --show-current', 'feature/gl\n');
+    on('glab mr create', 'https://gitlab.com/o/r/-/merge_requests/9\n');
+    on(
+      'glab mr view',
+      JSON.stringify({
+        iid: 9,
+        web_url: 'https://gitlab.com/o/r/-/merge_requests/9',
+        state: 'opened',
+        source_branch: 'feature/gl',
+        target_branch: 'main',
+      }),
+    );
+
+    const result = await prCreateGitlab({
+      title: 'a title',
+      body: 'a body',
+      base: 'main',
+    });
+
+    expectOk(result);
+    expect(result.data.number).toBe(9);
+
+    const createCall = findCall('glab mr create');
+    expect(createCall).toContain('--title');
+    expect(createCall).toContain('a title');
+    expect(createCall).toContain('--description');
+    expect(createCall).toContain('a body');
+    expect(createCall).toContain('--target-branch');
+    expect(createCall).toContain('main');
+    expect(createCall).toContain('--source-branch');
+    expect(createCall).toContain('feature/gl');
+    // --yes is the load-bearing non-interactive flag for glab.
+    expect(createCall).toContain('--yes');
+    expect(createCall).not.toContain('--draft');
+  });
+
+  test('parses glab mr view response into PrCreateResponse', async () => {
+    on('git branch --show-current', 'feature/y\n');
+    on('glab mr create', 'created\n');
+    on(
+      'glab mr view',
+      JSON.stringify({
+        iid: 12,
+        web_url: 'https://gitlab.com/o/r/-/merge_requests/12',
+        state: 'opened',
+        source_branch: 'feature/y',
+        target_branch: 'develop',
+      }),
+    );
+
+    const result = await prCreateGitlab({ title: 't', body: 'b', base: 'develop' });
+    expectOk(result);
+    expect(result.data).toEqual({
+      number: 12,
+      url: 'https://gitlab.com/o/r/-/merge_requests/12',
+      state: 'open',
+      head: 'feature/y',
+      base: 'develop',
+      created: true,
+    });
+  });
+
+  test('returns AdapterResult{ok:false, code} on glab failure (not thrown)', async () => {
+    on('git branch --show-current', 'feature/z\n');
+    on('glab mr create', () => {
+      const err = new Error('glab: not authenticated') as ThrowableError;
+      err.stderr = 'glab: not authenticated';
+      err.status = 1;
+      throw err;
+    });
+
+    const result = await prCreateGitlab({ title: 't', body: 'b', base: 'main' });
+    expectErr(result);
+    expect(result.code).toBe('glab_mr_create_failed');
+    expect(result.error).toContain('glab mr create failed');
+  });
+
+  test('idempotent path: "already exists" → looks up existing MR and returns created:false', async () => {
+    on('git branch --show-current', 'feature/dup\n');
+    on('glab mr create', () => {
+      const err = new Error('Another open merge request already exists') as ThrowableError;
+      err.stderr = 'Another open merge request already exists';
+      err.status = 1;
+      throw err;
+    });
+    on(
+      'glab mr view',
+      JSON.stringify({
+        iid: 77,
+        web_url: 'https://gitlab.com/o/r/-/merge_requests/77',
+        state: 'opened',
+        source_branch: 'feature/dup',
+        target_branch: 'main',
+      }),
+    );
+
+    const result = await prCreateGitlab({ title: 't', body: 'b', base: 'main' });
+    expectOk(result);
+    expect(result.data.number).toBe(77);
+    expect(result.data.created).toBe(false);
+  });
+
+  test('-R flag forwarded when args.repo provided (GitLab uses -R, not --repo)', async () => {
+    on('git branch --show-current', 'feature/cross\n');
+    on('glab mr create', 'created\n');
+    on(
+      'glab mr view',
+      JSON.stringify({
+        iid: 5,
+        web_url: 'https://gitlab.com/Org/Other/-/merge_requests/5',
+        state: 'opened',
+        source_branch: 'feature/cross',
+        target_branch: 'main',
+      }),
+    );
+
+    await prCreateGitlab({ title: 't', body: 'b', base: 'main', repo: 'Org/Other' });
+    const create = findCall('glab mr create');
+    expect(create).toContain('-R');
+    expect(create).toContain('Org/Other');
+    const view = findCall('glab mr view');
+    expect(view).toContain('-R');
+    expect(view).toContain('Org/Other');
+  });
+
+  test('default-branch resolution via glab api projects/<encoded> when args.base undefined', async () => {
+    on('git branch --show-current', 'feature/no-base\n');
+    on(
+      'glab api projects/',
+      JSON.stringify({ default_branch: 'main' }),
+    );
+    on('glab mr create', 'created\n');
+    on(
+      'glab mr view',
+      JSON.stringify({
+        iid: 33,
+        web_url: 'https://gitlab.com/Org/Repo/-/merge_requests/33',
+        state: 'opened',
+        source_branch: 'feature/no-base',
+        target_branch: 'main',
+      }),
+    );
+
+    const result = await prCreateGitlab({ title: 't', body: 'b', repo: 'Org/Repo' });
+    expectOk(result);
+
+    const probe = findCall('glab api projects/');
+    // GitLab requires URL-encoded slug
+    expect(probe).toContain('Org%2FRepo');
+    // Confirm resolved branch flowed into create.
+    expect(findCall('glab mr create')).toContain('main');
+  });
+});

--- a/lib/adapters/pr-create-gitlab.ts
+++ b/lib/adapters/pr-create-gitlab.ts
@@ -1,0 +1,167 @@
+/**
+ * GitLab `pr_create` adapter implementation.
+ *
+ * Lifted from `handlers/pr_create.ts` per Story 1.3. Mirrors `pr-create-github.ts`
+ * — the handler dispatches to either depending on cwd platform.
+ *
+ * GitLab divergences from the GitHub flow:
+ * - `glab mr create --yes` (non-interactive); `gh pr create` doesn't need it.
+ * - `glab mr create` doesn't print a parseable URL on stdout — re-fetch via
+ *   `glab mr view <head> -F json` to get the canonical IID + web_url.
+ * - `glab api projects/<encoded>` for default branch (no `--jq` flag — parse
+ *   the JSON in-process).
+ */
+
+import { execSync } from 'child_process';
+import { runArgv } from '../shared/error-norm.js';
+import type {
+  AdapterResult,
+  PrCreateArgs,
+  PrCreateResponse,
+} from './types.js';
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function getCurrentBranch(cwd: string): string {
+  const result = runArgv(['git', 'branch', '--show-current'], cwd);
+  if (result.exitCode !== 0) {
+    throw new Error(`git branch --show-current failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout.trim();
+}
+
+/**
+ * Resolve the repo's default branch via `glab api projects/<encoded>`.
+ * Use `:id` as the project segment when no slug is provided — `glab` resolves
+ * that from the cwd remote.
+ */
+function getDefaultBranch(repo: string | undefined, cwd: string): string {
+  const project = repo !== undefined ? repo.replace(/\//g, '%2F') : ':id';
+  const result = runArgv(['glab', 'api', `projects/${project}`], cwd);
+  if (result.exitCode !== 0 || result.stdout.trim().length === 0) {
+    throw new Error(
+      `failed to resolve GitLab default branch: ${result.stderr.trim() || 'empty response'}`,
+    );
+  }
+  const parsed = JSON.parse(result.stdout) as { default_branch?: string };
+  if (typeof parsed.default_branch !== 'string' || parsed.default_branch.length === 0) {
+    throw new Error('default_branch missing or empty in glab api response');
+  }
+  return parsed.default_branch;
+}
+
+function lookupGitlabMr(
+  head: string,
+  cwd: string,
+  repo: string | undefined,
+): PrCreateResponse | null {
+  const cmd = ['glab', 'mr', 'view', head, '-F', 'json'];
+  if (repo !== undefined) cmd.push('-R', repo);
+  const view = runArgv(cmd, cwd);
+  if (view.exitCode !== 0) return null;
+  try {
+    const parsed = JSON.parse(view.stdout) as {
+      iid: number;
+      web_url: string;
+      state: string;
+      source_branch: string;
+      target_branch: string;
+    };
+    if (parsed.state !== 'opened') return null;
+    return {
+      number: parsed.iid,
+      url: parsed.web_url,
+      state: 'open',
+      head: parsed.source_branch,
+      base: parsed.target_branch,
+      created: false,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function prCreateGitlab(
+  args: PrCreateArgs,
+): Promise<AdapterResult<PrCreateResponse>> {
+  try {
+    const cwd = projectDir();
+    const head = args.head ?? getCurrentBranch(cwd);
+    const base = args.base && args.base.length > 0
+      ? args.base
+      : getDefaultBranch(args.repo, cwd);
+
+    const createCmd = [
+      'glab', 'mr', 'create',
+      '--title', args.title,
+      '--description', args.body,
+      '--target-branch', base,
+      '--source-branch', head,
+      '--yes',
+    ];
+    if (args.draft) createCmd.push('--draft');
+    if (args.repo !== undefined) createCmd.push('-R', args.repo);
+
+    const result = runArgv(createCmd, cwd);
+    if (result.exitCode !== 0) {
+      const errText = (result.stderr + result.stdout).toLowerCase();
+      // glab says "Another open merge request already exists" on duplicate.
+      // Treat as the idempotent path: look up + return the existing MR.
+      if (errText.includes('already exists')) {
+        const existing = lookupGitlabMr(head, cwd, args.repo);
+        if (existing) return { ok: true, data: existing };
+        return {
+          ok: false,
+          code: 'mr_exists_lookup_failed',
+          error: `glab mr create: MR already exists for branch '${head}' but could not be found via lookup`,
+        };
+      }
+      return {
+        ok: false,
+        code: 'glab_mr_create_failed',
+        error: `glab mr create failed: ${result.stderr.trim() || result.stdout.trim()}`,
+      };
+    }
+
+    // `glab mr create` doesn't print a URL on stdout. Re-fetch by source-branch.
+    const viewCmd = ['glab', 'mr', 'view', head, '-F', 'json'];
+    if (args.repo !== undefined) viewCmd.push('-R', args.repo);
+    const view = runArgv(viewCmd, cwd);
+    if (view.exitCode !== 0) {
+      return {
+        ok: false,
+        code: 'glab_mr_view_failed',
+        error: `glab mr view failed: ${view.stderr.trim() || view.stdout.trim()}`,
+      };
+    }
+    const parsed = JSON.parse(view.stdout) as {
+      iid: number;
+      web_url: string;
+      state: string;
+      source_branch: string;
+      target_branch: string;
+    };
+    return {
+      ok: true,
+      data: {
+        number: parsed.iid,
+        url: parsed.web_url,
+        state: 'open',
+        head: parsed.source_branch,
+        base: parsed.target_branch,
+        created: true,
+      },
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'unexpected_error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// See pr-create-github.ts for the rationale.
+void execSync;

--- a/lib/adapters/types.test.ts
+++ b/lib/adapters/types.test.ts
@@ -31,10 +31,18 @@ describe('PlatformAdapter contract', () => {
     });
   }
 
-  test('Story 1.2 vacuous-pass: every method returns platform_unsupported', async () => {
-    // When a real implementation lands (Story 1.3+), it removes that method
-    // from this list. By Phase 3 close, this test should iterate zero methods.
-    for (const method of PLATFORM_ADAPTER_METHODS) {
+  // Methods migrated to a real adapter implementation. Each migration story
+  // (1.3 onward) appends here so the vacuous-pass test below stops asserting
+  // `platform_unsupported` for that method. By Phase 3 close, this set
+  // contains every method in PLATFORM_ADAPTER_METHODS and the test below
+  // iterates zero methods.
+  //
+  // Story 1.3 (#240): prCreate
+  const MIGRATED_METHODS = new Set<string>(['prCreate']);
+
+  test('still-stubbed methods return platform_unsupported', async () => {
+    const stubbed = PLATFORM_ADAPTER_METHODS.filter((m) => !MIGRATED_METHODS.has(m));
+    for (const method of stubbed) {
       const fn = (githubAdapter as unknown as Record<string, (args: unknown) => Promise<unknown>>)[method];
       const result = (await fn({})) as { platform_unsupported?: true; hint?: string };
       expect(result.platform_unsupported).toBe(true);

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -42,8 +42,24 @@ export type AdapterResult<T> =
 // just one type without re-touching the interface body.
 // ---------------------------------------------------------------------------
 
-export type PrCreateArgs = unknown;
-export type PrCreateResponse = unknown;
+export interface PrCreateArgs {
+  title: string;
+  body: string;
+  base?: string;
+  head?: string;
+  draft?: boolean;
+  repo?: string;
+}
+
+export interface PrCreateResponse {
+  number: number;
+  url: string;
+  state: 'open';
+  head: string;
+  base: string;
+  /** True when this call created the PR/MR; false when it pre-existed (idempotent path). */
+  created: boolean;
+}
 export type PrMergeArgs = unknown;
 export type PrMergeResponse = unknown;
 export type PrMergeWaitArgs = unknown;

--- a/lib/shared/error-norm.ts
+++ b/lib/shared/error-norm.ts
@@ -1,0 +1,57 @@
+/**
+ * Subprocess error normalization — convert `child_process.execSync`'s
+ * exception-on-non-zero contract into the result-bag shape adapter code
+ * consumes uniformly.
+ *
+ * `execSync` throws on non-zero exit; the thrown error has `.status`,
+ * `.stdout`, `.stderr` properties (Buffer or string). This module wraps
+ * the throw into a typed `RunResult` so adapter code can branch on
+ * `exitCode` without try/catch noise at every call site.
+ *
+ * Extracted from `pr_merge.ts` / `pr_create.ts` per Story 1.3.
+ */
+
+import { execSync } from 'child_process';
+import { shellEscape } from './shell-escape.js';
+
+export interface RunResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface ExecError extends Error {
+  stdout?: Buffer | string;
+  stderr?: Buffer | string;
+  status?: number;
+}
+
+export function bufToString(b: unknown): string {
+  if (b === undefined || b === null) return '';
+  if (typeof b === 'string') return b;
+  if (typeof (b as Buffer).toString === 'function') return (b as Buffer).toString();
+  return String(b);
+}
+
+/**
+ * Build a single shell command from an argv array (each element shell-escaped)
+ * and run it via `execSync`. Returns a `RunResult` on success or non-zero exit;
+ * never throws.
+ *
+ * `cwd` is required so adapter callers can run against a project directory
+ * passed in via the `CLAUDE_PROJECT_DIR` env or `process.cwd()` fallback.
+ */
+export function runArgv(cmd: string[], cwd: string): RunResult {
+  const shellCmd = cmd.map(shellEscape).join(' ');
+  try {
+    const stdout = execSync(shellCmd, { cwd, encoding: 'utf8' });
+    return { exitCode: 0, stdout, stderr: '' };
+  } catch (err) {
+    const e = err as ExecError;
+    return {
+      exitCode: typeof e.status === 'number' ? e.status : -1,
+      stdout: bufToString(e.stdout),
+      stderr: bufToString(e.stderr) || (err instanceof Error ? err.message : String(err)),
+    };
+  }
+}

--- a/lib/shared/shell-escape.ts
+++ b/lib/shared/shell-escape.ts
@@ -1,0 +1,20 @@
+/**
+ * Single-quote-and-escape one argv element so it can be joined with spaces
+ * into a single shell command string for `execSync`.
+ *
+ * Wraps the value in single quotes and escapes embedded single quotes via
+ * the `'\''` four-char sequence. Safe for arbitrary user-supplied strings —
+ * titles, bodies, branch names, commit messages — that the shell will then
+ * word-split.
+ *
+ * Extracted from `pr_merge.ts` / `pr_create.ts` per Story 1.3 (first adapter
+ * migration to need a shared subprocess-boundary helper).
+ *
+ * **Contract:** call this on RAW argv values, never on already-escaped strings
+ * (double-escaping silently corrupts the value). The canonical use is
+ * `cmd.map(shellEscape).join(' ')` inside `runArgv` (`lib/shared/error-norm.ts`)
+ * — adapter callers should pass raw values to `runArgv` and let it escape.
+ */
+export function shellEscape(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}

--- a/scripts/ci/migration-allowlist.txt
+++ b/scripts/ci/migration-allowlist.txt
@@ -20,7 +20,6 @@ ibm.ts
 label_create.ts
 label_list.ts
 pr_comment.ts
-pr_create.ts
 pr_diff.ts
 pr_files.ts
 pr_list.ts

--- a/tests/pr_create.test.ts
+++ b/tests/pr_create.test.ts
@@ -87,7 +87,7 @@ describe('pr_create handler', () => {
   });
 
   test('github_happy_path — creates PR and returns normalized response', async () => {
-    onExec('git remote -v', 'origin\tgit@github.com:org/repo.git (fetch)\n');
+    onExec('git remote get-url origin', 'git@github.com:org/repo.git\n');
     onExec('git branch --show-current', 'feature/76-pr-create\n');
     onExec('gh pr create', 'https://github.com/org/repo/pull/42\n');
     onExec(
@@ -118,7 +118,7 @@ describe('pr_create handler', () => {
   });
 
   test('gitlab_happy_path — creates MR and returns normalized response', async () => {
-    onExec('git remote -v', 'origin\tgit@gitlab.com:org/repo.git (fetch)\n');
+    onExec('git remote get-url origin', 'git@gitlab.com:org/repo.git\n');
     onExec('git branch --show-current', 'feature/76-pr-create\n');
     onExec('glab mr create', 'https://gitlab.com/org/repo/-/merge_requests/7\n');
     onExec(
@@ -149,7 +149,7 @@ describe('pr_create handler', () => {
   });
 
   test('draft_flag_github — passes --draft to gh pr create', async () => {
-    onExec('git remote -v', 'origin\tgit@github.com:org/repo.git (fetch)\n');
+    onExec('git remote get-url origin', 'git@github.com:org/repo.git\n');
     onExec('git branch --show-current', 'feature/76-pr-create\n');
     onExec('gh pr create', 'https://github.com/org/repo/pull/99\n');
     onExec(
@@ -177,7 +177,7 @@ describe('pr_create handler', () => {
   });
 
   test('draft_flag_gitlab — passes --draft to glab mr create', async () => {
-    onExec('git remote -v', 'origin\tgit@gitlab.com:org/repo.git (fetch)\n');
+    onExec('git remote get-url origin', 'git@gitlab.com:org/repo.git\n');
     onExec('git branch --show-current', 'feature/76-pr-create\n');
     onExec('glab mr create', 'https://gitlab.com/org/repo/-/merge_requests/8\n');
     onExec(
@@ -221,7 +221,7 @@ describe('pr_create handler', () => {
   // ---- #159: auto-resolve default branch when base is omitted ------------
 
   test('default_branch_resolution_github — base omitted resolves via gh repo view', async () => {
-    onExec('git remote -v', 'origin\tgit@github.com:org/repo.git (fetch)\n');
+    onExec('git remote get-url origin', 'git@github.com:org/repo.git\n');
     onExec('git branch --show-current', 'feature/159-default-branch\n');
     // gh repo view --json defaultBranchRef --jq .defaultBranchRef.name
     onExec('gh repo view', 'main\n');
@@ -253,7 +253,7 @@ describe('pr_create handler', () => {
   });
 
   test('default_branch_resolution_gitlab — base omitted resolves via glab api', async () => {
-    onExec('git remote -v', 'origin\tgit@gitlab.com:org/repo.git (fetch)\n');
+    onExec('git remote get-url origin', 'git@gitlab.com:org/repo.git\n');
     onExec('git branch --show-current', 'feature/159-default-branch\n');
     // glab api projects/:id — no --jq flag (handler parses JSON in-process).
     onExec('glab api', () => {
@@ -299,7 +299,7 @@ describe('pr_create handler', () => {
   });
 
   test('explicit_base_wins — auto-resolution skipped when base is provided', async () => {
-    onExec('git remote -v', 'origin\tgit@github.com:org/repo.git (fetch)\n');
+    onExec('git remote get-url origin', 'git@github.com:org/repo.git\n');
     onExec('git branch --show-current', 'feature/159-default-branch\n');
     // gh repo view MUST NOT be called when explicit base provided — fail loudly.
     failExec('gh repo view', 'FAIL: repo view should not be called with explicit base', 99);
@@ -329,7 +329,7 @@ describe('pr_create handler', () => {
   });
 
   test('default_branch_resolution_failure — surfaces ok:false when gh repo view fails', async () => {
-    onExec('git remote -v', 'origin\tgit@github.com:org/repo.git (fetch)\n');
+    onExec('git remote get-url origin', 'git@github.com:org/repo.git\n');
     onExec('git branch --show-current', 'feature/159-default-branch\n');
     failExec('gh repo view', 'auth required');
 
@@ -343,7 +343,7 @@ describe('pr_create handler', () => {
   });
 
   test('explicit_head_overrides_git_branch — uses args.head when provided', async () => {
-    onExec('git remote -v', 'origin\tgit@github.com:org/repo.git (fetch)\n');
+    onExec('git remote get-url origin', 'git@github.com:org/repo.git\n');
     // git branch should NOT be called when head is provided — fail loudly.
     failExec(
       'git branch --show-current',
@@ -375,7 +375,7 @@ describe('pr_create handler', () => {
   });
 
   test('github_error_path — gh pr create fails, returns ok=false with error', async () => {
-    onExec('git remote -v', 'origin\tgit@github.com:org/repo.git (fetch)\n');
+    onExec('git remote get-url origin', 'git@github.com:org/repo.git\n');
     onExec('git branch --show-current', 'feature/76-pr-create\n');
     failExec('gh pr create', 'authentication error: not logged in');
 
@@ -391,7 +391,7 @@ describe('pr_create handler', () => {
   });
 
   test('github_idempotent — duplicate PR returns existing with created=false', async () => {
-    onExec('git remote -v', 'origin\tgit@github.com:org/repo.git (fetch)\n');
+    onExec('git remote get-url origin', 'git@github.com:org/repo.git\n');
     onExec('git branch --show-current', 'feature/76-pr-create\n');
     failExec(
       'gh pr create',
@@ -424,7 +424,7 @@ describe('pr_create handler', () => {
   });
 
   test('gitlab_idempotent — duplicate MR returns existing with created=false', async () => {
-    onExec('git remote -v', 'origin\tgit@gitlab.com:org/repo.git (fetch)\n');
+    onExec('git remote get-url origin', 'git@gitlab.com:org/repo.git\n');
     onExec('git branch --show-current', 'feature/76-pr-create\n');
     failExec(
       'glab mr create',
@@ -456,7 +456,7 @@ describe('pr_create handler', () => {
 
   test('route_with_repo_github — appends --repo to gh pr create/view when repo provided', async () => {
     // cwd remote is a DIFFERENT repo — repo arg must override.
-    onExec('git remote -v', 'origin\tgit@github.com:cwd-org/cwd-repo.git (fetch)\n');
+    onExec('git remote get-url origin', 'git@github.com:cwd-org/cwd-repo.git\n');
     onExec('git branch --show-current', 'feature/196-cross-repo\n');
     onExec(
       'gh pr create',
@@ -492,7 +492,7 @@ describe('pr_create handler', () => {
   });
 
   test('route_with_repo_gitlab — appends -R to glab mr create/view when repo provided', async () => {
-    onExec('git remote -v', 'origin\tgit@gitlab.com:cwd-org/cwd-repo.git (fetch)\n');
+    onExec('git remote get-url origin', 'git@gitlab.com:cwd-org/cwd-repo.git\n');
     onExec('git branch --show-current', 'feature/196-cross-repo\n');
     onExec(
       'glab mr create',
@@ -528,7 +528,7 @@ describe('pr_create handler', () => {
   });
 
   test('regression_without_repo — gh pr create argv has no --repo flag', async () => {
-    onExec('git remote -v', 'origin\tgit@github.com:org/repo.git (fetch)\n');
+    onExec('git remote get-url origin', 'git@github.com:org/repo.git\n');
     onExec('git branch --show-current', 'feature/xyz\n');
     onExec('gh pr create', 'https://github.com/org/repo/pull/100\n');
     onExec(
@@ -572,7 +572,7 @@ describe('pr_create handler', () => {
 
   test('fallback_platform_detection — uses git remote URL to route', async () => {
     // Remote URL identifies gitlab — handler must dispatch to glab path.
-    onExec('git remote -v', 'origin\thttps://gitlab.com/org/repo.git (fetch)\n');
+    onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git\n');
     onExec('git branch --show-current', 'feature/76-pr-create\n');
     onExec('glab mr create', 'https://gitlab.com/org/repo/-/merge_requests/11\n');
     onExec(
@@ -599,7 +599,7 @@ describe('pr_create handler', () => {
   // ---- argv-shape assertion (Story 1.1 unit test ledger) ------------------
 
   test('execSync invocation matches gh CLI shape', async () => {
-    onExec('git remote -v', 'origin\tgit@github.com:org/repo.git (fetch)\n');
+    onExec('git remote get-url origin', 'git@github.com:org/repo.git\n');
     onExec('git branch --show-current', 'feature/argv-shape\n');
     onExec('gh pr create', 'https://github.com/org/repo/pull/123\n');
     onExec(


### PR DESCRIPTION
## Summary

Story 1.3 of the platform-adapter retrofit. Migrates `pr_create` from a self-contained handler with inline platform branching + direct subprocess calls to the adapter pattern landed in Story 1.2 (#239 / PR #265). This is the first real method-pair migration; it sets the template for Stories 1.4–1.11.

## Changes

**Adapter implementations (`lib/adapters/`)**
- `pr-create-github.ts` — `prCreateGithub(args)` owns `gh pr create` / `gh pr view` / `gh pr list` / `gh repo view` invocations. Returns `AdapterResult<PrCreateResponse>`.
- `pr-create-gitlab.ts` — `prCreateGitlab(args)` owns `glab mr create` / `glab mr view` and `glab api projects/<encoded>` for default-branch resolution.
- `types.ts` — `PrCreateArgs`/`PrCreateResponse` refined from `unknown` to concrete shapes.
- `github.ts` + `gitlab.ts` — `prCreate` slot now points at the real impls.
- `types.test.ts` — vacuous-pass test now skips a `MIGRATED_METHODS = {prCreate}` set; each subsequent migration story appends.

**Shared helpers (`lib/shared/`, per dev spec §5.3)**
- `shell-escape.ts` — `shellEscape()` lifted from handlers/pr_create.ts. First adapter migration is the natural home for the helper. Docstring states the contract clearly (RAW argv values; never pre-escaped).
- `error-norm.ts` — `RunResult`, `ExecError`, `bufToString`, `runArgv()` — the uniform argv→`execSync`-with-result-bag wrapper. Adapter callers pass raw argv arrays; runArgv handles escaping + exception-to-result.

**Handler refactor (`handlers/pr_create.ts`)**
- Was 383 lines; now **52**. Strips platform branching, subprocess, helpers.
- Pure validation (Zod) + `getAdapter({repo}).prCreate(args)` dispatch + envelope wrap.
- Per dev spec §4.4 step 4: `platform_unsupported` surfaces as `{ok: true, platform_unsupported: true, hint}` — NOT collapsed into `{ok: false}`. The dispatch succeeded; the platform just doesn't have the concept. (Reviewer-flagged; fixed in-PR. Sets the migration template for Stories 1.4–1.11.)

**Tests**
- 13 new colocated subprocess-boundary cases (R-15): `pr-create-github.test.ts` (7) + `pr-create-gitlab.test.ts` (6).
- Existing `tests/pr_create.test.ts`: 21/21 pass via the new dispatch path. The git-remote-detection stubs were updated from `git remote -v` to `git remote get-url origin` (the new shared `detectPlatform` calls the latter; the old handler-local one called the former) — 17 mechanical replacements via script.

**Gate-grep activation**
- `pr_create.ts` removed from `scripts/ci/migration-allowlist.txt`. Allowlist down to 31 (was 32). R-09 + R-10 now actively enforce against `handlers/pr_create.ts`; both pass post-refactor.

## Linked Issues

Closes #240

## Test Plan

- [x] `bun test` — **1479 / 0** (was 1466; +13 new colocated tests)
- [x] `bun run lint` — `tsc --noEmit` clean
- [x] `./scripts/ci/validate.sh` — codegen, lint, gate-greps (now active on pr_create.ts), shellcheck, tests, smoke 73/73 — all green
- [x] `./scripts/ci/gate-greps.sh` standalone — checks 42 non-allowlisted handlers (was 41 + pr_create.ts), all clean
- [x] `trivy fs --severity HIGH,CRITICAL` — 0 findings
- [x] Code review: 2 HIGH-confidence findings fixed in-PR
  - `shellEscape` docstring contradicted its only caller (would have primed Story 1.4+ authors for double-escape bugs); rewrote contract.
  - `platform_unsupported` envelope was `{ok: false, error}`; spec §4.4 mandates `{ok: true, platform_unsupported: true, hint}`. Fixed.
- [ ] CI green on the PR (in flight)

**Deferred for follow-up**: `getAdapter({repo})` ignores `args.repo` for cross-repo dispatch — pre-existing from Story 1.2's deliberate forward-compat shape, not a regression in this PR. File post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)