### PR TITLE
feat(adapter): migrate pr_diff to platform adapter pattern (#241)

### DIFF
--- a/handlers/pr_diff.ts
+++ b/handlers/pr_diff.ts
@@ -1,12 +1,11 @@
-// Origin Operations family handler.
-// See docs/handlers/origin-operations-guide.md for the canonical pattern,
-// gh ↔ glab field mappings, and normalized response schemas.
+// Origin Operations family handler — adapter-dispatching shell.
+// Subprocess + platform branching live in lib/adapters/pr-diff-{github,gitlab}.ts;
+// see docs/handlers/origin-operations-guide.md for the canonical pattern and
+// docs/platform-adapter-retrofit-devspec.md §5 for the contract.
 
-import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform } from '../lib/shared/detect-platform.js';
-import { gitlabApiMr } from '../lib/glab.js';
+import { getAdapter } from '../lib/adapters/index.js';
 
 const inputSchema = z.object({
   number: z.number().int().positive(),
@@ -16,100 +15,8 @@ const inputSchema = z.object({
     .optional(),
 });
 
-type Input = z.infer<typeof inputSchema>;
-
-const MAX_LINES = 10000;
-const HEAD_KEEP = 5000;
-const TAIL_KEEP = 5000;
-
-function projectDir(): string {
-  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
-}
-
-function exec(cmd: string): string {
-  return execSync(cmd, {
-    cwd: projectDir(),
-    encoding: 'utf8',
-    maxBuffer: 256 * 1024 * 1024, // 256 MiB — diffs can be large
-  });
-}
-
-function repoFlag(repo: string | undefined): string {
-  return repo !== undefined ? ` --repo ${repo}` : '';
-}
-
-function parseSlugOpts(slug: string | undefined): { owner?: string; repo?: string } | undefined {
-  if (slug === undefined) return undefined;
-  const idx = slug.indexOf('/');
-  if (idx <= 0 || idx === slug.length - 1) return undefined;
-  return { owner: slug.slice(0, idx), repo: slug.slice(idx + 1) };
-}
-
-function getGithubDiff(num: number, repo?: string): string {
-  return exec(`gh pr diff ${num}${repoFlag(repo)}`);
-}
-
-function getGithubUrl(num: number, repo?: string): string {
-  const raw = exec(`gh pr view ${num} --json url${repoFlag(repo)}`);
-  const parsed = JSON.parse(raw) as { url: string };
-  return parsed.url;
-}
-
-function getGitlabDiff(num: number, repo?: string): string {
-  return exec(`glab mr diff ${num}${repoFlag(repo)}`);
-}
-
-function getGitlabUrl(num: number, repo?: string): string {
-  const mr = gitlabApiMr(num, parseSlugOpts(repo));
-  return mr.web_url;
-}
-
-function countLines(diff: string): number {
-  if (diff.length === 0) return 0;
-  let count = 0;
-  for (let i = 0; i < diff.length; i++) {
-    if (diff.charCodeAt(i) === 10) count++;
-  }
-  // If the diff doesn't end with a newline, the last line still counts.
-  if (diff.charCodeAt(diff.length - 1) !== 10) count++;
-  return count;
-}
-
-function countFiles(diff: string): number {
-  if (diff.length === 0) return 0;
-  const matches = diff.match(/^diff --git /gm);
-  return matches ? matches.length : 0;
-}
-
-interface TruncateResult {
-  diff: string;
-  truncated: boolean;
-}
-
-function maybeTruncate(diff: string, lineCount: number): TruncateResult {
-  if (lineCount <= MAX_LINES) {
-    return { diff, truncated: false };
-  }
-
-  // Split on newlines while preserving them.
-  const lines = diff.split('\n');
-  // If diff ends with '\n', split produces a trailing empty string; drop it
-  // so the keep-count math lines up with countLines() above.
-  const hadTrailingNewline = lines.length > 0 && lines[lines.length - 1] === '';
-  if (hadTrailingNewline) lines.pop();
-
-  const totalLines = lines.length;
-  const head = lines.slice(0, HEAD_KEEP);
-  const tail = lines.slice(totalLines - TAIL_KEEP);
-  const omitted = totalLines - HEAD_KEEP - TAIL_KEEP;
-
-  const joined =
-    head.join('\n') +
-    `\n... [${omitted} lines omitted] ...\n` +
-    tail.join('\n') +
-    (hadTrailingNewline ? '\n' : '');
-
-  return { diff: joined, truncated: true };
+function envelope(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] };
 }
 
 const prDiffHandler: HandlerDef = {
@@ -118,54 +25,25 @@ const prDiffHandler: HandlerDef = {
     'Fetch the unified diff for a PR/MR as a single string, with line/file counts and a safety-valve truncation above 10000 lines.',
   inputSchema,
   async execute(rawArgs: unknown) {
-    let args: Input;
+    let args;
     try {
       args = inputSchema.parse(rawArgs);
     } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
 
-    try {
-      const platform = detectPlatform();
-      const rawDiff =
-        platform === 'github'
-          ? getGithubDiff(args.number, args.repo)
-          : getGitlabDiff(args.number, args.repo);
-      const url =
-        platform === 'github'
-          ? getGithubUrl(args.number, args.repo)
-          : getGitlabUrl(args.number, args.repo);
+    const adapter = getAdapter({ repo: args.repo });
+    const result = await adapter.prDiff(args);
 
-      const rawLineCount = countLines(rawDiff);
-      const fileCount = countFiles(rawDiff);
-      const { diff, truncated } = maybeTruncate(rawDiff, rawLineCount);
-      const lineCount = truncated ? countLines(diff) : rawLineCount;
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({
-              ok: true,
-              number: args.number,
-              diff,
-              line_count: lineCount,
-              file_count: fileCount,
-              url,
-              truncated,
-            }),
-          },
-        ],
-      };
-    } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+    // Per dev spec §4.4 step 4: surface `platform_unsupported` as a typed
+    // signal alongside `ok: true` — NOT as an error. The dispatch succeeded;
+    // the platform just doesn't have the concept. Callers branch on the
+    // discriminator instead of confusing it with a runtime failure.
+    if ('platform_unsupported' in result) {
+      return envelope({ ok: true, platform_unsupported: true, hint: result.hint });
     }
+    if (!result.ok) return envelope({ ok: false, error: result.error });
+    return envelope({ ok: true, ...result.data });
   },
 };
 

