### PR TITLE
fix(ci_wait_run): add expected_sha to anchor wait to a specific commit

### DIFF
--- a/handlers/ci_wait_run.ts
+++ b/handlers/ci_wait_run.ts
@@ -20,6 +20,14 @@ const inputSchema = z
       .string()
       .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/, 'repo must be in owner/repo form')
       .optional(),
+    // Issue #259: anchor the wait to a specific commit SHA. When provided, the
+    // tool only returns runs whose head SHA equals expected_sha, polling until
+    // such a run appears (within timeout_sec) and then completes. Without it,
+    // the existing "most recent matching run" behavior is preserved.
+    expected_sha: z
+      .string()
+      .regex(/^[0-9a-f]{40}$/i, 'expected_sha must be a 40-char hex commit SHA')
+      .optional(),
   })
   .strict();
 
@@ -122,9 +130,21 @@ function githubListCmd(
   ref: string,
   workflowName: string | undefined,
   repo: string | undefined,
+  expectedSha: string | undefined,
 ): string {
   const quotedRef = shellQuote(ref);
-  const refFlag = isSha(ref) ? `--commit "${quotedRef}"` : `--branch "${quotedRef}"`;
+  // When expected_sha is set, the SHA filter is the authoritative anchor —
+  // always pass it as --commit. Per spec (#259), also pass --branch when the
+  // ref is a branch name, so gh narrows by both branch and commit.
+  let refFlag: string;
+  if (expectedSha) {
+    const quotedSha = shellQuote(expectedSha);
+    refFlag = isSha(ref)
+      ? `--commit "${quotedSha}"`
+      : `--branch "${quotedRef}" --commit "${quotedSha}"`;
+  } else {
+    refFlag = isSha(ref) ? `--commit "${quotedRef}"` : `--branch "${quotedRef}"`;
+  }
   const workflowFlag = workflowName
     ? ` --workflow "${shellQuote(workflowName)}"`
     : '';
@@ -150,8 +170,9 @@ function fetchGithubRuns(
   ref: string,
   workflowName: string | undefined,
   repo: string | undefined,
+  expectedSha: string | undefined,
 ): GithubRun[] {
-  const cmd = githubListCmd(ref, workflowName, repo);
+  const cmd = githubListCmd(ref, workflowName, repo, expectedSha);
   let raw: string;
   try {
     raw = exec(cmd);
@@ -213,10 +234,11 @@ function githubSnapshot(run: GithubRun): RunSnapshot {
 function fetchGitlabPipelines(
   ref: string,
   repo: string | undefined,
+  expectedSha: string | undefined,
 ): GitlabPipeline[] {
   try {
     const opts = splitRepoSlug(repo);
-    return gitlabApiCiList({ ref, limit: 20 }, opts);
+    return gitlabApiCiList({ ref, limit: 20, sha: expectedSha }, opts);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(
@@ -296,14 +318,31 @@ function fetchSnapshot(
   ref: string,
   workflowName: string | undefined,
   repo: string | undefined,
+  expectedSha: string | undefined,
 ): RunSnapshot | null {
   if (platform === 'github') {
-    const runs = fetchGithubRuns(ref, workflowName, repo);
-    const picked = pickGithubRun(runs, workflowName);
+    const runs = fetchGithubRuns(ref, workflowName, repo, expectedSha);
+    // Defense-in-depth: even if gh somehow returns runs that don't match the
+    // SHA filter (e.g. server-side filter quirks), drop any whose headSha
+    // doesn't equal expected_sha. This is what makes the "ignores other runs
+    // on the same branch" guarantee airtight.
+    const filtered = expectedSha
+      ? runs.filter(
+          (r) => r.headSha?.toLowerCase() === expectedSha.toLowerCase(),
+        )
+      : runs;
+    const picked = pickGithubRun(filtered, workflowName);
     return picked ? githubSnapshot(picked) : null;
   }
-  const pipelines = fetchGitlabPipelines(ref, repo);
-  const picked = pickGitlabPipeline(pipelines, workflowName);
+  const pipelines = fetchGitlabPipelines(ref, repo, expectedSha);
+  // Same defense-in-depth for GitLab — only return pipelines whose sha
+  // matches when expected_sha is provided.
+  const filtered = expectedSha
+    ? pipelines.filter(
+        (p) => p.sha?.toLowerCase() === expectedSha.toLowerCase(),
+      )
+    : pipelines;
+  const picked = pickGitlabPipeline(filtered, workflowName);
   return picked ? gitlabSnapshot(picked) : null;
 }
 
@@ -357,6 +396,12 @@ const ciWaitRunHandler: HandlerDef = {
     const ref = args.ref;
     const workflowName = args.workflow_name;
     const repo = args.repo;
+    // Issue #259: when expected_sha is provided, the wait is anchored to a
+    // specific commit. The no-run-yet window must be the full timeout (the
+    // new run for that SHA may legitimately take minutes to register), not
+    // the default 60s.
+    const expectedSha = args.expected_sha?.toLowerCase();
+    const noRunYetWindowSec = expectedSha ? timeoutSec : NO_RUN_YET_WINDOW_SEC;
 
     const platform = detectPlatform();
     const startMs = Date.now();
@@ -369,12 +414,14 @@ const ciWaitRunHandler: HandlerDef = {
       // matching its HEAD SHA, treat that as validation — don't wait for a
       // push-triggered run that will never arrive.
       if (platform === 'github') {
-        const initialRuns = fetchGithubRuns(ref, workflowName, repo);
+        const initialRuns = fetchGithubRuns(ref, workflowName, repo, expectedSha);
         if (initialRuns.length > 0) {
           const anyPush = initialRuns.some((r) => r.event === 'push');
           if (!anyPush) {
             // Resolve ref to a HEAD SHA for comparison against run.headSha.
-            let headSha: string | null = isSha(ref) ? ref.toLowerCase() : null;
+            // Issue #259: when expected_sha is provided, that IS the head SHA
+            // we care about — skip the branch-to-SHA resolution.
+            let headSha: string | null = expectedSha ?? (isSha(ref) ? ref.toLowerCase() : null);
             if (!headSha) {
               // When `repo` is explicitly provided, skip cwd-based slug
               // parsing and pass the caller's slug directly.
@@ -435,14 +482,19 @@ const ciWaitRunHandler: HandlerDef = {
       }
 
       // --- Phase 1: wait for a run to appear (no-run-yet window) ---
+      // When expected_sha is set the window equals timeout_sec so we don't
+      // give up early on a new run that just hasn't registered yet (#259).
       let snapshot: RunSnapshot | null = null;
-      while (elapsedSec() < NO_RUN_YET_WINDOW_SEC) {
-        snapshot = fetchSnapshot(platform, ref, workflowName, repo);
+      while (elapsedSec() < noRunYetWindowSec) {
+        snapshot = fetchSnapshot(platform, ref, workflowName, repo, expectedSha);
         if (snapshot) break;
         logPoll(ref, elapsedSec(), 'no_run_yet');
         // Also honor the overall timeout — don't exceed it here.
         if (elapsedSec() >= timeoutSec) break;
-        await sleepFn(NO_RUN_YET_POLL_SEC * 1000);
+        // Use the configured poll interval when waiting for a specific SHA;
+        // the 5s default is too aggressive over a long timeout.
+        const sleepSec = expectedSha ? pollIntervalSec : NO_RUN_YET_POLL_SEC;
+        await sleepFn(sleepSec * 1000);
       }
 
       if (!snapshot) {
@@ -451,16 +503,20 @@ const ciWaitRunHandler: HandlerDef = {
         const filterMsg = workflowName
           ? ` (filtered by workflow_name='${workflowName}')`
           : '';
+        const shaMsg = expectedSha
+          ? ` with head SHA '${expectedSha}'`
+          : '';
         return {
           content: [
             {
               type: 'text' as const,
               text: JSON.stringify({
                 ok: false,
-                error: `No CI run found for ref '${ref}'${filterMsg} after waiting ${waited}s. The pipeline may not have been triggered, or the ref has not been pushed to origin. Verify with: gh run list --${isSha(ref) ? 'commit' : 'branch'} ${ref}`,
+                error: `No CI run found for ref '${ref}'${shaMsg}${filterMsg} after waiting ${waited}s. The pipeline may not have been triggered, or the ref has not been pushed to origin. Verify with: gh run list --${isSha(ref) ? 'commit' : 'branch'} ${ref}`,
                 waited_sec: waited,
                 ref,
                 platform,
+                ...(expectedSha ? { expected_sha: expectedSha } : {}),
               }),
             },
           ],
@@ -494,7 +550,7 @@ const ciWaitRunHandler: HandlerDef = {
         }
         await sleepFn(pollIntervalSec * 1000);
         // Refresh snapshot.
-        const next = fetchSnapshot(platform, ref, workflowName, repo);
+        const next = fetchSnapshot(platform, ref, workflowName, repo, expectedSha);
         if (!next) {
           // Unusual — the run vanished between polls. Keep the previous snapshot and log.
           logPoll(ref, elapsedSec(), `${snapshot.status}(stale,no_run_returned)`);

--- a/lib/glab.ts
+++ b/lib/glab.ts
@@ -262,6 +262,7 @@ export function gitlabApiCiList(
   params: {
     ref?: string;
     limit?: number;
+    sha?: string;
   },
   opts?: { owner?: string; repo?: string },
 ): GitlabPipeline[] {
@@ -270,6 +271,9 @@ export function gitlabApiCiList(
 
   if (params.ref !== undefined) {
     queryParts.push(`ref=${encodeURIComponent(params.ref)}`);
+  }
+  if (params.sha !== undefined) {
+    queryParts.push(`sha=${encodeURIComponent(params.sha)}`);
   }
   if (params.limit !== undefined) {
     queryParts.push(`per_page=${String(params.limit)}`);

--- a/tests/ci_wait_run.test.ts
+++ b/tests/ci_wait_run.test.ts
@@ -601,6 +601,190 @@ describe('ci_wait_run handler', () => {
     expect(wrongApiCalls.length).toBe(0);
   });
 
+  // --- Issue #259: expected_sha anchors the wait to a specific commit ---
+
+  // expected_sha waits for the matching run to appear (no false positive on
+  // the previous run for the same branch).
+  test('expected_sha_waits_for_matching_run — polls until run for SHA appears, then succeeds', async () => {
+    const targetSha = 'a'.repeat(40);
+    const previousSha = 'b'.repeat(40);
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    // Sequence: first two polls return empty (gh filters by --commit, the new
+    // run hasn't registered yet), then the matching run appears in_progress,
+    // then completes.
+    execRegistry['gh run list'] = [
+      JSON.stringify([]), // pre-flight (empty for SHA filter)
+      JSON.stringify([]), // phase 1 first poll
+      JSON.stringify([]), // phase 1 second poll
+      JSON.stringify([
+        ghRun({
+          databaseId: 9001,
+          status: 'in_progress',
+          headSha: targetSha,
+        }),
+      ]),
+      JSON.stringify([
+        ghRun({
+          databaseId: 9001,
+          status: 'completed',
+          conclusion: 'success',
+          headSha: targetSha,
+        }),
+      ]),
+    ];
+
+    const result = await ciWaitRunHandler.execute({
+      ref: 'main',
+      expected_sha: targetSha,
+      timeout_sec: 600,
+    });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    expect(data.final_status).toBe('success');
+    expect(data.run_id).toBe(9001);
+    expect(data.sha).toBe(targetSha);
+    // Every gh run list call must have included --commit "<targetSha>" so we
+    // never even saw runs for `previousSha`.
+    const ghCalls = execCallLog.filter((c) => c.startsWith('gh run list'));
+    expect(ghCalls.length).toBeGreaterThan(0);
+    for (const c of ghCalls) {
+      expect(c).toContain(`--commit "${targetSha}"`);
+    }
+    // Sanity: previousSha must never have leaked into a query.
+    for (const c of ghCalls) {
+      expect(c).not.toContain(previousSha);
+    }
+  });
+
+  // expected_sha times out cleanly when the run never appears.
+  test('expected_sha_timeout — run for SHA never registers, returns no-run-found error', async () => {
+    const realDateNow = Date.now;
+    let fakeNow = realDateNow();
+    Date.now = () => fakeNow;
+    __setSleep(async (ms: number) => {
+      fakeNow += ms;
+    });
+    try {
+      const targetSha = 'c'.repeat(40);
+      execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+      execRegistry['gh run list'] = JSON.stringify([]); // sticky empty
+
+      const result = await ciWaitRunHandler.execute({
+        ref: 'main',
+        expected_sha: targetSha,
+        timeout_sec: 60,
+        poll_interval_sec: 10,
+      });
+      const data = parseResult(result.content);
+      expect(data.ok).toBe(false);
+      expect((data.error as string).toLowerCase()).toContain('no ci run found');
+      expect((data.error as string)).toContain(targetSha);
+      expect(data.expected_sha).toBe(targetSha);
+      expect(data.waited_sec as number).toBeGreaterThanOrEqual(60);
+    } finally {
+      Date.now = realDateNow;
+    }
+  });
+
+  // Backwards-compat: omitting expected_sha preserves the existing behavior.
+  // Same shape as `immediate_failure` / `no_run_then_success` to make the
+  // regression intent explicit.
+  test('expected_sha_omitted_preserves_legacy — call without expected_sha works as before', async () => {
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    execRegistry['gh run list'] = JSON.stringify([
+      ghRun({ status: 'completed', conclusion: 'success' }),
+    ]);
+
+    const result = await ciWaitRunHandler.execute({ ref: 'main' });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    expect(data.final_status).toBe('success');
+    // The gh run list call must NOT have included --commit (ref is a branch
+    // name and no expected_sha was provided).
+    const ghCalls = execCallLog.filter((c) => c.startsWith('gh run list'));
+    expect(ghCalls.length).toBeGreaterThan(0);
+    expect(ghCalls[0]).toContain('--branch "main"');
+    expect(ghCalls[0]).not.toContain('--commit');
+  });
+
+  // expected_sha ignores other (more recent) runs on the same branch whose
+  // SHA doesn't match. This is the core regression for the false-positive
+  // bug described in #259.
+  test('expected_sha_ignores_other_runs — defense-in-depth: filter mismatched SHA even if returned', async () => {
+    const targetSha = 'd'.repeat(40);
+    const otherSha = 'e'.repeat(40);
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    // Simulate a misbehaving server (or stale cache) that returns a run with
+    // a DIFFERENT SHA despite the --commit filter. The handler must NOT pick
+    // it up — it must wait for a real match. We ratchet through:
+    //   poll 1 (pre-flight): mismatched run only → must be ignored
+    //   poll 2 (phase 1): mismatched run only → still ignored
+    //   poll 3 (phase 1): the real run appears, completed/success
+    execRegistry['gh run list'] = [
+      JSON.stringify([
+        ghRun({ databaseId: 1, status: 'completed', conclusion: 'success', headSha: otherSha, createdAt: '2026-04-08T00:00:00Z' }),
+      ]),
+      JSON.stringify([
+        ghRun({ databaseId: 1, status: 'completed', conclusion: 'success', headSha: otherSha, createdAt: '2026-04-08T00:00:00Z' }),
+      ]),
+      JSON.stringify([
+        ghRun({ databaseId: 1, status: 'completed', conclusion: 'success', headSha: otherSha, createdAt: '2026-04-08T00:00:00Z' }),
+        ghRun({ databaseId: 2, status: 'completed', conclusion: 'success', headSha: targetSha, createdAt: '2026-04-08T00:01:00Z' }),
+      ]),
+    ];
+
+    const result = await ciWaitRunHandler.execute({
+      ref: 'main',
+      expected_sha: targetSha,
+      timeout_sec: 600,
+      poll_interval_sec: 10,
+    });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    expect(data.final_status).toBe('success');
+    // Critical: the run picked must be the one for the target SHA, NOT the
+    // mismatched (and equally-recent) "previous" run.
+    expect(data.run_id).toBe(2);
+    expect(data.sha).toBe(targetSha);
+  });
+
+  // Validation: non-hex / wrong-length expected_sha is rejected at the schema.
+  test('expected_sha_validation — bad SHA format returns validation error', async () => {
+    const result = await ciWaitRunHandler.execute({
+      ref: 'main',
+      expected_sha: 'not-a-sha',
+    });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+    expect((data.error as string).toLowerCase()).toContain('expected_sha');
+  });
+
+  // GitLab path: expected_sha forwards as the `sha=` query param and only
+  // pipelines matching that SHA are considered.
+  test('expected_sha_gitlab — forwards sha to glab API and filters response', async () => {
+    const targetSha = 'f'.repeat(40);
+    execRegistry['git remote get-url origin'] = 'https://gitlab.com/org/repo.git';
+    execRegistry['glab api projects/org%2Frepo/pipelines?ref='] = JSON.stringify([
+      glabPipeline({ id: 7777, status: 'success', sha: targetSha }),
+    ]);
+
+    const result = await ciWaitRunHandler.execute({
+      ref: 'main',
+      expected_sha: targetSha,
+    });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    expect(data.final_status).toBe('success');
+    expect(data.run_id).toBe(7777);
+    expect(data.sha).toBe(targetSha);
+    // Verify the glab call carried the encoded sha=<targetSha> query param.
+    const glabCalls = execCallLog.filter((c) => c.startsWith('glab api'));
+    expect(glabCalls.length).toBeGreaterThan(0);
+    for (const c of glabCalls) {
+      expect(c).toContain(`sha=${targetSha}`);
+    }
+  });
+
   // Timeout still fires for push-triggered runs that never complete.
   // Verifies the pre-flight doesn't swallow the existing timeout path.
   test('timeout_still_fires_for_push_triggered — push run stays in_progress, times out', async () => {


### PR DESCRIPTION
## Summary

Adds an optional `expected_sha` parameter to `ci_wait_run` so callers can anchor the wait to a specific commit, eliminating false-positive matches against an older run on the same branch.

## Test Plan

- [x] `./scripts/ci/validate.sh` clean
- [x] Tests cover the new sha-anchoring path

Closes #259