### PR TITLE
feat(adapter): migrate pr_comment to platform adapter pattern (#245)

### DIFF
--- a/handlers/pr_comment.ts
+++ b/handlers/pr_comment.ts
@@ -1,15 +1,11 @@
-// Origin Operations family handler.
-// See docs/handlers/origin-operations-guide.md for the canonical pattern,
-// gh ↔ glab field mappings, and normalized response schemas.
+// Origin Operations family handler — adapter-dispatching shell.
+// Subprocess + platform branching live in lib/adapters/pr-comment-{github,gitlab}.ts;
+// see docs/handlers/origin-operations-guide.md for the canonical pattern and
+// docs/platform-adapter-retrofit-devspec.md §5 for the contract.
 
-import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-
-// Codebase convention: child_process.execSync (29/36 handlers, including
-// pr_merge / pr_create). Tests mock it via `mock.module('child_process', ...)`.
-// This handler was migrated from Bun's spawn API for uniformity (#253) so the
-// adapter retrofit can stub the subprocess boundary in one place.
+import { getAdapter } from '../lib/adapters/index.js';
 
 const inputSchema = z.object({
   number: z.number().int().positive('number must be a positive integer'),
@@ -20,115 +16,8 @@ const inputSchema = z.object({
     .optional(),
 });
 
-type Input = z.infer<typeof inputSchema>;
-
-function projectDir(): string {
-  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
-}
-
-interface RunResult {
-  exitCode: number;
-  stdout: string;
-  stderr: string;
-}
-
-interface ExecError extends Error {
-  stdout?: Buffer | string;
-  stderr?: Buffer | string;
-  status?: number;
-}
-
-function bufToString(b: unknown): string {
-  if (b === undefined || b === null) return '';
-  if (typeof b === 'string') return b;
-  if (typeof (b as Buffer).toString === 'function') return (b as Buffer).toString();
-  return String(b);
-}
-
-function shellEscape(value: string): string {
-  // Single-quote the arg and escape any embedded single quotes — same form
-  // as pr_merge.ts / pr_create.ts. Safe for arbitrary user-supplied strings
-  // (markdown bodies, branch names) when the shell is invoked.
-  return `'${value.replace(/'/g, `'\\''`)}'`;
-}
-
-function run(cmd: string[], cwd: string): RunResult {
-  const shellCmd = cmd.map(shellEscape).join(' ');
-  try {
-    const stdout = execSync(shellCmd, { cwd, encoding: 'utf8' });
-    return { exitCode: 0, stdout, stderr: '' };
-  } catch (err) {
-    const e = err as ExecError;
-    return {
-      exitCode: typeof e.status === 'number' ? e.status : -1,
-      stdout: bufToString(e.stdout),
-      stderr: bufToString(e.stderr) || (err instanceof Error ? err.message : String(err)),
-    };
-  }
-}
-
-function detectPlatform(cwd: string): 'github' | 'gitlab' {
-  const proc = run(['git', 'remote', 'get-url', 'origin'], cwd);
-  if (proc.exitCode !== 0) return 'github';
-  const url = proc.stdout.trim();
-  return url.includes('gitlab') ? 'gitlab' : 'github';
-}
-
-/**
- * Parse a GitHub PR comment ID from the URL `gh pr comment` prints to stdout.
- * Format: https://github.com/<owner>/<repo>/pull/<num>#issuecomment-<id>
- */
-function parseGithubCommentId(stdout: string): number | null {
-  const match = /#issuecomment-(\d+)/.exec(stdout);
-  return match ? parseInt(match[1], 10) : null;
-}
-
-/**
- * Parse a GitLab MR note ID from the URL `glab mr note` prints to stdout.
- * Format: https://gitlab.com/<group>/<repo>/-/merge_requests/<num>#note_<id>
- */
-function parseGitlabNoteId(stdout: string): number | null {
-  const match = /#note_(\d+)/.exec(stdout);
-  return match ? parseInt(match[1], 10) : null;
-}
-
-interface PostResult {
-  commentId: number;
-  url: string;
-}
-
-function postGithubComment(num: number, body: string, cwd: string, repo?: string): PostResult {
-  const cmd = ['gh', 'pr', 'comment', String(num), '--body', body];
-  if (repo !== undefined) {
-    cmd.push('--repo', repo);
-  }
-  const proc = run(cmd, cwd);
-  if (proc.exitCode !== 0) {
-    throw new Error(`gh pr comment failed: ${proc.stderr.trim() || proc.stdout.trim()}`);
-  }
-  const url = proc.stdout.trim().split(/\s+/).pop() ?? proc.stdout.trim();
-  const commentId = parseGithubCommentId(proc.stdout);
-  if (commentId === null) {
-    throw new Error(`failed to parse comment ID from gh output: ${proc.stdout.trim()}`);
-  }
-  return { commentId, url };
-}
-
-function postGitlabComment(num: number, body: string, cwd: string, repo?: string): PostResult {
-  const cmd = ['glab', 'mr', 'note', String(num), '--message', body];
-  if (repo !== undefined) {
-    cmd.push('-R', repo);
-  }
-  const proc = run(cmd, cwd);
-  if (proc.exitCode !== 0) {
-    throw new Error(`glab mr note failed: ${proc.stderr.trim() || proc.stdout.trim()}`);
-  }
-  const url = proc.stdout.trim().split(/\s+/).pop() ?? proc.stdout.trim();
-  const commentId = parseGitlabNoteId(proc.stdout);
-  if (commentId === null) {
-    throw new Error(`failed to parse note ID from glab output: ${proc.stdout.trim()}`);
-  }
-  return { commentId, url };
+function envelope(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] };
 }
 
 const prCommentHandler: HandlerDef = {
@@ -137,44 +26,25 @@ const prCommentHandler: HandlerDef = {
     'Post a top-level comment on a PR/MR. Plain markdown body. Returns the created comment/note ID.',
   inputSchema,
   async execute(rawArgs: unknown) {
-    let args: Input;
+    let args;
     try {
       args = inputSchema.parse(rawArgs);
     } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
 
-    try {
-      const cwd = projectDir();
-      const platform = detectPlatform(cwd);
+    const adapter = getAdapter({ repo: args.repo });
+    const result = await adapter.prComment(args);
 
-      const { commentId, url } =
-        platform === 'github'
-          ? postGithubComment(args.number, args.body, cwd, args.repo)
-          : postGitlabComment(args.number, args.body, cwd, args.repo);
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({
-              ok: true,
-              number: args.number,
-              comment_id: commentId,
-              url,
-            }),
-          },
-        ],
-      };
-    } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+    // Per dev spec §4.4 step 4: surface `platform_unsupported` as a typed
+    // signal alongside `ok: true` — NOT as an error. The dispatch succeeded;
+    // the platform just doesn't have the concept. Callers branch on the
+    // discriminator instead of confusing it with a runtime failure.
+    if ('platform_unsupported' in result) {
+      return envelope({ ok: true, platform_unsupported: true, hint: result.hint });
     }
+    if (!result.ok) return envelope({ ok: false, error: result.error });
+    return envelope({ ok: true, ...result.data });
   },
 };
 

--- a/lib/adapters/github.ts
+++ b/lib/adapters/github.ts
@@ -14,6 +14,7 @@
  */
 
 import type { PlatformAdapter } from './types.js';
+import { prCommentGithub } from './pr-comment-github.js';
 import { prCreateGithub } from './pr-create-github.js';
 import { prDiffGithub } from './pr-diff-github.js';
 import { prFilesGithub } from './pr-files-github.js';
@@ -31,7 +32,7 @@ export const githubAdapter: PlatformAdapter = {
   prMergeWait: stubMethod,
   prStatus: prStatusGithub,
   prDiff: prDiffGithub,
-  prComment: stubMethod,
+  prComment: prCommentGithub,
   prFiles: prFilesGithub,
   prList: prListGithub,
   prWaitCi: stubMethod,

--- a/lib/adapters/gitlab.ts
+++ b/lib/adapters/gitlab.ts
@@ -15,6 +15,7 @@
  */
 
 import type { PlatformAdapter } from './types.js';
+import { prCommentGitlab } from './pr-comment-gitlab.js';
 import { prCreateGitlab } from './pr-create-gitlab.js';
 import { prDiffGitlab } from './pr-diff-gitlab.js';
 import { prFilesGitlab } from './pr-files-gitlab.js';
@@ -32,7 +33,7 @@ export const gitlabAdapter: PlatformAdapter = {
   prMergeWait: stubMethod,
   prStatus: prStatusGitlab,
   prDiff: prDiffGitlab,
-  prComment: stubMethod,
+  prComment: prCommentGitlab,
   prFiles: prFilesGitlab,
   prList: prListGitlab,
   prWaitCi: stubMethod,

--- a/lib/adapters/pr-comment-github.test.ts
+++ b/lib/adapters/pr-comment-github.test.ts
@@ -1,0 +1,181 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { AdapterResult, PrCommentResponse } from './types.ts';
+
+// Subprocess-boundary tests for the GitHub pr_comment adapter (R-15).
+// Integration-level coverage (handler dispatch, error envelope, schema
+// validation) stays in tests/pr_comment.test.ts; this file owns the argv-shape
+// and response-parsing assertions that prove the adapter speaks `gh` correctly.
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { prCommentGithub } = await import('./pr-comment-github.ts');
+
+function on(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
+function expectOk(
+  r: AdapterResult<PrCommentResponse>,
+): asserts r is { ok: true; data: PrCommentResponse } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectErr(
+  r: AdapterResult<PrCommentResponse>,
+): asserts r is { ok: false; error: string; code: string } {
+  if (!('ok' in r) || r.ok) {
+    throw new Error(`expected error result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('prCommentGithub — subprocess boundary', () => {
+  test('gh CLI invocation matches expected argv shape (happy path)', async () => {
+    on(
+      'gh pr comment',
+      'https://github.com/org/repo/pull/42#issuecomment-1001\n',
+    );
+
+    const result = await prCommentGithub({ number: 42, body: 'looks good' });
+    expectOk(result);
+    expect(result.data.comment_id).toBe(1001);
+    expect(result.data.number).toBe(42);
+    expect(result.data.url).toBe('https://github.com/org/repo/pull/42#issuecomment-1001');
+
+    const ghCall = findCall('gh pr comment');
+    expect(ghCall).toContain('gh');
+    expect(ghCall).toContain('pr');
+    expect(ghCall).toContain('comment');
+    expect(ghCall).toContain('42');
+    expect(ghCall).toContain('--body');
+    expect(ghCall).toContain('looks good');
+    // No --repo flag when args.repo is omitted.
+    expect(ghCall).not.toContain("'--repo'");
+  });
+
+  test('multi-line markdown body is preserved verbatim through shell-escape', async () => {
+    on(
+      'gh pr comment',
+      'https://github.com/org/repo/pull/7#issuecomment-2002\n',
+    );
+
+    const body = [
+      '**heads up** — see [issue](https://example.com/x)',
+      '',
+      '```ts',
+      'const x: number = 1;',
+      'console.log(`hello ${x}`);',
+      '```',
+      '',
+      '- item one',
+      '- item two',
+    ].join('\n');
+
+    const result = await prCommentGithub({ number: 7, body });
+    expectOk(result);
+    expect(result.data.comment_id).toBe(2002);
+
+    // Body survives shell-escaping: assert each non-trivial line is present
+    // verbatim in the unquoted command. Newlines inside single-quoted shell
+    // strings are preserved literally — no escaping needed.
+    const ghCall = findCall('gh pr comment');
+    const flat = unquote(ghCall);
+    expect(flat).toContain('**heads up**');
+    expect(flat).toContain('[issue](https://example.com/x)');
+    expect(flat).toContain('```ts');
+    expect(flat).toContain('const x: number = 1;');
+    expect(flat).toContain('console.log(`hello ${x}`);');
+    expect(flat).toContain('- item one');
+    expect(flat).toContain('- item two');
+  });
+
+  test('parses comment_id from #issuecomment-<id> URL fragment', async () => {
+    on(
+      'gh pr comment',
+      'https://github.com/org/repo/pull/3#issuecomment-3003\n',
+    );
+
+    const result = await prCommentGithub({ number: 3, body: 'hi' });
+    expectOk(result);
+    expect(result.data.comment_id).toBe(3003);
+    expect(result.data.url).toBe('https://github.com/org/repo/pull/3#issuecomment-3003');
+  });
+
+  test('returns AdapterResult{ok:false, code} on gh failure (not thrown)', async () => {
+    on('gh pr comment', () => {
+      const err = new Error('HTTP 404: Not Found') as ThrowableError;
+      err.stderr = 'HTTP 404: Not Found';
+      err.status = 1;
+      throw err;
+    });
+
+    const result = await prCommentGithub({ number: 9999, body: 'nope' });
+    expectErr(result);
+    expect(result.code).toBe('gh_pr_comment_failed');
+    expect(result.error).toContain('gh pr comment failed');
+    expect(result.error).toContain('HTTP 404');
+  });
+
+  test('returns parse-failure code when stdout lacks #issuecomment-<id>', async () => {
+    on('gh pr comment', 'posted comment ok\n');
+
+    const result = await prCommentGithub({ number: 1, body: 'x' });
+    expectErr(result);
+    expect(result.code).toBe('gh_comment_id_parse_failed');
+    expect(result.error).toContain('failed to parse comment ID');
+  });
+
+  test('--repo flag forwarded when args.repo provided', async () => {
+    on(
+      'gh pr comment',
+      'https://github.com/Wave-Engineering/mcp-server-sdlc/pull/42#issuecomment-1001\n',
+    );
+
+    await prCommentGithub({
+      number: 42,
+      body: 'cross-repo',
+      repo: 'Wave-Engineering/mcp-server-sdlc',
+    });
+
+    const ghCall = findCall('gh pr comment');
+    expect(ghCall).toContain('--repo');
+    expect(ghCall).toContain('Wave-Engineering/mcp-server-sdlc');
+  });
+});

--- a/lib/adapters/pr-comment-github.ts
+++ b/lib/adapters/pr-comment-github.ts
@@ -1,0 +1,88 @@
+/**
+ * GitHub `pr_comment` adapter implementation.
+ *
+ * Lifted from `handlers/pr_comment.ts` per Story 1.8. The handler is now a
+ * thin dispatcher; this module owns the GitHub-specific subprocess work and
+ * normalizes the response into `AdapterResult<PrCommentResponse>`.
+ *
+ * Errors that come back from `gh` are converted into `{ok: false, error, code}`
+ * — never thrown — so the handler doesn't need a try/catch around the dispatch.
+ *
+ * Argv shape: `gh pr comment <num> --body <body> [--repo <slug>]`. The
+ * comment ID is parsed from the `#issuecomment-<id>` fragment that `gh`
+ * prints on stdout.
+ */
+
+import { execSync } from 'child_process';
+import { runArgv } from '../shared/error-norm.js';
+import type {
+  AdapterResult,
+  PrCommentArgs,
+  PrCommentResponse,
+} from './types.js';
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+/**
+ * Parse a GitHub PR comment ID from the URL `gh pr comment` prints to stdout.
+ * Format: https://github.com/<owner>/<repo>/pull/<num>#issuecomment-<id>
+ */
+function parseGithubCommentId(stdout: string): number | null {
+  const match = /#issuecomment-(\d+)/.exec(stdout);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+export async function prCommentGithub(
+  args: PrCommentArgs,
+): Promise<AdapterResult<PrCommentResponse>> {
+  // Bound any exception that escapes the helpers below into a typed result —
+  // adapter callers must not have to try/catch.
+  try {
+    const cwd = projectDir();
+    const cmd = ['gh', 'pr', 'comment', String(args.number), '--body', args.body];
+    if (args.repo !== undefined) {
+      cmd.push('--repo', args.repo);
+    }
+
+    const result = runArgv(cmd, cwd);
+    if (result.exitCode !== 0) {
+      return {
+        ok: false,
+        code: 'gh_pr_comment_failed',
+        error: `gh pr comment failed: ${result.stderr.trim() || result.stdout.trim()}`,
+      };
+    }
+
+    const url = result.stdout.trim().split(/\s+/).pop() ?? result.stdout.trim();
+    const commentId = parseGithubCommentId(result.stdout);
+    if (commentId === null) {
+      return {
+        ok: false,
+        code: 'gh_comment_id_parse_failed',
+        error: `failed to parse comment ID from gh output: ${result.stdout.trim()}`,
+      };
+    }
+
+    return {
+      ok: true,
+      data: {
+        number: args.number,
+        comment_id: commentId,
+        url,
+      },
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'unexpected_error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// `execSync` is intentionally re-imported above so that adapter-level test
+// files can `mock.module('child_process', ...)` and intercept this module's
+// subprocess calls without needing access to the handler's mock setup.
+void execSync;

--- a/lib/adapters/pr-comment-gitlab.test.ts
+++ b/lib/adapters/pr-comment-gitlab.test.ts
@@ -1,0 +1,178 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { AdapterResult, PrCommentResponse } from './types.ts';
+
+// Subprocess-boundary tests for the GitLab pr_comment adapter (R-15).
+// Integration-level coverage stays in tests/pr_comment.test.ts.
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { prCommentGitlab } = await import('./pr-comment-gitlab.ts');
+
+function on(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
+function expectOk(
+  r: AdapterResult<PrCommentResponse>,
+): asserts r is { ok: true; data: PrCommentResponse } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectErr(
+  r: AdapterResult<PrCommentResponse>,
+): asserts r is { ok: false; error: string; code: string } {
+  if (!('ok' in r) || r.ok) {
+    throw new Error(`expected error result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('prCommentGitlab — subprocess boundary', () => {
+  test('glab CLI invocation matches expected argv shape (happy path)', async () => {
+    on(
+      'glab mr note',
+      'https://gitlab.com/org/repo/-/merge_requests/55#note_9090\n',
+    );
+
+    const result = await prCommentGitlab({ number: 55, body: 'ship it' });
+    expectOk(result);
+    expect(result.data.comment_id).toBe(9090);
+    expect(result.data.number).toBe(55);
+    expect(result.data.url).toBe('https://gitlab.com/org/repo/-/merge_requests/55#note_9090');
+
+    const glabCall = findCall('glab mr note');
+    expect(glabCall).toContain('glab');
+    expect(glabCall).toContain('mr');
+    expect(glabCall).toContain('note');
+    expect(glabCall).toContain('55');
+    // GitLab uses --message, not --body
+    expect(glabCall).toContain('--message');
+    expect(glabCall).toContain('ship it');
+    // No -R when args.repo omitted
+    expect(glabCall).not.toContain("'-R'");
+  });
+
+  test('multi-line markdown body is preserved verbatim through shell-escape', async () => {
+    on(
+      'glab mr note',
+      'https://gitlab.com/org/repo/-/merge_requests/88#note_7070\n',
+    );
+
+    const body = [
+      '### Review findings',
+      '',
+      '```python',
+      'def hello():',
+      '    print("world")',
+      '```',
+      '',
+      '- bullet one',
+      '- bullet two',
+    ].join('\n');
+
+    const result = await prCommentGitlab({ number: 88, body });
+    expectOk(result);
+    expect(result.data.comment_id).toBe(7070);
+
+    // Body survives shell-escaping: each line should be present verbatim in
+    // the unquoted command. Single-quoted shell tokens preserve newlines.
+    const glabCall = findCall('glab mr note');
+    const flat = unquote(glabCall);
+    expect(flat).toContain('### Review findings');
+    expect(flat).toContain('```python');
+    expect(flat).toContain('def hello():');
+    expect(flat).toContain('print("world")');
+    expect(flat).toContain('- bullet one');
+    expect(flat).toContain('- bullet two');
+  });
+
+  test('parses note ID from #note_<id> URL fragment', async () => {
+    on(
+      'glab mr note',
+      'https://gitlab.example.com/team/proj/-/merge_requests/11#note_2222\n',
+    );
+
+    const result = await prCommentGitlab({ number: 11, body: 'hi' });
+    expectOk(result);
+    expect(result.data.comment_id).toBe(2222);
+    expect(result.data.url).toBe('https://gitlab.example.com/team/proj/-/merge_requests/11#note_2222');
+  });
+
+  test('returns AdapterResult{ok:false, code} on glab failure (not thrown)', async () => {
+    on('glab mr note', () => {
+      const err = new Error('permission denied') as ThrowableError;
+      err.stderr = 'permission denied';
+      err.status = 1;
+      throw err;
+    });
+
+    const result = await prCommentGitlab({ number: 9999, body: 'nope' });
+    expectErr(result);
+    expect(result.code).toBe('glab_mr_note_failed');
+    expect(result.error).toContain('glab mr note failed');
+    expect(result.error).toContain('permission denied');
+  });
+
+  test('returns parse-failure code when stdout lacks #note_<id>', async () => {
+    on('glab mr note', 'posted note ok\n');
+
+    const result = await prCommentGitlab({ number: 1, body: 'x' });
+    expectErr(result);
+    expect(result.code).toBe('glab_note_id_parse_failed');
+    expect(result.error).toContain('failed to parse note ID');
+  });
+
+  test('-R flag forwarded when args.repo provided (GitLab uses -R, not --repo)', async () => {
+    on(
+      'glab mr note',
+      'https://gitlab.com/target-org/target-repo/-/merge_requests/55#note_9090\n',
+    );
+
+    await prCommentGitlab({
+      number: 55,
+      body: 'cross-repo',
+      repo: 'target-org/target-repo',
+    });
+
+    const glabCall = findCall('glab mr note');
+    expect(glabCall).toContain('-R');
+    expect(glabCall).toContain('target-org/target-repo');
+  });
+});

--- a/lib/adapters/pr-comment-gitlab.ts
+++ b/lib/adapters/pr-comment-gitlab.ts
@@ -1,0 +1,83 @@
+/**
+ * GitLab `pr_comment` adapter implementation.
+ *
+ * Lifted from `handlers/pr_comment.ts` per Story 1.8. Mirrors
+ * `pr-comment-github.ts` — the handler dispatches to either depending on cwd
+ * platform.
+ *
+ * GitLab divergences from the GitHub flow:
+ * - `glab mr note` (not `pr comment`).
+ * - `--message` flag (not `--body`).
+ * - `-R` repo flag (not `--repo`).
+ * - Note ID parsed from `#note_<id>` fragment (not `#issuecomment-<id>`).
+ */
+
+import { execSync } from 'child_process';
+import { runArgv } from '../shared/error-norm.js';
+import type {
+  AdapterResult,
+  PrCommentArgs,
+  PrCommentResponse,
+} from './types.js';
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+/**
+ * Parse a GitLab MR note ID from the URL `glab mr note` prints to stdout.
+ * Format: https://gitlab.com/<group>/<repo>/-/merge_requests/<num>#note_<id>
+ */
+function parseGitlabNoteId(stdout: string): number | null {
+  const match = /#note_(\d+)/.exec(stdout);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+export async function prCommentGitlab(
+  args: PrCommentArgs,
+): Promise<AdapterResult<PrCommentResponse>> {
+  try {
+    const cwd = projectDir();
+    const cmd = ['glab', 'mr', 'note', String(args.number), '--message', args.body];
+    if (args.repo !== undefined) {
+      cmd.push('-R', args.repo);
+    }
+
+    const result = runArgv(cmd, cwd);
+    if (result.exitCode !== 0) {
+      return {
+        ok: false,
+        code: 'glab_mr_note_failed',
+        error: `glab mr note failed: ${result.stderr.trim() || result.stdout.trim()}`,
+      };
+    }
+
+    const url = result.stdout.trim().split(/\s+/).pop() ?? result.stdout.trim();
+    const noteId = parseGitlabNoteId(result.stdout);
+    if (noteId === null) {
+      return {
+        ok: false,
+        code: 'glab_note_id_parse_failed',
+        error: `failed to parse note ID from glab output: ${result.stdout.trim()}`,
+      };
+    }
+
+    return {
+      ok: true,
+      data: {
+        number: args.number,
+        comment_id: noteId,
+        url,
+      },
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'unexpected_error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// See pr-comment-github.ts for the rationale.
+void execSync;

--- a/lib/adapters/types.test.ts
+++ b/lib/adapters/types.test.ts
@@ -42,7 +42,8 @@ describe('PlatformAdapter contract', () => {
   // Story 1.5 (#242): prFiles
   // Story 1.6 (#243): prList
   // Story 1.7 (#244): prStatus
-  const MIGRATED_METHODS = new Set<string>(['prCreate', 'prDiff', 'prFiles', 'prList', 'prStatus']);
+  // Story 1.8 (#245): prComment
+  const MIGRATED_METHODS = new Set<string>(['prCreate', 'prDiff', 'prFiles', 'prList', 'prStatus', 'prComment']);
 
   test('still-stubbed methods return platform_unsupported', async () => {
     const stubbed = PLATFORM_ADAPTER_METHODS.filter((m) => !MIGRATED_METHODS.has(m));

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -119,8 +119,17 @@ export interface PrDiffResponse {
   url: string;
   truncated: boolean;
 }
-export type PrCommentArgs = unknown;
-export type PrCommentResponse = unknown;
+export interface PrCommentArgs {
+  number: number;
+  body: string;
+  repo?: string;
+}
+
+export interface PrCommentResponse {
+  number: number;
+  comment_id: number;
+  url: string;
+}
 export interface PrFilesArgs {
   number: number;
   repo?: string;

--- a/scripts/ci/migration-allowlist.txt
+++ b/scripts/ci/migration-allowlist.txt
@@ -19,7 +19,6 @@ epic_sub_issues.ts
 ibm.ts
 label_create.ts
 label_list.ts
-pr_comment.ts
 pr_merge.ts
 pr_merge_wait.ts
 pr_wait_ci.ts

--- a/tests/pr_comment.test.ts
+++ b/tests/pr_comment.test.ts
@@ -393,10 +393,13 @@ describe('pr_comment handler', () => {
 
     await handler.execute({ number: 42, body: 'shape-check' });
 
-    // Exactly one gh call (the comment) and one git call (platform detect).
+    // Exactly one gh call (the comment, via the adapter's `runArgv` which
+    // shell-escapes every token) and one git call (platform detect — the
+    // adapter routing layer calls `detectPlatform()` which uses raw `execSync`
+    // without shell-escape, hence the unquoted match).
     const ghCalls = execCalls.filter((c) => c.includes("'gh'"));
     expect(ghCalls.length).toBe(1);
-    const gitCalls = execCalls.filter((c) => c.includes("'git'"));
+    const gitCalls = execCalls.filter((c) => c.includes('git remote get-url'));
     expect(gitCalls.length).toBe(1);
 
     // The single gh call is fully shell-escaped: every token wrapped in '...'.


### PR DESCRIPTION
## Summary

Story 1.8 of the platform adapter retrofit: migrates `handlers/pr_comment.ts` from inline platform branching + direct `execSync` calls to the GitHub/GitLab adapter pattern. Handler shrinks from 182 lines to 51 lines (51% under the 80-line ceiling) and `pr_comment.ts` is removed from the migration allowlist (27 → 26 entries). Gate-greps now enforce the no-platform-branching invariant on this handler.

## Changes

- New `lib/adapters/pr-comment-github.ts` — `gh pr comment <num> --body <body> [--repo <slug>]`, parses `#issuecomment-<id>` from stdout
- New `lib/adapters/pr-comment-gitlab.ts` — `glab mr note <num> --message <body> [-R <slug>]`, parses `#note_<id>`
- New colocated tests `lib/adapters/pr-comment-{github,gitlab}.test.ts` — 6 subprocess-boundary tests each (12 total)
- Refactored `handlers/pr_comment.ts` — pure adapter dispatcher, no `execSync`, no `detectPlatform` branching; spreads `result.data` into envelope to preserve top-level `data.number` / `data.comment_id` / `data.url` integration-test assertions
- `lib/adapters/types.ts` — concrete `PrCommentArgs` / `PrCommentResponse` interfaces (replaced `unknown`)
- `lib/adapters/{github,gitlab}.ts` — wired `prComment` adapter, dropped stub
- `lib/adapters/types.test.ts` — added `'prComment'` to `MIGRATED_METHODS` (now 6 entries)
- `scripts/ci/migration-allowlist.txt` — removed `pr_comment.ts` (27 → 26)
- `tests/pr_comment.test.ts` — single assertion update in `execSync invocation matches gh CLI shape` test (`gitCalls` filter matches unquoted `git remote get-url`, mirroring PR #270 / pr_status precedent)

## Linked Issues

Closes #245

## Test Plan

- Full `./scripts/ci/validate.sh` — GREEN, 1573/0 across 96 files
- Targeted: `bun test tests/pr_comment.test.ts lib/adapters/pr-comment-github.test.ts lib/adapters/pr-comment-gitlab.test.ts` — 30/30 pass (124 expect() calls)
- Gate-greps: 47 non-allowlisted handlers checked, all OK (was 46 — pr_comment now enforced)
- Migration allowlist: 26 entries (was 27)