--- a/lib/adapters/github.ts
+++ b/lib/adapters/github.ts
@@ -15,6 +15,7 @@
 
 import type { PlatformAdapter } from './types.js';
 import { prCreateGithub } from './pr-create-github.js';
+import { prDiffGithub } from './pr-diff-github.js';
 
 const stubMethod = async (_args: unknown) => ({
   platform_unsupported: true as const,
@@ -26,7 +27,7 @@ export const githubAdapter: PlatformAdapter = {
   prMerge: stubMethod,
   prMergeWait: stubMethod,
   prStatus: stubMethod,
-  prDiff: stubMethod,
+  prDiff: prDiffGithub,
   prComment: stubMethod,
   prFiles: stubMethod,
   prList: stubMethod,

--- a/lib/adapters/gitlab.ts
+++ b/lib/adapters/gitlab.ts
@@ -16,6 +16,7 @@
 
 import type { PlatformAdapter } from './types.js';
 import { prCreateGitlab } from './pr-create-gitlab.js';
+import { prDiffGitlab } from './pr-diff-gitlab.js';
 
 const stubMethod = async (_args: unknown) => ({
   platform_unsupported: true as const,
@@ -27,7 +28,7 @@ export const gitlabAdapter: PlatformAdapter = {
   prMerge: stubMethod,
   prMergeWait: stubMethod,
   prStatus: stubMethod,
-  prDiff: stubMethod,
+  prDiff: prDiffGitlab,
   prComment: stubMethod,
   prFiles: stubMethod,
   prList: stubMethod,

--- a/lib/adapters/pr-diff-github.test.ts
+++ b/lib/adapters/pr-diff-github.test.ts
@@ -1,0 +1,239 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { AdapterResult, PrDiffResponse } from './types.ts';
+
+// Subprocess-boundary tests for the GitHub pr_diff adapter (R-15).
+// Integration-level coverage (handler dispatch, error envelope) stays in
+// tests/pr_diff.test.ts; this file owns the argv-shape and response-parsing
+// assertions that prove the adapter speaks `gh` correctly, plus the
+// 10000-line truncation safety-valve.
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { prDiffGithub } = await import('./pr-diff-github.ts');
+
+function on(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
+// Narrow AdapterResult into the success branch — throws if it's an error or
+// platform_unsupported variant. Lets test bodies access `.data` directly
+// without nested `if ('ok' in r && r.ok)` ceremony at every assertion.
+function expectOk(
+  r: AdapterResult<PrDiffResponse>,
+): asserts r is { ok: true; data: PrDiffResponse } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectErr(
+  r: AdapterResult<PrDiffResponse>,
+): asserts r is { ok: false; error: string; code: string } {
+  if (!('ok' in r) || r.ok) {
+    throw new Error(`expected error result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+const TWO_FILE_DIFF = `diff --git a/foo.txt b/foo.txt
+index 1234567..89abcde 100644
+--- a/foo.txt
++++ b/foo.txt
+@@ -1,1 +1,1 @@
+-old
++new
+diff --git a/bar.txt b/bar.txt
+index abcdef0..fedcba9 100644
+--- a/bar.txt
++++ b/bar.txt
+@@ -1,1 +1,1 @@
+-foo
++bar
+`;
+
+function buildHugeDiff(lineCount: number): string {
+  const parts: string[] = ['diff --git a/big.txt b/big.txt'];
+  parts.push('index 1234567..89abcde 100644');
+  parts.push('--- a/big.txt');
+  parts.push('+++ b/big.txt');
+  parts.push(`@@ -1,${lineCount - 4} +1,${lineCount - 4} @@`);
+  for (let i = 0; i < lineCount - 5; i++) {
+    parts.push(`+line ${i}`);
+  }
+  return parts.join('\n') + '\n';
+}
+
+describe('prDiffGithub — subprocess boundary', () => {
+  test('gh CLI invocation matches expected argv shape (happy path)', async () => {
+    on('gh pr diff', TWO_FILE_DIFF);
+    on(
+      'gh pr view',
+      JSON.stringify({ url: 'https://github.com/org/repo/pull/42' }),
+    );
+
+    const result = await prDiffGithub({ number: 42 });
+
+    expectOk(result);
+    expect(result.data.number).toBe(42);
+
+    const diffCall = findCall('gh pr diff');
+    expect(diffCall).toContain('42');
+    // No --repo flag absent an explicit slug.
+    expect(diffCall).not.toContain('--repo');
+
+    const viewCall = findCall('gh pr view');
+    expect(viewCall).toContain('42');
+    expect(viewCall).toContain('--json');
+    expect(viewCall).toContain('url');
+  });
+
+  test('parses unified diff response into PrDiffResponse', async () => {
+    on('gh pr diff', TWO_FILE_DIFF);
+    on(
+      'gh pr view',
+      JSON.stringify({ url: 'https://github.com/org/repo/pull/42' }),
+    );
+
+    const result = await prDiffGithub({ number: 42 });
+    expectOk(result);
+    expect(result.data).toEqual({
+      number: 42,
+      diff: TWO_FILE_DIFF,
+      line_count: 14,
+      file_count: 2,
+      url: 'https://github.com/org/repo/pull/42',
+      truncated: false,
+    });
+  });
+
+  test('returns AdapterResult{ok:false, code} on gh pr diff failure (not thrown)', async () => {
+    on('gh pr diff', () => {
+      const err = new Error('gh: auth required') as ThrowableError;
+      err.stderr = 'gh: auth required';
+      err.status = 4;
+      throw err;
+    });
+
+    const result = await prDiffGithub({ number: 42 });
+    expectErr(result);
+    expect(result.code).toBe('gh_pr_diff_failed');
+    expect(result.error).toContain('gh pr diff failed');
+  });
+
+  test('returns AdapterResult{ok:false, code} on gh pr view failure (not thrown)', async () => {
+    on('gh pr diff', TWO_FILE_DIFF);
+    on('gh pr view', () => {
+      const err = new Error('gh: not found') as ThrowableError;
+      err.stderr = 'gh: not found';
+      err.status = 1;
+      throw err;
+    });
+
+    const result = await prDiffGithub({ number: 42 });
+    expectErr(result);
+    expect(result.code).toBe('gh_pr_view_failed');
+    expect(result.error).toContain('gh pr view failed');
+  });
+
+  test('handles 10000-line truncation safety valve', async () => {
+    const huge = buildHugeDiff(20000);
+    on('gh pr diff', huge);
+    on(
+      'gh pr view',
+      JSON.stringify({ url: 'https://github.com/org/repo/pull/500' }),
+    );
+
+    const result = await prDiffGithub({ number: 500 });
+    expectOk(result);
+    expect(result.data.truncated).toBe(true);
+    // Must contain the omission marker.
+    expect(result.data.diff).toContain('lines omitted');
+    // Must preserve the head.
+    expect(result.data.diff.startsWith('diff --git a/big.txt b/big.txt')).toBe(true);
+    // Truncated diff must be dramatically smaller than the original.
+    expect(result.data.diff.split('\n').length).toBeLessThan(huge.split('\n').length);
+    // Roughly 10000 content lines + 1 omission marker.
+    expect(result.data.line_count).toBeGreaterThan(10000);
+    expect(result.data.line_count).toBeLessThan(10010);
+  });
+
+  test('exactly 10000 lines is NOT truncated (at-threshold regression)', async () => {
+    const atLimit = buildHugeDiff(10000);
+    on('gh pr diff', atLimit);
+    on(
+      'gh pr view',
+      JSON.stringify({ url: 'https://github.com/org/repo/pull/123' }),
+    );
+
+    const result = await prDiffGithub({ number: 123 });
+    expectOk(result);
+    expect(result.data.truncated).toBe(false);
+    expect(result.data.diff).toBe(atLimit);
+  });
+
+  test('empty diff returns zero counts', async () => {
+    on('gh pr diff', '');
+    on(
+      'gh pr view',
+      JSON.stringify({ url: 'https://github.com/org/repo/pull/99' }),
+    );
+
+    const result = await prDiffGithub({ number: 99 });
+    expectOk(result);
+    expect(result.data.diff).toBe('');
+    expect(result.data.line_count).toBe(0);
+    expect(result.data.file_count).toBe(0);
+    expect(result.data.truncated).toBe(false);
+  });
+
+  test('--repo flag forwarded when args.repo provided', async () => {
+    on('gh pr diff', TWO_FILE_DIFF);
+    on(
+      'gh pr view',
+      JSON.stringify({ url: 'https://github.com/Org/Other/pull/12' }),
+    );
+
+    await prDiffGithub({ number: 12, repo: 'Org/Other' });
+    const diff = findCall('gh pr diff');
+    expect(diff).toContain('--repo');
+    expect(diff).toContain('Org/Other');
+    const view = findCall('gh pr view');
+    expect(view).toContain('--repo');
+    expect(view).toContain('Org/Other');
+  });
+});

--- a/lib/adapters/pr-diff-github.ts
+++ b/lib/adapters/pr-diff-github.ts
@@ -1,0 +1,143 @@
+/**
+ * GitHub `pr_diff` adapter implementation.
+ *
+ * Lifted from `handlers/pr_diff.ts` per Story 1.4. The handler is now a
+ * thin dispatcher; this module owns the GitHub-specific subprocess work and
+ * normalizes the response into `AdapterResult<PrDiffResponse>`.
+ *
+ * Errors that come back from `gh` are converted into `{ok: false, error, code}`
+ * — never thrown — so the handler doesn't need a try/catch around the dispatch.
+ *
+ * Truncation safety-valve (`MAX_LINES`/`HEAD_KEEP`/`TAIL_KEEP`) is preserved
+ * in-adapter; it's a single-consumer concern that does not warrant a shared
+ * helper today.
+ */
+
+import { execSync } from 'child_process';
+import { runArgv } from '../shared/error-norm.js';
+import type {
+  AdapterResult,
+  PrDiffArgs,
+  PrDiffResponse,
+} from './types.js';
+
+const MAX_LINES = 10000;
+const HEAD_KEEP = 5000;
+const TAIL_KEEP = 5000;
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function countLines(diff: string): number {
+  if (diff.length === 0) return 0;
+  let count = 0;
+  for (let i = 0; i < diff.length; i++) {
+    if (diff.charCodeAt(i) === 10) count++;
+  }
+  // If the diff doesn't end with a newline, the last line still counts.
+  if (diff.charCodeAt(diff.length - 1) !== 10) count++;
+  return count;
+}
+
+function countFiles(diff: string): number {
+  if (diff.length === 0) return 0;
+  const matches = diff.match(/^diff --git /gm);
+  return matches ? matches.length : 0;
+}
+
+interface TruncateResult {
+  diff: string;
+  truncated: boolean;
+}
+
+function maybeTruncate(diff: string, lineCount: number): TruncateResult {
+  if (lineCount <= MAX_LINES) {
+    return { diff, truncated: false };
+  }
+
+  // Split on newlines while preserving them.
+  const lines = diff.split('\n');
+  // If diff ends with '\n', split produces a trailing empty string; drop it
+  // so the keep-count math lines up with countLines() above.
+  const hadTrailingNewline = lines.length > 0 && lines[lines.length - 1] === '';
+  if (hadTrailingNewline) lines.pop();
+
+  const totalLines = lines.length;
+  const head = lines.slice(0, HEAD_KEEP);
+  const tail = lines.slice(totalLines - TAIL_KEEP);
+  const omitted = totalLines - HEAD_KEEP - TAIL_KEEP;
+
+  const joined =
+    head.join('\n') +
+    `\n... [${omitted} lines omitted] ...\n` +
+    tail.join('\n') +
+    (hadTrailingNewline ? '\n' : '');
+
+  return { diff: joined, truncated: true };
+}
+
+export async function prDiffGithub(
+  args: PrDiffArgs,
+): Promise<AdapterResult<PrDiffResponse>> {
+  // Bound any exception that escapes the helpers below into a typed result —
+  // adapter callers must not have to try/catch.
+  try {
+    const cwd = projectDir();
+
+    // Fetch the unified diff.
+    const diffCmd = ['gh', 'pr', 'diff', String(args.number)];
+    if (args.repo !== undefined) diffCmd.push('--repo', args.repo);
+    const diffResult = runArgv(diffCmd, cwd);
+    if (diffResult.exitCode !== 0) {
+      return {
+        ok: false,
+        code: 'gh_pr_diff_failed',
+        error: `gh pr diff failed: ${diffResult.stderr.trim() || diffResult.stdout.trim()}`,
+      };
+    }
+    const rawDiff = diffResult.stdout;
+
+    // Fetch the canonical PR URL.
+    const viewCmd = ['gh', 'pr', 'view', String(args.number), '--json', 'url'];
+    if (args.repo !== undefined) viewCmd.push('--repo', args.repo);
+    const viewResult = runArgv(viewCmd, cwd);
+    if (viewResult.exitCode !== 0) {
+      return {
+        ok: false,
+        code: 'gh_pr_view_failed',
+        error: `gh pr view failed: ${viewResult.stderr.trim() || viewResult.stdout.trim()}`,
+      };
+    }
+    const parsed = JSON.parse(viewResult.stdout) as { url: string };
+    const url = parsed.url;
+
+    const rawLineCount = countLines(rawDiff);
+    const fileCount = countFiles(rawDiff);
+    const { diff, truncated } = maybeTruncate(rawDiff, rawLineCount);
+    const lineCount = truncated ? countLines(diff) : rawLineCount;
+
+    return {
+      ok: true,
+      data: {
+        number: args.number,
+        diff,
+        line_count: lineCount,
+        file_count: fileCount,
+        url,
+        truncated,
+      },
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'unexpected_error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// `execSync` is intentionally re-imported above so that adapter-level test
+// files can `mock.module('child_process', ...)` and intercept this module's
+// subprocess calls without needing access to the handler's mock setup.
+void execSync;

--- a/lib/adapters/pr-diff-gitlab.test.ts
+++ b/lib/adapters/pr-diff-gitlab.test.ts
@@ -1,0 +1,244 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { AdapterResult, PrDiffResponse } from './types.ts';
+
+// Subprocess-boundary tests for the GitLab pr_diff adapter (R-15).
+// Integration-level coverage stays in tests/pr_diff.test.ts.
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { prDiffGitlab } = await import('./pr-diff-gitlab.ts');
+
+function on(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
+function expectOk(
+  r: AdapterResult<PrDiffResponse>,
+): asserts r is { ok: true; data: PrDiffResponse } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectErr(
+  r: AdapterResult<PrDiffResponse>,
+): asserts r is { ok: false; error: string; code: string } {
+  if (!('ok' in r) || r.ok) {
+    throw new Error(`expected error result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+const TWO_FILE_DIFF = `diff --git a/foo.txt b/foo.txt
+index 1234567..89abcde 100644
+--- a/foo.txt
++++ b/foo.txt
+@@ -1,1 +1,1 @@
+-old
++new
+diff --git a/bar.txt b/bar.txt
+index abcdef0..fedcba9 100644
+--- a/bar.txt
++++ b/bar.txt
+@@ -1,1 +1,1 @@
+-foo
++bar
+`;
+
+function buildHugeDiff(lineCount: number): string {
+  const parts: string[] = ['diff --git a/big.txt b/big.txt'];
+  parts.push('index 1234567..89abcde 100644');
+  parts.push('--- a/big.txt');
+  parts.push('+++ b/big.txt');
+  parts.push(`@@ -1,${lineCount - 4} +1,${lineCount - 4} @@`);
+  for (let i = 0; i < lineCount - 5; i++) {
+    parts.push(`+line ${i}`);
+  }
+  return parts.join('\n') + '\n';
+}
+
+describe('prDiffGitlab — subprocess boundary', () => {
+  test('glab CLI invocation matches expected argv shape (happy path)', async () => {
+    on('git remote get-url origin', 'https://gitlab.com/org/repo.git');
+    on('glab mr diff', TWO_FILE_DIFF);
+    on(
+      'glab api projects/org%2Frepo/merge_requests/11',
+      JSON.stringify({
+        iid: 11,
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/11',
+        title: 't',
+        description: '',
+        state: 'opened',
+        source_branch: 's',
+        target_branch: 'main',
+        labels: [],
+      }),
+    );
+
+    const result = await prDiffGitlab({ number: 11 });
+    expectOk(result);
+    expect(result.data.number).toBe(11);
+
+    const diffCall = findCall('glab mr diff');
+    expect(diffCall).toContain('11');
+    // No --repo absent an explicit slug.
+    expect(diffCall).not.toContain('--repo');
+  });
+
+  test('parses unified diff response into PrDiffResponse', async () => {
+    on('git remote get-url origin', 'https://gitlab.com/org/repo.git');
+    on('glab mr diff', TWO_FILE_DIFF);
+    on(
+      'glab api projects/org%2Frepo/merge_requests/11',
+      JSON.stringify({
+        iid: 11,
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/11',
+        title: 't',
+        description: '',
+        state: 'opened',
+        source_branch: 's',
+        target_branch: 'main',
+        labels: [],
+      }),
+    );
+
+    const result = await prDiffGitlab({ number: 11 });
+    expectOk(result);
+    expect(result.data).toEqual({
+      number: 11,
+      diff: TWO_FILE_DIFF,
+      line_count: 14,
+      file_count: 2,
+      url: 'https://gitlab.com/org/repo/-/merge_requests/11',
+      truncated: false,
+    });
+  });
+
+  test('returns AdapterResult{ok:false, code} on glab mr diff failure (not thrown)', async () => {
+    on('glab mr diff', () => {
+      const err = new Error('glab: not authenticated') as ThrowableError;
+      err.stderr = 'glab: not authenticated';
+      err.status = 1;
+      throw err;
+    });
+
+    const result = await prDiffGitlab({ number: 11 });
+    expectErr(result);
+    expect(result.code).toBe('glab_mr_diff_failed');
+    expect(result.error).toContain('glab mr diff failed');
+  });
+
+  test('handles 10000-line truncation safety valve', async () => {
+    const huge = buildHugeDiff(20000);
+    on('git remote get-url origin', 'https://gitlab.com/org/repo.git');
+    on('glab mr diff', huge);
+    on(
+      'glab api projects/org%2Frepo/merge_requests/500',
+      JSON.stringify({
+        iid: 500,
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/500',
+        title: 't',
+        description: '',
+        state: 'opened',
+        source_branch: 's',
+        target_branch: 'main',
+        labels: [],
+      }),
+    );
+
+    const result = await prDiffGitlab({ number: 500 });
+    expectOk(result);
+    expect(result.data.truncated).toBe(true);
+    expect(result.data.diff).toContain('lines omitted');
+    expect(result.data.diff.startsWith('diff --git a/big.txt b/big.txt')).toBe(true);
+    expect(result.data.diff.split('\n').length).toBeLessThan(huge.split('\n').length);
+    expect(result.data.line_count).toBeGreaterThan(10000);
+    expect(result.data.line_count).toBeLessThan(10010);
+  });
+
+  test('empty diff returns zero counts', async () => {
+    on('git remote get-url origin', 'https://gitlab.com/org/repo.git');
+    on('glab mr diff', '');
+    on(
+      'glab api projects/org%2Frepo/merge_requests/22',
+      JSON.stringify({
+        iid: 22,
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/22',
+        title: 't',
+        description: '',
+        state: 'opened',
+        source_branch: 's',
+        target_branch: 'main',
+        labels: [],
+      }),
+    );
+
+    const result = await prDiffGitlab({ number: 22 });
+    expectOk(result);
+    expect(result.data.diff).toBe('');
+    expect(result.data.line_count).toBe(0);
+    expect(result.data.file_count).toBe(0);
+  });
+
+  test('--repo flag forwarded into glab mr diff and slug routed into glab api path', async () => {
+    on('git remote get-url origin', 'https://gitlab.com/cwd-org/cwd-repo.git');
+    on('glab mr diff', TWO_FILE_DIFF);
+    on(
+      'glab api projects/target-org%2Ftarget-repo/merge_requests/11',
+      JSON.stringify({
+        iid: 11,
+        web_url: 'https://gitlab.com/target-org/target-repo/-/merge_requests/11',
+        title: 't',
+        description: '',
+        state: 'opened',
+        source_branch: 's',
+        target_branch: 'main',
+        labels: [],
+      }),
+    );
+
+    const result = await prDiffGitlab({ number: 11, repo: 'target-org/target-repo' });
+    expectOk(result);
+    const diff = findCall('glab mr diff');
+    expect(diff).toContain('--repo');
+    expect(diff).toContain('target-org/target-repo');
+    const api = findCall('glab api projects/');
+    expect(api).toContain('target-org%2Ftarget-repo');
+    expect(api).not.toContain('cwd-org%2Fcwd-repo');
+  });
+});

--- a/lib/adapters/pr-diff-gitlab.ts
+++ b/lib/adapters/pr-diff-gitlab.ts
@@ -1,0 +1,135 @@
+/**
+ * GitLab `pr_diff` adapter implementation.
+ *
+ * Lifted from `handlers/pr_diff.ts` per Story 1.4. Mirrors `pr-diff-github.ts`
+ * — the handler dispatches to either depending on cwd platform.
+ *
+ * GitLab divergences from the GitHub flow:
+ * - `glab mr diff <iid>` for the unified diff (no `--json` mode needed).
+ * - URL is fetched via `gitlabApiMr` (per Dev Spec §5.3 — the `lib/glab.ts`
+ *   wrapper stays). `glab mr view --output json` is unsupported in glab 1.36;
+ *   the API path returns the canonical `web_url` directly.
+ *
+ * Truncation safety-valve mirrors the GitHub adapter; identical thresholds.
+ */
+
+import { execSync } from 'child_process';
+import { runArgv } from '../shared/error-norm.js';
+import { gitlabApiMr } from '../glab.js';
+import type {
+  AdapterResult,
+  PrDiffArgs,
+  PrDiffResponse,
+} from './types.js';
+
+const MAX_LINES = 10000;
+const HEAD_KEEP = 5000;
+const TAIL_KEEP = 5000;
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function parseSlugOpts(slug: string | undefined): { owner?: string; repo?: string } | undefined {
+  if (slug === undefined) return undefined;
+  const idx = slug.indexOf('/');
+  if (idx <= 0 || idx === slug.length - 1) return undefined;
+  return { owner: slug.slice(0, idx), repo: slug.slice(idx + 1) };
+}
+
+function countLines(diff: string): number {
+  if (diff.length === 0) return 0;
+  let count = 0;
+  for (let i = 0; i < diff.length; i++) {
+    if (diff.charCodeAt(i) === 10) count++;
+  }
+  if (diff.charCodeAt(diff.length - 1) !== 10) count++;
+  return count;
+}
+
+function countFiles(diff: string): number {
+  if (diff.length === 0) return 0;
+  const matches = diff.match(/^diff --git /gm);
+  return matches ? matches.length : 0;
+}
+
+interface TruncateResult {
+  diff: string;
+  truncated: boolean;
+}
+
+function maybeTruncate(diff: string, lineCount: number): TruncateResult {
+  if (lineCount <= MAX_LINES) {
+    return { diff, truncated: false };
+  }
+
+  const lines = diff.split('\n');
+  const hadTrailingNewline = lines.length > 0 && lines[lines.length - 1] === '';
+  if (hadTrailingNewline) lines.pop();
+
+  const totalLines = lines.length;
+  const head = lines.slice(0, HEAD_KEEP);
+  const tail = lines.slice(totalLines - TAIL_KEEP);
+  const omitted = totalLines - HEAD_KEEP - TAIL_KEEP;
+
+  const joined =
+    head.join('\n') +
+    `\n... [${omitted} lines omitted] ...\n` +
+    tail.join('\n') +
+    (hadTrailingNewline ? '\n' : '');
+
+  return { diff: joined, truncated: true };
+}
+
+export async function prDiffGitlab(
+  args: PrDiffArgs,
+): Promise<AdapterResult<PrDiffResponse>> {
+  try {
+    const cwd = projectDir();
+
+    // Fetch the unified diff via glab CLI.
+    const diffCmd = ['glab', 'mr', 'diff', String(args.number)];
+    if (args.repo !== undefined) diffCmd.push('--repo', args.repo);
+    const diffResult = runArgv(diffCmd, cwd);
+    if (diffResult.exitCode !== 0) {
+      return {
+        ok: false,
+        code: 'glab_mr_diff_failed',
+        error: `glab mr diff failed: ${diffResult.stderr.trim() || diffResult.stdout.trim()}`,
+      };
+    }
+    const rawDiff = diffResult.stdout;
+
+    // Fetch the canonical MR URL via the typed `gitlabApiMr` wrapper. Per
+    // Dev Spec §5.3, `lib/glab.ts` stays as the shared GitLab REST client;
+    // adapters layer on top rather than reimplementing it.
+    const mr = gitlabApiMr(args.number, parseSlugOpts(args.repo));
+    const url = mr.web_url;
+
+    const rawLineCount = countLines(rawDiff);
+    const fileCount = countFiles(rawDiff);
+    const { diff, truncated } = maybeTruncate(rawDiff, rawLineCount);
+    const lineCount = truncated ? countLines(diff) : rawLineCount;
+
+    return {
+      ok: true,
+      data: {
+        number: args.number,
+        diff,
+        line_count: lineCount,
+        file_count: fileCount,
+        url,
+        truncated,
+      },
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'unexpected_error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// See pr-diff-github.ts for the rationale.
+void execSync;

--- a/lib/adapters/types.test.ts
+++ b/lib/adapters/types.test.ts
@@ -38,7 +38,8 @@ describe('PlatformAdapter contract', () => {
   // iterates zero methods.
   //
   // Story 1.3 (#240): prCreate
-  const MIGRATED_METHODS = new Set<string>(['prCreate']);
+  // Story 1.4 (#241): prDiff
+  const MIGRATED_METHODS = new Set<string>(['prCreate', 'prDiff']);
 
   test('still-stubbed methods return platform_unsupported', async () => {
     const stubbed = PLATFORM_ADAPTER_METHODS.filter((m) => !MIGRATED_METHODS.has(m));

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -66,8 +66,19 @@ export type PrMergeWaitArgs = unknown;
 export type PrMergeWaitResponse = unknown;
 export type PrStatusArgs = unknown;
 export type PrStatusResponse = unknown;
-export type PrDiffArgs = unknown;
-export type PrDiffResponse = unknown;
+export interface PrDiffArgs {
+  number: number;
+  repo?: string;
+}
+
+export interface PrDiffResponse {
+  number: number;
+  diff: string;
+  line_count: number;
+  file_count: number;
+  url: string;
+  truncated: boolean;
+}
 export type PrCommentArgs = unknown;
 export type PrCommentResponse = unknown;
 export type PrFilesArgs = unknown;

--- a/scripts/ci/migration-allowlist.txt
+++ b/scripts/ci/migration-allowlist.txt
@@ -20,7 +20,6 @@ ibm.ts
 label_create.ts
 label_list.ts
 pr_comment.ts
-pr_diff.ts
 pr_files.ts
 pr_list.ts
 pr_merge.ts

--- a/tests/pr_diff.test.ts
+++ b/tests/pr_diff.test.ts
@@ -2,16 +2,27 @@ import { describe, test, expect, mock, beforeEach } from 'bun:test';
 
 // --- Mock child_process.execSync at module level ---
 // We intercept execSync via a registry so individual tests can override calls.
+//
+// pr_diff now dispatches through the platform adapter (Story 1.4 / #241), and
+// the GitHub adapter calls subprocess via `runArgv` which shell-escapes its
+// argv (`'gh' 'pr' 'diff' '42'`). The `unquote` shim strips that quoting so
+// test match-keys can stay as plain `gh pr diff 42` strings — same pattern
+// adopted by tests/pr_create.test.ts in PR #266.
 
 let execRegistry: Array<{ match: string; value: string }> = [];
 let execError: Error | null = null;
 let execCalls: string[] = [];
 
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
 function mockExec(cmd: string): string {
   execCalls.push(cmd);
   if (execError) throw execError;
+  const flat = unquote(cmd);
   for (const { match, value } of execRegistry) {
-    if (cmd.includes(match)) return value;
+    if (cmd.includes(match) || flat.includes(match)) return value;
   }
   throw new Error(`Unexpected exec call: ${cmd}`);
 }
@@ -259,10 +270,10 @@ describe('pr_diff handler', () => {
     const data = parseResult(result.content);
     expect(data.ok).toBe(true);
 
-    const diffCall = execCalls.find((c) => c.startsWith('gh pr diff 42')) ?? '';
-    expect(diffCall).toContain('--repo Wave-Engineering/mcp-server-sdlc');
-    const viewCall = execCalls.find((c) => c.startsWith('gh pr view 42')) ?? '';
-    expect(viewCall).toContain('--repo Wave-Engineering/mcp-server-sdlc');
+    const diffCall = execCalls.find((c) => unquote(c).startsWith('gh pr diff 42')) ?? '';
+    expect(unquote(diffCall)).toContain('--repo Wave-Engineering/mcp-server-sdlc');
+    const viewCall = execCalls.find((c) => unquote(c).startsWith('gh pr view 42')) ?? '';
+    expect(unquote(viewCall)).toContain('--repo Wave-Engineering/mcp-server-sdlc');
   });
 
   test('route_with_repo — gitlab forwards slug into glab mr diff + glab api path', async () => {
@@ -280,8 +291,8 @@ describe('pr_diff handler', () => {
     const data = parseResult(result.content);
     expect(data.ok).toBe(true);
 
-    const diffCall = execCalls.find((c) => c.startsWith('glab mr diff 11')) ?? '';
-    expect(diffCall).toContain('--repo target-org/target-repo');
+    const diffCall = execCalls.find((c) => unquote(c).startsWith('glab mr diff 11')) ?? '';
+    expect(unquote(diffCall)).toContain('--repo target-org/target-repo');
     const apiCall = execCalls.find((c) => c.includes('glab api projects/')) ?? '';
     expect(apiCall).toContain('target-org%2Ftarget-repo');
     expect(apiCall).not.toContain('cwd-org%2Fcwd-repo');
@@ -297,10 +308,10 @@ describe('pr_diff handler', () => {
 
     await prDiffHandler.execute({ number: 7 });
 
-    const diffCall = execCalls.find((c) => c.startsWith('gh pr diff 7')) ?? '';
-    expect(diffCall).not.toContain('--repo');
-    const viewCall = execCalls.find((c) => c.startsWith('gh pr view 7')) ?? '';
-    expect(viewCall).not.toContain('--repo');
+    const diffCall = execCalls.find((c) => unquote(c).startsWith('gh pr diff 7')) ?? '';
+    expect(unquote(diffCall)).not.toContain('--repo');
+    const viewCall = execCalls.find((c) => unquote(c).startsWith('gh pr view 7')) ?? '';
+    expect(unquote(viewCall)).not.toContain('--repo');
   });
 
   test('invalid_slug_early_error — returns ok:false with zero exec calls', async () => {


### PR DESCRIPTION
## Summary

Story 1.4 of the platform-adapter retrofit: migrate `handlers/pr_diff.ts` from inline `gh`/`glab` subprocess calls to the platform adapter pattern, following the proven PR #266 (pr_create) template. Handler shrinks 172 -> 50 lines; subprocess work moves into typed `lib/adapters/pr-diff-{github,gitlab}.ts` adapters with `AdapterResult<PrDiffResponse>` discipline.

## Changes

- **Adapters created (4 files):**
  - `lib/adapters/pr-diff-github.ts` — `prDiffGithub`; owns `gh pr diff` + `gh pr view --json url`; truncation safety-valve inline (HEAD_KEEP=5000, TAIL_KEEP=5000, MAX_LINES=10000).
  - `lib/adapters/pr-diff-gitlab.ts` — `prDiffGitlab`; owns `glab mr diff` via `runArgv` + `gitlabApiMr` for `web_url`.
  - `lib/adapters/pr-diff-github.test.ts` — 8 colocated subprocess-boundary tests.
  - `lib/adapters/pr-diff-gitlab.test.ts` — 6 colocated subprocess-boundary tests.
- **Handler refactor:** `handlers/pr_diff.ts` now pure validation + `getAdapter({repo}).prDiff(args)` dispatch; `platform_unsupported` envelope branch returns `{ok:true, platform_unsupported:true, hint}` per Dev Spec §4.4 step 4.
- **Adapter wiring:** `lib/adapters/{github,gitlab}.ts` now reference real adapter functions instead of `stubMethod`.
- **Types:** `lib/adapters/types.ts` replaces `unknown` with concrete `PrDiffArgs` / `PrDiffResponse` interfaces.
- **Contract test:** `lib/adapters/types.test.ts` — `MIGRATED_METHODS` adds `'prDiff'`.
- **Allowlist:** `scripts/ci/migration-allowlist.txt` removes `pr_diff.ts` (31 -> 30); R-09 + R-10 gate-greps now actively enforce against `handlers/pr_diff.ts`.
- **Existing test shim:** `tests/pr_diff.test.ts` adds 3-line `unquote` shim so existing match-keys still match the now shell-escaped argv from `runArgv` — same mechanical change PR #266 applied to `tests/pr_create.test.ts`. No test logic changed.

## Linked Issues

Closes #241

## Test Plan

- `bun test tests/pr_diff.test.ts lib/adapters/pr-diff-github.test.ts lib/adapters/pr-diff-gitlab.test.ts` -> **28 pass / 0 fail / 98 expect()**
  - Existing integration: 14/14
  - New colocated GitHub: 8/8
  - New colocated GitLab: 6/6
- `./scripts/ci/validate.sh` (full) -> **1493 pass / 0 fail / 3699 expect()**; codegen OK (73 handlers); TS lint OK; gate-greps OK (43 non-allowlisted handlers, including newly-promoted `pr_diff.ts`); shellcheck OK; runtime smoke 73/73.