### PR TITLE
feat(adapter): migrate pr_merge_wait + lib/pr_state.ts to platform adapter pattern (closes F2) (#248)

### DIFF
--- a/handlers/pr_merge.ts
+++ b/handlers/pr_merge.ts
@@ -9,7 +9,6 @@
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
 import { getAdapter } from '../lib/adapters/index.js';
-import type { PrMergeArgs, PrMergeResponse } from '../lib/adapters/types.js';
 
 const inputSchema = z.object({
   number: z.number().int().positive('number must be a positive integer'),
@@ -24,18 +23,6 @@ const inputSchema = z.object({
 
 function envelope(payload: unknown) {
   return { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] };
-}
-
-// Compat shim for pr_merge_wait (#248); removed when Story 1.11 migrates it.
-type LegacyAggregate = ({ ok: true } & PrMergeResponse) | { ok: false; error: string };
-export async function performMerge(
-  _platform: 'github' | 'gitlab',
-  args: PrMergeArgs,
-): Promise<LegacyAggregate> {
-  const result = await getAdapter({ repo: args.repo }).prMerge(args);
-  if ('platform_unsupported' in result) return { ok: false, error: `platform_unsupported: ${result.hint}` };
-  if (!result.ok) return { ok: false, error: result.error };
-  return { ok: true, ...result.data };
 }
 
 const prMergeHandler: HandlerDef = {

--- a/handlers/pr_merge_wait.ts
+++ b/handlers/pr_merge_wait.ts
@@ -1,5 +1,9 @@
-// Origin Operations family handler.
-// See docs/handlers/origin-operations-guide.md for the canonical pattern.
+// Origin Operations family handler — adapter-dispatching shell.
+// Subprocess + platform branching live in lib/adapters/pr-merge-wait-{github,gitlab}.ts;
+// the platform-agnostic polling loop lives in lib/pr-merge-wait-poll.ts so it
+// isn't duplicated per platform. See docs/handlers/origin-operations-guide.md
+// for the canonical pattern and docs/platform-adapter-retrofit-devspec.md §5
+// for the contract.
 //
 // pr_merge_wait wraps pr_merge with a "block until commit lands on main" guarantee.
 // Use this when downstream work (`git pull main`, post-merge CI checks) needs the
@@ -8,10 +12,7 @@
 
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform } from '../lib/shared/detect-platform.js';
-import { parseRepoSlug } from '../lib/shared/parse-repo-slug.js';
-import { fetchPrState, type PrStateInfo } from '../lib/pr_state.js';
-import { performMerge } from './pr_merge.js';
+import { getAdapter } from '../lib/adapters/index.js';
 
 const inputSchema = z.object({
   number: z.number().int().positive('number must be a positive integer'),
@@ -29,209 +30,8 @@ const inputSchema = z.object({
     .optional(),
 });
 
-type Input = z.infer<typeof inputSchema>;
-type Platform = 'github' | 'gitlab';
-
-const DEFAULT_TIMEOUT_SEC = 600;
-const POLL_INTERVAL_MS = 10_000;
-
-// Detect-and-skip synthesizes this aggregate when the PR is already MERGED
-// before invocation. We don't know how it was merged historically (direct vs
-// queue, this session vs earlier), so report the conservative defaults and
-// surface the situation via a warning.
-function synthesizeAlreadyMerged(num: number, info: PrStateInfo) {
-  return {
-    ok: true as const,
-    number: num,
-    enrolled: true,
-    merged: true,
-    merge_method: 'direct_squash' as const,
-    queue: { enabled: false, position: null, enforced: false },
-    pr_state: 'MERGED' as const,
-    url: info.url,
-    merge_commit_sha: info.mergeCommitSha,
-    warnings: ['PR was already merged before invocation; pr_merge was not called'],
-  };
-}
-
-export interface PollDeps {
-  fetchState: () => PrStateInfo;
-  intervalMs: number;
-  timeoutMs: number;
-  now: () => number;
-  sleep: (ms: number) => Promise<void>;
-}
-
-export interface PollSuccess {
-  ok: true;
-  state: PrStateInfo;
-  elapsedMs: number;
-}
-
-export interface PollTimeout {
-  ok: false;
-  reason: 'timeout';
-  lastState: PrStateInfo;
-  elapsedMs: number;
-}
-
-export interface PollFetchError {
-  ok: false;
-  reason: 'fetch_error';
-  error: string;
-  lastState: PrStateInfo | null;
-  elapsedMs: number;
-}
-
-// Pure poller — no module-level globals, no platform knowledge. Loops:
-// fetch → return on merged → check timeout → sleep. The sleep happens AFTER
-// the timeout check, so if the budget is already spent we don't waste another
-// interval before reporting it. Injectable now/sleep makes tests instant.
-//
-// fetchState exceptions are caught and reported as a `fetch_error` variant so
-// the caller can preserve the "PR was already enrolled" context — distinct
-// from a clean timeout. Without this distinction, a transient `gh` failure
-// mid-poll would surface as a generic outer-catch error and the caller would
-// have no idea whether the merge itself failed or just the polling did.
-export async function pollUntilMerged(
-  deps: PollDeps,
-): Promise<PollSuccess | PollTimeout | PollFetchError> {
-  const start = deps.now();
-  let lastState: PrStateInfo | null = null;
-  while (true) {
-    let info: PrStateInfo;
-    try {
-      info = deps.fetchState();
-    } catch (err) {
-      return {
-        ok: false,
-        reason: 'fetch_error',
-        error: err instanceof Error ? err.message : String(err),
-        lastState,
-        elapsedMs: deps.now() - start,
-      };
-    }
-    lastState = info;
-    const elapsedMs = deps.now() - start;
-    if (info.state === 'merged') {
-      return { ok: true, state: info, elapsedMs };
-    }
-    if (elapsedMs >= deps.timeoutMs) {
-      return { ok: false, reason: 'timeout', lastState: info, elapsedMs };
-    }
-    await deps.sleep(deps.intervalMs);
-  }
-}
-
-function defaultSleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-interface MergeAggregate {
-  ok: true;
-  number: number;
-  enrolled: boolean;
-  merged: boolean;
-  merge_method: 'direct_squash' | 'merge_queue';
-  queue: { enabled: boolean; position: number | null; enforced: boolean };
-  pr_state: 'OPEN' | 'MERGED';
-  url: string;
-  merge_commit_sha?: string;
-  warnings: string[];
-}
-
-interface MergeFailure {
-  ok: false;
-  error: string;
-}
-
-function isFailure(r: MergeAggregate | MergeFailure): r is MergeFailure {
-  return r.ok === false;
-}
-
-async function executeWait(
-  args: Input,
-  platform: Platform,
-  pollOverrides?: Partial<Pick<PollDeps, 'now' | 'sleep' | 'intervalMs'>>,
-): Promise<MergeAggregate | MergeFailure> {
-  const slug = args.repo ?? parseRepoSlug() ?? undefined;
-  const timeoutMs = (args.timeout_sec ?? DEFAULT_TIMEOUT_SEC) * 1000;
-
-  // Detect-and-skip: if the PR is already MERGED, return immediately. Saves a
-  // pointless `gh pr merge` call (which would error "already merged") and a
-  // full polling cycle.
-  let preState: PrStateInfo;
-  try {
-    preState = fetchPrState(platform, args.number, slug);
-  } catch (err) {
-    return {
-      ok: false,
-      error: `pr_merge_wait failed to read initial PR state: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    };
-  }
-  if (preState.state === 'merged') {
-    return synthesizeAlreadyMerged(args.number, preState);
-  }
-
-  const mergeResult = (await performMerge(platform, args)) as MergeAggregate | MergeFailure;
-  if (isFailure(mergeResult)) return mergeResult;
-  if (mergeResult.merged) {
-    // Direct path — already on main. No need to poll.
-    return mergeResult;
-  }
-
-  // Queue path: enrolled but not yet on main. Poll until merged or timeout.
-  const poll = await pollUntilMerged({
-    fetchState: () => fetchPrState(platform, args.number, slug),
-    intervalMs: pollOverrides?.intervalMs ?? POLL_INTERVAL_MS,
-    timeoutMs,
-    now: pollOverrides?.now ?? Date.now,
-    sleep: pollOverrides?.sleep ?? defaultSleep,
-  });
-
-  if (!poll.ok) {
-    if (poll.reason === 'fetch_error') {
-      // Critical context: the PR was successfully enrolled — only the polling
-      // loop failed. Caller can retry the wait without re-enrolling.
-      const lastSnippet = poll.lastState
-        ? `last_state: ${poll.lastState.state.toUpperCase()}`
-        : 'no successful poll before failure';
-      return {
-        ok: false,
-        error:
-          `pr_merge_wait polling failed for PR #${args.number} after enrollment ` +
-          `(${lastSnippet}, queue.enforced: ${mergeResult.queue.enforced}): ${poll.error}`,
-      };
-    }
-    return {
-      ok: false,
-      error:
-        `pr_merge_wait timed out after ${args.timeout_sec ?? DEFAULT_TIMEOUT_SEC}s ` +
-        `waiting for PR #${args.number} to land on main ` +
-        `(last_state: ${poll.lastState.state.toUpperCase()}, ` +
-        `queue.enforced: ${mergeResult.queue.enforced})`,
-    };
-  }
-
-  return {
-    ...mergeResult,
-    merged: true,
-    pr_state: 'MERGED',
-    url: poll.state.url || mergeResult.url,
-    merge_commit_sha: poll.state.mergeCommitSha ?? mergeResult.merge_commit_sha,
-  };
-}
-
-// Exposed for tests so they can inject fake clock + sleep without requiring
-// real wall-clock time. Production callers go through the handler.
-export async function executeWaitForTest(
-  args: Input,
-  platform: Platform,
-  overrides: Partial<Pick<PollDeps, 'now' | 'sleep' | 'intervalMs'>>,
-): Promise<MergeAggregate | MergeFailure> {
-  return executeWait(args, platform, overrides);
+function envelope(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] };
 }
 
 const prMergeWaitHandler: HandlerDef = {
@@ -245,28 +45,19 @@ const prMergeWaitHandler: HandlerDef = {
     'enrollment is enough.',
   inputSchema,
   async execute(rawArgs: unknown) {
-    let args: Input;
+    let args;
     try {
       args = inputSchema.parse(rawArgs);
     } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
 
-    try {
-      const platform = detectPlatform();
-      const result = await executeWait(args, platform);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-      };
-    } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+    const result = await getAdapter({ repo: args.repo }).prMergeWait(args);
+    if ('platform_unsupported' in result) {
+      return envelope({ ok: true, platform_unsupported: true, hint: result.hint });
     }
+    if (!result.ok) return envelope({ ok: false, error: result.error });
+    return envelope({ ok: true, ...result.data });
   },
 };
 

--- a/lib/adapters/fetch-pr-state-github.test.ts
+++ b/lib/adapters/fetch-pr-state-github.test.ts
@@ -1,0 +1,149 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { AdapterResult, PrStateInfo } from './types.ts';
+
+// Subprocess-boundary tests for the GitHub fetchPrState adapter (Story 1.11,
+// hybrid sub-call). Mirrors the pattern used by every adapter test file:
+// install own mock.module BEFORE the dynamic import (56-file convention).
+
+function expectOk(
+  r: AdapterResult<PrStateInfo>,
+): asserts r is { ok: true; data: PrStateInfo } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectErr(
+  r: AdapterResult<PrStateInfo>,
+): asserts r is { ok: false; error: string; code: string } {
+  if (!('ok' in r) || r.ok) {
+    throw new Error(`expected error result, got ${JSON.stringify(r)}`);
+  }
+}
+
+let execCalls: string[] = [];
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string) => {
+  execCalls.push(cmd);
+  return execMockFn(cmd);
+});
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { fetchPrStateGithub, fetchPrStateGithubSync } = await import(
+  './fetch-pr-state-github.ts'
+);
+
+beforeEach(() => {
+  execCalls = [];
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+});
+
+describe('fetchPrStateGithubSync — subprocess boundary', () => {
+  test('parses MERGED state with merge commit sha', () => {
+    execMockFn = () =>
+      JSON.stringify({
+        state: 'MERGED',
+        url: 'https://github.com/org/repo/pull/42',
+        mergeCommit: { oid: 'deadbeef' },
+      });
+    const info = fetchPrStateGithubSync(42);
+    expect(info.state).toBe('merged');
+    expect(info.url).toBe('https://github.com/org/repo/pull/42');
+    expect(info.mergeCommitSha).toBe('deadbeef');
+  });
+
+  test('parses OPEN state with no merge commit', () => {
+    execMockFn = () =>
+      JSON.stringify({
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/42',
+        mergeCommit: null,
+      });
+    const info = fetchPrStateGithubSync(42);
+    expect(info.state).toBe('open');
+    expect(info.mergeCommitSha).toBeUndefined();
+  });
+
+  test('parses CLOSED state', () => {
+    execMockFn = () =>
+      JSON.stringify({
+        state: 'CLOSED',
+        url: 'https://github.com/org/repo/pull/42',
+        mergeCommit: null,
+      });
+    const info = fetchPrStateGithubSync(42);
+    expect(info.state).toBe('closed');
+  });
+
+  test('passes --repo when supplied', () => {
+    execMockFn = () =>
+      JSON.stringify({ state: 'OPEN', url: '', mergeCommit: null });
+    fetchPrStateGithubSync(42, 'org/other-repo');
+    expect(execCalls[0]).toContain('--repo org/other-repo');
+  });
+
+  test('omits --repo when not supplied (uses cwd)', () => {
+    execMockFn = () =>
+      JSON.stringify({ state: 'OPEN', url: '', mergeCommit: null });
+    fetchPrStateGithubSync(42);
+    expect(execCalls[0]).not.toContain('--repo');
+  });
+
+  test('unknown state defaults to open', () => {
+    execMockFn = () =>
+      JSON.stringify({ state: 'WEIRD', url: '', mergeCommit: null });
+    expect(fetchPrStateGithubSync(42).state).toBe('open');
+  });
+
+  test('rejects malicious repo slug at adapter boundary (no exec)', () => {
+    expect(() => fetchPrStateGithubSync(42, 'org/repo; rm -rf /')).toThrow(
+      /invalid repo slug/,
+    );
+    expect(execCalls.length).toBe(0);
+  });
+
+  test('rejects repo slug with shell metacharacter (no exec)', () => {
+    expect(() => fetchPrStateGithubSync(42, 'org/repo`whoami`')).toThrow(
+      /invalid repo slug/,
+    );
+    expect(execCalls.length).toBe(0);
+  });
+
+  test('rejects repo with no slash (no exec)', () => {
+    expect(() => fetchPrStateGithubSync(42, 'just-a-name')).toThrow(/invalid repo slug/);
+    expect(execCalls.length).toBe(0);
+  });
+});
+
+describe('fetchPrStateGithub — AdapterResult wrapper', () => {
+  test('returns ok:true wrapping PrStateInfo on success', async () => {
+    execMockFn = () =>
+      JSON.stringify({
+        state: 'MERGED',
+        url: 'https://github.com/org/repo/pull/1',
+        mergeCommit: { oid: 'abc' },
+      });
+    const result = await fetchPrStateGithub({ number: 1 });
+    expectOk(result);
+    expect(result.data.state).toBe('merged');
+    expect(result.data.mergeCommitSha).toBe('abc');
+  });
+
+  test('returns ok:false with code on subprocess failure', async () => {
+    execMockFn = () => {
+      throw new Error('gh: PR not found');
+    };
+    const result = await fetchPrStateGithub({ number: 999 });
+    expectErr(result);
+    expect(result.code).toBe('gh_pr_view_failed');
+    expect(result.error).toContain('PR not found');
+  });
+
+  test('returns ok:false on invalid repo slug (no exec)', async () => {
+    const result = await fetchPrStateGithub({ number: 1, repo: 'bad; rm' });
+    expectErr(result);
+    expect(result.error).toMatch(/invalid repo slug/);
+    expect(execCalls.length).toBe(0);
+  });
+});

--- a/lib/adapters/fetch-pr-state-github.ts
+++ b/lib/adapters/fetch-pr-state-github.ts
@@ -1,0 +1,86 @@
+/**
+ * GitHub `fetchPrState` adapter implementation — the FIRST hybrid sub-call
+ * lifted into the platform-adapter pair (Story 1.11, #248).
+ *
+ * Lifted from `lib/pr_state.ts`'s `fetchGithubPrState`. Returns only what the
+ * merge flow needs (state, url, sha) — intentionally narrower than `prStatus`,
+ * which fetches checks + mergeability separately. Consumed by:
+ *   - `prMergeWait` for "block until merged" polling
+ *   - `prMerge` (both platforms) for post-merge URL/sha lookup + the #258 fix
+ *     (read actual state after gh exit-0 instead of trusting that gh==merged)
+ *
+ * Per Dev Spec §5.5, hybrid sub-calls live on `PlatformAdapter` and are
+ * routed through `getAdapter()` like any other method — there is no separate
+ * "hybrid" registry. The adapter contract test in `types.test.ts` enforces
+ * presence on both platforms.
+ */
+
+import { execSync } from 'child_process';
+import type {
+  AdapterResult,
+  FetchPrStateArgs,
+  PrState,
+  PrStateInfo,
+} from './types.js';
+
+interface GithubPrViewResponse {
+  state?: string;
+  url?: string;
+  mergeCommit?: { oid?: string } | null;
+}
+
+// Same charset as merge_queue_detect.ts and wave_previous_merged.ts — GitHub's
+// owner/repo grammar. Defended at the adapter boundary so any caller (handler,
+// peer adapter) gets the same protection without having to remember to
+// validate themselves.
+const GITHUB_REPO_SLUG = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
+function repoFlag(repo: string | undefined): string {
+  if (repo === undefined) return '';
+  if (!GITHUB_REPO_SLUG.test(repo)) {
+    throw new Error(`fetchPrStateGithub: invalid repo slug ${JSON.stringify(repo)}`);
+  }
+  return ` --repo ${repo}`;
+}
+
+function normalizeGithubState(raw: string): PrState {
+  const upper = raw.toUpperCase();
+  if (upper === 'MERGED') return 'merged';
+  if (upper === 'CLOSED') return 'closed';
+  return 'open';
+}
+
+export function fetchPrStateGithubSync(num: number, repo?: string): PrStateInfo {
+  const raw = execSync(
+    `gh pr view ${num} --json state,url,mergeCommit${repoFlag(repo)}`,
+    { encoding: 'utf8' },
+  );
+  const parsed = JSON.parse(raw) as GithubPrViewResponse;
+  return {
+    state: normalizeGithubState(parsed.state ?? ''),
+    url: parsed.url ?? '',
+    mergeCommitSha: parsed.mergeCommit?.oid,
+  };
+}
+
+export async function fetchPrStateGithub(
+  args: FetchPrStateArgs,
+): Promise<AdapterResult<PrStateInfo>> {
+  // Bound any exception (subprocess failure, JSON parse error, slug validation)
+  // into a typed result — adapter callers must not have to try/catch.
+  try {
+    const info = fetchPrStateGithubSync(args.number, args.repo);
+    return { ok: true, data: info };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'gh_pr_view_failed',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// `execSync` is intentionally re-imported above so that adapter-level test
+// files can `mock.module('child_process', ...)` and intercept this module's
+// subprocess calls.
+void execSync;

--- a/lib/adapters/fetch-pr-state-gitlab.test.ts
+++ b/lib/adapters/fetch-pr-state-gitlab.test.ts
@@ -1,0 +1,107 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { AdapterResult, PrStateInfo } from './types.ts';
+
+// Subprocess-boundary tests for the GitLab fetchPrState adapter (Story 1.11,
+// hybrid sub-call). Each test file installs its OWN mock.module BEFORE the
+// dynamic import (56-file convention).
+
+function expectOk(
+  r: AdapterResult<PrStateInfo>,
+): asserts r is { ok: true; data: PrStateInfo } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectErr(
+  r: AdapterResult<PrStateInfo>,
+): asserts r is { ok: false; error: string; code: string } {
+  if (!('ok' in r) || r.ok) {
+    throw new Error(`expected error result, got ${JSON.stringify(r)}`);
+  }
+}
+
+let execCalls: string[] = [];
+let execMockFn: (cmd: string) => string = () => '';
+const mockExecSync = mock((cmd: string) => {
+  execCalls.push(cmd);
+  return execMockFn(cmd);
+});
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { fetchPrStateGitlab, fetchPrStateGitlabSync } = await import(
+  './fetch-pr-state-gitlab.ts'
+);
+
+beforeEach(() => {
+  execCalls = [];
+  execMockFn = () => '';
+  mockExecSync.mockClear();
+});
+
+describe('fetchPrStateGitlabSync — subprocess boundary', () => {
+  test('parses merged state via glab api', () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.includes('git remote get-url')) {
+        return 'https://gitlab.com/org/repo.git\n';
+      }
+      return JSON.stringify({
+        state: 'merged',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/7',
+        merge_commit_sha: 'cafebabe',
+      });
+    };
+    const info = fetchPrStateGitlabSync(7);
+    expect(info.state).toBe('merged');
+    expect(info.url).toBe('https://gitlab.com/org/repo/-/merge_requests/7');
+    expect(info.mergeCommitSha).toBe('cafebabe');
+  });
+
+  test('parses opened state', () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.includes('git remote get-url')) {
+        return 'https://gitlab.com/org/repo.git\n';
+      }
+      return JSON.stringify({
+        state: 'opened',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/7',
+      });
+    };
+    const info = fetchPrStateGitlabSync(7);
+    expect(info.state).toBe('open');
+    expect(info.mergeCommitSha).toBeUndefined();
+  });
+
+  test('uses explicit owner/repo when provided', () => {
+    execMockFn = () =>
+      JSON.stringify({ state: 'opened', web_url: '' });
+    fetchPrStateGitlabSync(11, 'foo/bar');
+    const apiCall = execCalls.find((c) => c.includes('glab api')) ?? '';
+    expect(apiCall).toContain('foo%2Fbar');
+  });
+});
+
+describe('fetchPrStateGitlab — AdapterResult wrapper', () => {
+  test('returns ok:true wrapping PrStateInfo on success', async () => {
+    execMockFn = () =>
+      JSON.stringify({
+        state: 'merged',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/1',
+        merge_commit_sha: 'abc',
+      });
+    const result = await fetchPrStateGitlab({ number: 1, repo: 'org/repo' });
+    expectOk(result);
+    expect(result.data.state).toBe('merged');
+    expect(result.data.mergeCommitSha).toBe('abc');
+  });
+
+  test('returns ok:false with code on subprocess failure', async () => {
+    execMockFn = () => {
+      throw new Error('glab: 404 not found');
+    };
+    const result = await fetchPrStateGitlab({ number: 999, repo: 'org/repo' });
+    expectErr(result);
+    expect(result.code).toBe('glab_api_mr_failed');
+    expect(result.error).toContain('not found');
+  });
+});

--- a/lib/adapters/fetch-pr-state-gitlab.ts
+++ b/lib/adapters/fetch-pr-state-gitlab.ts
@@ -1,0 +1,63 @@
+/**
+ * GitLab `fetchPrState` adapter implementation — the GitLab half of the FIRST
+ * hybrid sub-call (Story 1.11, #248).
+ *
+ * Lifted from `lib/pr_state.ts`'s `fetchGitlabMrState`. Returns only what the
+ * merge flow needs (state, url, sha). Consumed by:
+ *   - `prMergeWait` for "block until merged" polling
+ *   - `prMerge` (both platforms) for post-merge URL/sha lookup
+ *
+ * Uses the typed `gitlabApiMr` wrapper from `lib/glab.ts` rather than calling
+ * `execSync('glab api ...')` directly — same pattern as `prMergeGitlab` and
+ * the rest of the GitLab adapter family.
+ */
+
+import { gitlabApiMr } from '../glab.js';
+import type {
+  AdapterResult,
+  FetchPrStateArgs,
+  PrState,
+  PrStateInfo,
+} from './types.js';
+
+function parseSlugOpts(
+  slug: string | undefined,
+): { owner?: string; repo?: string } | undefined {
+  if (slug === undefined) return undefined;
+  const idx = slug.indexOf('/');
+  if (idx <= 0 || idx === slug.length - 1) return undefined;
+  return { owner: slug.slice(0, idx), repo: slug.slice(idx + 1) };
+}
+
+function normalizeGitlabState(raw: string): PrState {
+  const lower = raw.toLowerCase();
+  if (lower === 'merged') return 'merged';
+  if (lower === 'closed') return 'closed';
+  return 'open';
+}
+
+export function fetchPrStateGitlabSync(num: number, repo?: string): PrStateInfo {
+  const mr = gitlabApiMr(num, parseSlugOpts(repo));
+  return {
+    state: normalizeGitlabState(mr.state ?? ''),
+    url: mr.web_url ?? '',
+    mergeCommitSha: mr.merge_commit_sha ?? undefined,
+  };
+}
+
+export async function fetchPrStateGitlab(
+  args: FetchPrStateArgs,
+): Promise<AdapterResult<PrStateInfo>> {
+  // Bound any exception (subprocess failure, JSON parse error) into a typed
+  // result — adapter callers must not have to try/catch.
+  try {
+    const info = fetchPrStateGitlabSync(args.number, args.repo);
+    return { ok: true, data: info };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'glab_api_mr_failed',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/lib/adapters/github.ts
+++ b/lib/adapters/github.ts
@@ -14,12 +14,14 @@
  */
 
 import type { PlatformAdapter } from './types.js';
+import { fetchPrStateGithub } from './fetch-pr-state-github.js';
 import { prCommentGithub } from './pr-comment-github.js';
 import { prCreateGithub } from './pr-create-github.js';
 import { prDiffGithub } from './pr-diff-github.js';
 import { prFilesGithub } from './pr-files-github.js';
 import { prListGithub } from './pr-list-github.js';
 import { prMergeGithub } from './pr-merge-github.js';
+import { prMergeWaitGithub } from './pr-merge-wait-github.js';
 import { prStatusGithub } from './pr-status-github.js';
 import { prWaitCiGithub } from './pr-wait-ci-github.js';
 
@@ -31,7 +33,7 @@ const stubMethod = async (_args: unknown) => ({
 export const githubAdapter: PlatformAdapter = {
   prCreate: prCreateGithub,
   prMerge: prMergeGithub,
-  prMergeWait: stubMethod,
+  prMergeWait: prMergeWaitGithub,
   prStatus: prStatusGithub,
   prDiff: prDiffGithub,
   prComment: prCommentGithub,
@@ -53,4 +55,5 @@ export const githubAdapter: PlatformAdapter = {
   specAcceptanceCriteria: stubMethod,
   specDependencies: stubMethod,
   fetchIssue: stubMethod,
+  fetchPrState: fetchPrStateGithub,
 };

--- a/lib/adapters/gitlab.ts
+++ b/lib/adapters/gitlab.ts
@@ -15,12 +15,14 @@
  */
 
 import type { PlatformAdapter } from './types.js';
+import { fetchPrStateGitlab } from './fetch-pr-state-gitlab.js';
 import { prCommentGitlab } from './pr-comment-gitlab.js';
 import { prCreateGitlab } from './pr-create-gitlab.js';
 import { prDiffGitlab } from './pr-diff-gitlab.js';
 import { prFilesGitlab } from './pr-files-gitlab.js';
 import { prListGitlab } from './pr-list-gitlab.js';
 import { prMergeGitlab } from './pr-merge-gitlab.js';
+import { prMergeWaitGitlab } from './pr-merge-wait-gitlab.js';
 import { prStatusGitlab } from './pr-status-gitlab.js';
 import { prWaitCiGitlab } from './pr-wait-ci-gitlab.js';
 
@@ -32,7 +34,7 @@ const stubMethod = async (_args: unknown) => ({
 export const gitlabAdapter: PlatformAdapter = {
   prCreate: prCreateGitlab,
   prMerge: prMergeGitlab,
-  prMergeWait: stubMethod,
+  prMergeWait: prMergeWaitGitlab,
   prStatus: prStatusGitlab,
   prDiff: prDiffGitlab,
   prComment: prCommentGitlab,
@@ -54,4 +56,5 @@ export const gitlabAdapter: PlatformAdapter = {
   specAcceptanceCriteria: stubMethod,
   specDependencies: stubMethod,
   fetchIssue: stubMethod,
+  fetchPrState: fetchPrStateGitlab,
 };

--- a/lib/adapters/pr-merge-github.ts
+++ b/lib/adapters/pr-merge-github.ts
@@ -7,25 +7,28 @@
  *
  * Preserves the #225 aggregate envelope shape — `{enrolled, merged,
  * merge_method, queue, pr_state, url, merge_commit_sha?, warnings}` — and the
- * #263 fix for honest merged-state reporting (read actual state via
- * `fetchGithubPrState` after gh exit-0 instead of trusting that gh==merged).
+ * #263 fix for honest merged-state reporting (read actual state via the
+ * `fetchPrState` adapter after gh exit-0 instead of trusting that gh==merged).
  *
- * The merge-queue detect helper (`detectMergeQueue`) and PR state fetcher
- * (`fetchGithubPrState`) stay where they are per Dev Spec §5.3 — this adapter
- * imports from them, it does NOT re-lift them.
+ * Story 1.11 (#248) routes `PR state` lookups through
+ * `getAdapter().fetchPrState(...)` — the FIRST hybrid sub-call dispatched
+ * via the platform adapter — instead of importing `lib/pr_state.ts` directly.
+ * The merge-queue detect helper (`detectMergeQueue`) stays as a `lib/` import
+ * (still GitHub-only).
  */
 
 import { execSync } from 'child_process';
 import { writeFileSync } from 'fs';
 import { detectMergeQueue, type MergeQueueInfo } from '../merge_queue_detect.js';
-import { fetchGithubPrState } from '../pr_state.js';
 import { parseRepoSlug } from '../shared/parse-repo-slug.js';
+import { getAdapter } from './index.js';
 import type {
   AdapterResult,
   PrMergeArgs,
   PrMergeResponse,
   PrMergeQueueState,
   PrMergeMethod,
+  PrStateInfo,
 } from './types.js';
 
 interface ExecError extends Error {
@@ -186,11 +189,27 @@ function decideIntent(
   return { useQueue: false, warnings };
 }
 
-function mergeGithubViaQueue(
+// Read PR state through the routed adapter (Story 1.11 hybrid sub-call). The
+// helper unwraps `AdapterResult<PrStateInfo>` into `PrStateInfo` and throws on
+// failure so the existing try/catch wrapper in `prMergeGithub` can surface it
+// as a typed `unexpected_error`.
+async function fetchPrStateRouted(
+  number: number,
+  repo: string | undefined,
+): Promise<PrStateInfo> {
+  const result = await getAdapter({ repo }).fetchPrState({ number, repo });
+  if ('platform_unsupported' in result) {
+    throw new Error(`fetchPrState platform_unsupported: ${result.hint}`);
+  }
+  if (!result.ok) throw new Error(result.error);
+  return result.data;
+}
+
+async function mergeGithubViaQueue(
   args: PrMergeArgs,
   queue: PrMergeQueueState,
   warnings: string[],
-): AdapterResult<PrMergeResponse> {
+): Promise<AdapterResult<PrMergeResponse>> {
   const cmd = buildGithubMergeCommand(args.number, true, args.squash_message, args.repo);
   try {
     exec(cmd);
@@ -204,7 +223,7 @@ function mergeGithubViaQueue(
   // Queue enrollment is eager: gh returns immediately, the PR remains OPEN
   // until the queue rebases + reruns CI + lands. Honest reporting per #225:
   // enrolled but not yet merged.
-  const info = fetchGithubPrState(args.number, args.repo);
+  const info = await fetchPrStateRouted(args.number, args.repo);
   return {
     ok: true,
     data: aggregateOk({
@@ -220,11 +239,11 @@ function mergeGithubViaQueue(
   };
 }
 
-function mergeGithubDirect(
+async function mergeGithubDirect(
   args: PrMergeArgs,
   queue: PrMergeQueueState,
   warnings: string[],
-): AdapterResult<PrMergeResponse> {
+): Promise<AdapterResult<PrMergeResponse>> {
   const directCmd = buildGithubMergeCommand(
     args.number,
     false,
@@ -238,7 +257,7 @@ function mergeGithubDirect(
     // than merged it synchronously. Read the actual state and report honestly
     // so callers (especially pr_merge_wait) don't trust a stale "merged:true".
     // See #258 for the regression history.
-    const info = fetchGithubPrState(args.number, args.repo);
+    const info = await fetchPrStateRouted(args.number, args.repo);
     const actuallyMerged = info.state === 'merged';
     return {
       ok: true,
@@ -288,7 +307,7 @@ function mergeGithubDirect(
       error: `gh pr merge --auto failed after merge-queue fallback: ${extractFailure(err).message}`,
     };
   }
-  const info = fetchGithubPrState(args.number, args.repo);
+  const info = await fetchPrStateRouted(args.number, args.repo);
   return {
     ok: true,
     data: aggregateOk({
@@ -316,8 +335,8 @@ export async function prMergeGithub(
     const intent = decideIntent(args, mqInfo);
 
     return intent.useQueue
-      ? mergeGithubViaQueue(args, queue, intent.warnings)
-      : mergeGithubDirect(args, queue, intent.warnings);
+      ? await mergeGithubViaQueue(args, queue, intent.warnings)
+      : await mergeGithubDirect(args, queue, intent.warnings);
   } catch (err) {
     return {
       ok: false,

--- a/lib/adapters/pr-merge-gitlab.test.ts
+++ b/lib/adapters/pr-merge-gitlab.test.ts
@@ -76,6 +76,11 @@ function findCall(needle: string): string {
 beforeEach(() => {
   execRegistry = [];
   execCalls = [];
+  // Story 1.11 routes prMergeGitlab's post-merge state lookup through
+  // getAdapter().fetchPrState(...) — which calls detectPlatform(). Stub the
+  // cwd-remote so detection picks GitLab and the routed call lands on
+  // fetchPrStateGitlab (matching this adapter's intent).
+  on('git remote get-url origin', 'https://gitlab.com/org/repo.git\n');
 });
 
 describe('prMergeGitlab — subprocess boundary', () => {

--- a/lib/adapters/pr-merge-gitlab.ts
+++ b/lib/adapters/pr-merge-gitlab.ts
@@ -14,16 +14,18 @@
  * signal closes that leak so MCP callers can branch on the discriminator
  * instead of being lied to.
  *
- * The PR state fetcher (`fetchGitlabMrState`) stays in `lib/pr_state.ts` per
- * Dev Spec §5.3 — this adapter imports from it, it does NOT re-lift it.
+ * Story 1.11 (#248) routes the post-merge state lookup through
+ * `getAdapter().fetchPrState(...)` — the FIRST hybrid sub-call dispatched
+ * via the platform adapter — instead of importing `lib/pr_state.ts` directly.
  */
 
 import { execSync } from 'child_process';
-import { fetchGitlabMrState } from '../pr_state.js';
+import { getAdapter } from './index.js';
 import type {
   AdapterResult,
   PrMergeArgs,
   PrMergeResponse,
+  PrStateInfo,
 } from './types.js';
 
 interface ExecError extends Error {
@@ -112,7 +114,21 @@ export async function prMergeGitlab(
         error: `glab mr merge failed: ${extractFailure(err).message}`,
       };
     }
-    const info = fetchGitlabMrState(args.number, args.repo);
+    const stateResult = await getAdapter({ repo: args.repo }).fetchPrState({
+      number: args.number,
+      repo: args.repo,
+    });
+    if ('platform_unsupported' in stateResult) {
+      return {
+        ok: false,
+        code: 'fetch_pr_state_platform_unsupported',
+        error: `fetchPrState platform_unsupported: ${stateResult.hint}`,
+      };
+    }
+    if (!stateResult.ok) {
+      return { ok: false, code: stateResult.code, error: stateResult.error };
+    }
+    const info: PrStateInfo = stateResult.data;
     return {
       ok: true,
       data: {

--- a/lib/adapters/pr-merge-wait-github.test.ts
+++ b/lib/adapters/pr-merge-wait-github.test.ts
@@ -1,0 +1,322 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+import type { AdapterResult, PrMergeWaitResponse } from './types.ts';
+
+// Subprocess-boundary tests for the GitHub pr_merge_wait adapter (R-15).
+// Lifted from tests/pr_merge_wait.test.ts during Story 1.11 (#248). The
+// adapter orchestrates: detect-and-skip via fetchPrState, dispatch to
+// prMerge, and poll-until-merged on the queue path. Subprocess interception
+// happens via mock.module('child_process', ...) — every test installs its OWN
+// mock BEFORE the dynamic import (56-file convention; see
+// `.claude/projects/.../memory/MEMORY.md` "Bun mock.module pollution").
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+type Responder = string | (() => string);
+
+let execRegistry: Array<{ match: string; respond: Responder }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { executeMergeWaitForTest } = await import('./pr-merge-wait-github.ts');
+const { clearMergeQueueCache } = await import('../merge_queue_detect.ts');
+
+function on(match: string, respond: Responder) {
+  execRegistry.push({ match, respond });
+}
+
+function stubNoQueue() {
+  on(
+    'gh api graphql',
+    JSON.stringify({ data: { repository: { mergeQueue: null } } }),
+  );
+}
+
+function stubEnforcedQueue() {
+  on(
+    'gh api graphql',
+    JSON.stringify({ data: { repository: { mergeQueue: { __typename: 'MergeQueue' } } } }),
+  );
+}
+
+function fakeClock(startMs: number = 0) {
+  let nowMs = startMs;
+  let sleepCount = 0;
+  return {
+    now: () => nowMs,
+    sleep: async (ms: number) => {
+      nowMs += ms;
+      sleepCount += 1;
+    },
+    sleepCount: () => sleepCount,
+  };
+}
+
+function expectOk(
+  r: AdapterResult<PrMergeWaitResponse>,
+): asserts r is { ok: true; data: PrMergeWaitResponse } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectErr(
+  r: AdapterResult<PrMergeWaitResponse>,
+): asserts r is { ok: false; error: string; code: string } {
+  if (!('ok' in r) || r.ok) {
+    throw new Error(`expected error result, got ${JSON.stringify(r)}`);
+  }
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+  clearMergeQueueCache();
+  // Default cwd remote — GitHub origin so detectPlatform() picks github.
+  on('git remote get-url origin', 'https://github.com/org/repo.git\n');
+});
+
+afterEach(() => {
+  execRegistry = [];
+  execCalls = [];
+  clearMergeQueueCache();
+});
+
+describe('prMergeWaitGithub — adapter orchestration', () => {
+  test('detect-and-skip: PR already merged → no merge call, warning emitted', async () => {
+    on(
+      'gh pr view 50 --json state,url,mergeCommit',
+      JSON.stringify({
+        state: 'MERGED',
+        url: 'https://github.com/org/repo/pull/50',
+        mergeCommit: { oid: 'preexisting' },
+      }),
+    );
+
+    const result = await executeMergeWaitForTest(
+      { number: 50 },
+      { now: () => 0, sleep: async () => {}, intervalMs: 10000 },
+    );
+
+    expectOk(result);
+    expect(result.data.merged).toBe(true);
+    expect(result.data.pr_state).toBe('MERGED');
+    expect(result.data.merge_commit_sha).toBe('preexisting');
+    expect(result.data.warnings.length).toBe(1);
+    expect(result.data.warnings[0]).toContain('already merged');
+    expect(execCalls.find((c) => c.includes('gh pr merge'))).toBeUndefined();
+  });
+
+  test('direct merge path → returns synchronously, no polling', async () => {
+    stubNoQueue();
+    let viewCalls = 0;
+    on('gh pr view 51 --json state,url,mergeCommit', () => {
+      viewCalls += 1;
+      const merged = viewCalls >= 2;
+      return JSON.stringify({
+        state: merged ? 'MERGED' : 'OPEN',
+        url: 'https://github.com/org/repo/pull/51',
+        mergeCommit: merged ? { oid: 'direct51' } : null,
+      });
+    });
+    on('gh pr merge 51 --squash --delete-branch', '');
+
+    const clock = fakeClock();
+    const result = await executeMergeWaitForTest(
+      { number: 51 },
+      { now: clock.now, sleep: clock.sleep, intervalMs: 1 },
+    );
+
+    expectOk(result);
+    expect(result.data.merged).toBe(true);
+    expect(result.data.merge_method).toBe('direct_squash');
+    expect(result.data.merge_commit_sha).toBe('direct51');
+    expect(clock.sleepCount()).toBe(0);
+  });
+
+  // Regression #258 Bug 2: pr_merge_wait must NOT trust pr_merge's merged:true
+  // when the underlying gh pr merge actually only enrolled. Pre-fix the handler
+  // short-circuited at the direct path and reported merged:true; post-fix
+  // pr_merge reports merged:false and pr_merge_wait polls until landing.
+  test('regression #258: direct path returns merged:false → polls until landing', async () => {
+    stubNoQueue();
+    let viewCallCount = 0;
+    on('gh pr view 257 --json state,url,mergeCommit', () => {
+      viewCallCount += 1;
+      if (viewCallCount >= 5) {
+        return JSON.stringify({
+          state: 'MERGED',
+          url: 'https://github.com/org/repo/pull/257',
+          mergeCommit: { oid: 'eventually-merged' },
+        });
+      }
+      return JSON.stringify({
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/257',
+        mergeCommit: null,
+      });
+    });
+    on('gh pr merge 257 --squash --delete-branch', '');
+
+    const clock = fakeClock();
+    const result = await executeMergeWaitForTest(
+      { number: 257 },
+      { now: clock.now, sleep: clock.sleep, intervalMs: 1000 },
+    );
+
+    expectOk(result);
+    expect(result.data.merged).toBe(true);
+    expect(result.data.pr_state).toBe('MERGED');
+    expect(result.data.merge_commit_sha).toBe('eventually-merged');
+    expect(clock.sleepCount()).toBeGreaterThan(0);
+  });
+
+  test('queue path → polls until state flips to merged', async () => {
+    stubEnforcedQueue();
+    let viewCallCount = 0;
+    on('gh pr view 60 --json state,url,mergeCommit', () => {
+      viewCallCount += 1;
+      if (viewCallCount >= 5) {
+        return JSON.stringify({
+          state: 'MERGED',
+          url: 'https://github.com/org/repo/pull/60',
+          mergeCommit: { oid: 'queued-sha' },
+        });
+      }
+      return JSON.stringify({
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/60',
+        mergeCommit: null,
+      });
+    });
+    on('gh pr merge 60 --squash --delete-branch --auto', '');
+
+    const clock = fakeClock();
+    const result = await executeMergeWaitForTest(
+      { number: 60 },
+      { now: clock.now, sleep: clock.sleep, intervalMs: 1000 },
+    );
+
+    expectOk(result);
+    expect(result.data.merged).toBe(true);
+    expect(result.data.pr_state).toBe('MERGED');
+    expect(result.data.merge_method).toBe('merge_queue');
+    expect(result.data.merge_commit_sha).toBe('queued-sha');
+    expect(clock.sleepCount()).toBeGreaterThan(0);
+  });
+
+  test('queue path → timeout returns ok:false with descriptive error', async () => {
+    stubEnforcedQueue();
+    on(
+      'gh pr view 70 --json state,url,mergeCommit',
+      JSON.stringify({
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/70',
+        mergeCommit: null,
+      }),
+    );
+    on('gh pr merge 70 --squash --delete-branch --auto', '');
+
+    const clock = fakeClock();
+    const result = await executeMergeWaitForTest(
+      { number: 70, timeout_sec: 30 },
+      { now: clock.now, sleep: clock.sleep, intervalMs: 10000 },
+    );
+
+    expectErr(result);
+    expect(result.error).toContain('timed out after 30s');
+    expect(result.error).toContain('PR #70');
+    expect(result.error).toContain('queue.enforced: true');
+  });
+
+  test('queue path → fetch_error mid-poll surfaces "after enrollment" context', async () => {
+    stubEnforcedQueue();
+    let viewCallCount = 0;
+    on('gh pr view 71 --json state,url,mergeCommit', () => {
+      viewCallCount += 1;
+      if (viewCallCount >= 4) {
+        throw new Error('gh: API rate limit exceeded');
+      }
+      return JSON.stringify({
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/71',
+        mergeCommit: null,
+      });
+    });
+    on('gh pr merge 71 --squash --delete-branch --auto', '');
+
+    const clock = fakeClock();
+    const result = await executeMergeWaitForTest(
+      { number: 71 },
+      { now: clock.now, sleep: clock.sleep, intervalMs: 1000 },
+    );
+
+    expectErr(result);
+    expect(result.error).toContain('after enrollment');
+    expect(result.error).toContain('PR #71');
+    expect(result.error).toContain('rate limit');
+    expect(result.error).toContain('queue.enforced: true');
+  });
+
+  test('pr_merge failure propagates unchanged', async () => {
+    stubNoQueue();
+    on(
+      'gh pr view 80 --json state,url,mergeCommit',
+      JSON.stringify({
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/80',
+        mergeCommit: null,
+      }),
+    );
+    on('gh pr merge 80 --squash --delete-branch', () => {
+      const err = new Error('Pull request is not mergeable: conflicts') as ThrowableError;
+      err.stderr = 'Pull request is not mergeable: conflicts\n';
+      throw err;
+    });
+
+    const result = await executeMergeWaitForTest(
+      { number: 80 },
+      { now: () => 0, sleep: async () => {}, intervalMs: 1 },
+    );
+
+    expectErr(result);
+    expect(result.error).toContain('gh pr merge failed');
+  });
+
+  test('initial state-fetch failure surfaces a clear error', async () => {
+    on('gh pr view 90 --json state,url,mergeCommit', () => {
+      throw new Error('PR not found');
+    });
+
+    const result = await executeMergeWaitForTest(
+      { number: 90 },
+      { now: () => 0, sleep: async () => {}, intervalMs: 1 },
+    );
+
+    expectErr(result);
+    expect(result.error).toContain('failed to read initial PR state');
+    expect(result.error).toContain('PR not found');
+  });
+});

--- a/lib/adapters/pr-merge-wait-github.ts
+++ b/lib/adapters/pr-merge-wait-github.ts
@@ -1,0 +1,194 @@
+/**
+ * GitHub `pr_merge_wait` adapter implementation (Story 1.11, #248).
+ *
+ * Lifted from `handlers/pr_merge_wait.ts` per the standard PR-family template.
+ * The handler is now a thin dispatcher; this module owns the GitHub-specific
+ * orchestration: detect-and-skip via `fetchPrState`, call `prMerge`, decide
+ * whether to poll, and format the aggregate response.
+ *
+ * **Architectural rule (Dev Spec §5.5).** Both `pr-merge-wait-github.ts` and
+ * `pr-merge-wait-gitlab.ts` import `pollUntilMerged` from
+ * `lib/pr-merge-wait-poll.ts` — the loop is platform-agnostic and is NOT
+ * duplicated per platform. Both adapters call the shared `executeMergeWait`
+ * helper here; the per-platform exports are thin wrappers that pin the
+ * `platform` argument so contract-test routing stays honest.
+ *
+ * **Hybrid sub-call dispatch.** The state fetcher comes from the routed
+ * adapter (`getAdapter().fetchPrState(...)`), not a direct import. That keeps
+ * cross-platform hybrid sub-calls honest: they go through the same dispatch
+ * layer as top-level handler methods.
+ */
+
+import {
+  pollUntilMerged,
+  defaultSleep,
+  DEFAULT_TIMEOUT_SEC,
+  POLL_INTERVAL_MS,
+  type PrStateInfo,
+} from '../pr-merge-wait-poll.js';
+import { getAdapter } from './index.js';
+import type {
+  AdapterResult,
+  PrMergeWaitArgs,
+  PrMergeWaitResponse,
+} from './types.js';
+
+// Detect-and-skip synthesizes this aggregate when the PR is already MERGED
+// before invocation. We don't know how it was merged historically (direct vs
+// queue, this session vs earlier), so report the conservative defaults and
+// surface the situation via a warning.
+function synthesizeAlreadyMerged(num: number, info: PrStateInfo): PrMergeWaitResponse {
+  return {
+    number: num,
+    enrolled: true,
+    merged: true,
+    merge_method: 'direct_squash',
+    queue: { enabled: false, position: null, enforced: false },
+    pr_state: 'MERGED',
+    url: info.url,
+    merge_commit_sha: info.mergeCommitSha,
+    warnings: ['PR was already merged before invocation; pr_merge was not called'],
+  };
+}
+
+// Pull the PrStateInfo out of an AdapterResult; throws so the caller can fold
+// the error into a `fetch_error` poll variant or a top-level adapter failure.
+async function fetchStateOrThrow(
+  number: number,
+  repo: string | undefined,
+): Promise<PrStateInfo> {
+  const result = await getAdapter({ repo }).fetchPrState({ number, repo });
+  if ('platform_unsupported' in result) {
+    throw new Error(`fetchPrState platform_unsupported: ${result.hint}`);
+  }
+  if (!result.ok) throw new Error(result.error);
+  return result.data;
+}
+
+export interface ExecuteOverrides {
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  intervalMs?: number;
+}
+
+/**
+ * Shared executor — both `prMergeWaitGithub` and `prMergeWaitGitlab` delegate
+ * here. Platform-agnostic: every subprocess touch goes through `getAdapter()`.
+ */
+export async function executeMergeWait(
+  args: PrMergeWaitArgs,
+  overrides?: ExecuteOverrides,
+): Promise<AdapterResult<PrMergeWaitResponse>> {
+  const timeoutMs = (args.timeout_sec ?? DEFAULT_TIMEOUT_SEC) * 1000;
+
+  // Detect-and-skip: if the PR is already MERGED, return immediately. Saves a
+  // pointless `gh pr merge` / `glab mr merge` call (which would error
+  // "already merged") and a full polling cycle.
+  let preState: PrStateInfo;
+  try {
+    preState = await fetchStateOrThrow(args.number, args.repo);
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'fetch_initial_state_failed',
+      error: `pr_merge_wait failed to read initial PR state: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    };
+  }
+  if (preState.state === 'merged') {
+    return { ok: true, data: synthesizeAlreadyMerged(args.number, preState) };
+  }
+
+  // Delegate the merge itself to the routed prMerge adapter. Pre-Story 1.11
+  // this went through a `performMerge` compat shim in handlers/pr_merge.ts;
+  // the shim is removed by this story.
+  const adapter = getAdapter({ repo: args.repo });
+  const mergeResult = await adapter.prMerge({
+    number: args.number,
+    squash_message: args.squash_message,
+    use_merge_queue: args.use_merge_queue,
+    skip_train: args.skip_train,
+    repo: args.repo,
+  });
+
+  if ('platform_unsupported' in mergeResult) {
+    return {
+      ok: false,
+      code: 'pr_merge_platform_unsupported',
+      error: `pr_merge platform_unsupported: ${mergeResult.hint}`,
+    };
+  }
+  if (!mergeResult.ok) {
+    return { ok: false, code: 'pr_merge_failed', error: mergeResult.error };
+  }
+  const merge = mergeResult.data;
+  if (merge.merged) {
+    // Direct path — already on main. No need to poll.
+    return { ok: true, data: { ...merge } };
+  }
+
+  // Queue path: enrolled but not yet on main. Poll until merged or timeout.
+  // Each poll routes through getAdapter().fetchPrState — the hybrid sub-call
+  // pattern at work.
+  const poll = await pollUntilMerged({
+    fetchState: () => fetchStateOrThrow(args.number, args.repo),
+    intervalMs: overrides?.intervalMs ?? POLL_INTERVAL_MS,
+    timeoutMs,
+    now: overrides?.now ?? Date.now,
+    sleep: overrides?.sleep ?? defaultSleep,
+  });
+
+  if (!poll.ok) {
+    if (poll.reason === 'fetch_error') {
+      // Critical context: the PR was successfully enrolled — only the polling
+      // loop failed. Caller can retry the wait without re-enrolling.
+      const lastSnippet = poll.lastState
+        ? `last_state: ${poll.lastState.state.toUpperCase()}`
+        : 'no successful poll before failure';
+      return {
+        ok: false,
+        code: 'poll_fetch_error',
+        error:
+          `pr_merge_wait polling failed for PR #${args.number} after enrollment ` +
+          `(${lastSnippet}, queue.enforced: ${merge.queue.enforced}): ${poll.error}`,
+      };
+    }
+    return {
+      ok: false,
+      code: 'poll_timeout',
+      error:
+        `pr_merge_wait timed out after ${args.timeout_sec ?? DEFAULT_TIMEOUT_SEC}s ` +
+        `waiting for PR #${args.number} to land on main ` +
+        `(last_state: ${poll.lastState.state.toUpperCase()}, ` +
+        `queue.enforced: ${merge.queue.enforced})`,
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      ...merge,
+      merged: true,
+      pr_state: 'MERGED',
+      url: poll.state.url || merge.url,
+      merge_commit_sha: poll.state.mergeCommitSha ?? merge.merge_commit_sha,
+    },
+  };
+}
+
+export async function prMergeWaitGithub(
+  args: PrMergeWaitArgs,
+): Promise<AdapterResult<PrMergeWaitResponse>> {
+  return executeMergeWait(args);
+}
+
+// Test seam — drives `executeMergeWait` with injected clock + sleep so unit
+// tests can run without real wall-clock time. Both adapters share this seam
+// (the executor is platform-agnostic).
+export async function executeMergeWaitForTest(
+  args: PrMergeWaitArgs,
+  overrides: ExecuteOverrides,
+): Promise<AdapterResult<PrMergeWaitResponse>> {
+  return executeMergeWait(args, overrides);
+}

--- a/lib/adapters/pr-merge-wait-gitlab.test.ts
+++ b/lib/adapters/pr-merge-wait-gitlab.test.ts
@@ -1,0 +1,212 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+import type { AdapterResult, PrMergeWaitResponse } from './types.ts';
+
+// Cross-platform parity tests for the GitLab pr_merge_wait adapter (Story 1.11).
+// Mirrors the GitHub adapter scenarios — same orchestration, glab subprocess
+// shapes instead of gh. The orchestration helper (`executeMergeWait`) is
+// platform-free; routing happens via getAdapter() driven by the cwd remote.
+//
+// Each test file installs its OWN mock.module BEFORE the dynamic import
+// (56-file convention).
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+type Responder = string | (() => string);
+
+let execRegistry: Array<{ match: string; respond: Responder }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { prMergeWaitGitlab } = await import('./pr-merge-wait-gitlab.ts');
+const { executeMergeWaitForTest } = await import('./pr-merge-wait-github.ts');
+
+function on(match: string, respond: Responder) {
+  execRegistry.push({ match, respond });
+}
+
+function fakeClock(startMs: number = 0) {
+  let nowMs = startMs;
+  let sleepCount = 0;
+  return {
+    now: () => nowMs,
+    sleep: async (ms: number) => {
+      nowMs += ms;
+      sleepCount += 1;
+    },
+    sleepCount: () => sleepCount,
+  };
+}
+
+function expectOk(
+  r: AdapterResult<PrMergeWaitResponse>,
+): asserts r is { ok: true; data: PrMergeWaitResponse } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectErr(
+  r: AdapterResult<PrMergeWaitResponse>,
+): asserts r is { ok: false; error: string; code: string } {
+  if (!('ok' in r) || r.ok) {
+    throw new Error(`expected error result, got ${JSON.stringify(r)}`);
+  }
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+  // GitLab origin so detectPlatform() routes to gitlabAdapter.
+  on('git remote get-url origin', 'https://gitlab.com/org/repo.git\n');
+});
+
+afterEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('prMergeWaitGitlab — adapter orchestration (parity)', () => {
+  test('detect-and-skip: MR already merged → no merge call', async () => {
+    on(
+      'glab api projects/org%2Frepo/merge_requests/50',
+      JSON.stringify({
+        iid: 50,
+        state: 'merged',
+        source_branch: 'feature/x',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/50',
+        labels: [],
+        merge_commit_sha: 'preexisting',
+      }),
+    );
+
+    const result = await prMergeWaitGitlab({ number: 50, repo: 'org/repo' });
+
+    expectOk(result);
+    expect(result.data.merged).toBe(true);
+    expect(result.data.pr_state).toBe('MERGED');
+    expect(result.data.merge_commit_sha).toBe('preexisting');
+    expect(result.data.warnings.length).toBe(1);
+    expect(result.data.warnings[0]).toContain('already merged');
+    expect(execCalls.find((c) => c.includes('glab mr merge'))).toBeUndefined();
+  });
+
+  test('direct merge path → returns synchronously, no polling', async () => {
+    let viewCalls = 0;
+    on('glab api projects/org%2Frepo/merge_requests/51', () => {
+      viewCalls += 1;
+      const merged = viewCalls >= 2;
+      return JSON.stringify({
+        iid: 51,
+        state: merged ? 'merged' : 'opened',
+        source_branch: 'feature/x',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/51',
+        labels: [],
+        merge_commit_sha: merged ? 'direct51' : null,
+      });
+    });
+    on('glab mr merge 51 --squash --remove-source-branch --yes', '');
+
+    const clock = fakeClock();
+    const result = await executeMergeWaitForTest(
+      { number: 51, repo: 'org/repo' },
+      { now: clock.now, sleep: clock.sleep, intervalMs: 1 },
+    );
+
+    expectOk(result);
+    expect(result.data.merged).toBe(true);
+    expect(result.data.merge_method).toBe('direct_squash');
+    expect(result.data.merge_commit_sha).toBe('direct51');
+    expect(clock.sleepCount()).toBe(0);
+  });
+
+  test('skip_train propagates platform_unsupported from prMerge as ok:false', async () => {
+    // GitLab's prMerge returns platform_unsupported for skip_train (R-03 typed
+    // asymmetry). pr_merge_wait can't proceed, so it surfaces this as ok:false
+    // with a descriptive code/error. Pre-state fetch happens first so we stub
+    // an OPEN MR.
+    on(
+      'glab api projects/org%2Frepo/merge_requests/55',
+      JSON.stringify({
+        iid: 55,
+        state: 'opened',
+        source_branch: 'feature/x',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/55',
+        labels: [],
+      }),
+    );
+
+    const result = await prMergeWaitGitlab({
+      number: 55,
+      repo: 'org/repo',
+      skip_train: true,
+    });
+
+    expectErr(result);
+    expect(result.error).toContain('platform_unsupported');
+    expect(result.error).toContain('merge trains');
+  });
+
+  test('pr_merge failure propagates unchanged', async () => {
+    on(
+      'glab api projects/org%2Frepo/merge_requests/80',
+      JSON.stringify({
+        iid: 80,
+        state: 'opened',
+        source_branch: 'feature/x',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/80',
+        labels: [],
+      }),
+    );
+    on('glab mr merge 80 --squash --remove-source-branch --yes', () => {
+      const err = new Error('!! conflicts') as ThrowableError;
+      err.stderr = 'cannot merge\n';
+      throw err;
+    });
+
+    const result = await executeMergeWaitForTest(
+      { number: 80, repo: 'org/repo' },
+      { now: () => 0, sleep: async () => {}, intervalMs: 1 },
+    );
+
+    expectErr(result);
+    expect(result.error).toContain('glab mr merge failed');
+  });
+
+  test('initial state-fetch failure surfaces a clear error', async () => {
+    on('glab api projects/org%2Frepo/merge_requests/90', () => {
+      throw new Error('MR not found');
+    });
+
+    const result = await prMergeWaitGitlab({ number: 90, repo: 'org/repo' });
+
+    expectErr(result);
+    expect(result.error).toContain('failed to read initial PR state');
+  });
+});

--- a/lib/adapters/pr-merge-wait-gitlab.ts
+++ b/lib/adapters/pr-merge-wait-gitlab.ts
@@ -1,0 +1,28 @@
+/**
+ * GitLab `pr_merge_wait` adapter implementation (Story 1.11, #248).
+ *
+ * Mirrors `pr-merge-wait-github.ts` — both delegate to the shared
+ * `executeMergeWait` helper, which is platform-agnostic by virtue of routing
+ * every subprocess touch through `getAdapter()`. There is intentionally no
+ * GitLab-specific logic here: detect-and-skip uses `fetchPrState`, the merge
+ * itself goes through `prMerge`, and the polling loop reuses
+ * `lib/pr-merge-wait-poll.ts` (NOT duplicated per platform).
+ *
+ * The per-platform export pin is what the contract test (`types.test.ts`)
+ * needs — every method on `PLATFORM_ADAPTER_METHODS` must exist on both
+ * `gitlabAdapter` and `githubAdapter`. The behavior happens to be identical
+ * because the orchestration layer is platform-free.
+ */
+
+import { executeMergeWait } from './pr-merge-wait-github.js';
+import type {
+  AdapterResult,
+  PrMergeWaitArgs,
+  PrMergeWaitResponse,
+} from './types.js';
+
+export async function prMergeWaitGitlab(
+  args: PrMergeWaitArgs,
+): Promise<AdapterResult<PrMergeWaitResponse>> {
+  return executeMergeWait(args);
+}

--- a/lib/adapters/types.test.ts
+++ b/lib/adapters/types.test.ts
@@ -45,7 +45,19 @@ describe('PlatformAdapter contract', () => {
   // Story 1.8 (#245): prComment
   // Story 1.9 (#246): prWaitCi
   // Story 1.10 (#247): prMerge
-  const MIGRATED_METHODS = new Set<string>(['prCreate', 'prDiff', 'prFiles', 'prList', 'prStatus', 'prComment', 'prWaitCi', 'prMerge']);
+  // Story 1.11 (#248): prMergeWait + fetchPrState (first hybrid sub-call)
+  const MIGRATED_METHODS = new Set<string>([
+    'prCreate',
+    'prDiff',
+    'prFiles',
+    'prList',
+    'prStatus',
+    'prComment',
+    'prWaitCi',
+    'prMerge',
+    'prMergeWait',
+    'fetchPrState',
+  ]);
 
   test('still-stubbed methods return platform_unsupported', async () => {
     const stubbed = PLATFORM_ADAPTER_METHODS.filter((m) => !MIGRATED_METHODS.has(m));

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -88,8 +88,52 @@ export interface PrMergeResponse {
   merge_commit_sha?: string;
   warnings: string[];
 }
-export type PrMergeWaitArgs = unknown;
-export type PrMergeWaitResponse = unknown;
+export interface PrMergeWaitArgs {
+  number: number;
+  squash_message?: string;
+  use_merge_queue?: boolean;
+  skip_train?: boolean;
+  repo?: string;
+  timeout_sec?: number;
+}
+
+/**
+ * pr_merge_wait returns the same aggregate envelope as pr_merge with the
+ * "merged on main" guarantee: on success, `merged === true` and
+ * `pr_state === 'MERGED'`. Detect-and-skip emits a warning when the PR was
+ * already merged before invocation.
+ */
+export interface PrMergeWaitResponse {
+  number: number;
+  enrolled: boolean;
+  merged: boolean;
+  merge_method: PrMergeMethod;
+  queue: PrMergeQueueState;
+  pr_state: PrStateLabel;
+  url: string;
+  merge_commit_sha?: string;
+  warnings: string[];
+}
+
+/**
+ * Hybrid sub-call (Story 1.11). `fetchPrState` is the slim cross-platform
+ * PR/MR state fetcher used by both `prMergeWait` (polling until merged) and
+ * the per-platform `prMerge` adapters (post-merge URL/sha lookup). Returns
+ * only what the merge flow needs — state, url, sha — instead of the rich
+ * status payload `prStatus` returns.
+ */
+export interface FetchPrStateArgs {
+  number: number;
+  repo?: string;
+}
+
+export type PrState = 'open' | 'merged' | 'closed';
+
+export interface PrStateInfo {
+  state: PrState;
+  url: string;
+  mergeCommitSha?: string;
+}
 export interface PrStatusArgs {
   number: number;
   repo?: string;
@@ -257,6 +301,10 @@ export type SpecDependenciesResponse = unknown;
 // 1.12) produces the authoritative list of hybrid sub-calls; `fetchIssue` is
 // included here as the illustrative example. Adding/removing sub-calls is
 // expected during Phase 2 implementation.
+//
+// Story 1.11 added the FIRST real hybrid sub-call: `fetchPrState` — see
+// `FetchPrStateArgs` / `PrStateInfo` above. Used by `prMergeWait` and the
+// per-platform `prMerge` adapters.
 export type FetchIssueArgs = unknown;
 export type IssueData = unknown;
 
@@ -296,8 +344,12 @@ export interface PlatformAdapter {
   specAcceptanceCriteria(args: SpecAcceptanceCriteriaArgs): Promise<AdapterResult<SpecAcceptanceCriteriaResponse>>;
   specDependencies(args: SpecDependenciesArgs): Promise<AdapterResult<SpecDependenciesResponse>>;
 
-  // Hybrid sub-calls (illustrative; final set determined by Story 1.12 survey)
+  // Hybrid sub-calls (illustrative; final set determined by Story 1.12 survey).
+  // `fetchPrState` is the first real hybrid (Story 1.11) — consumed by
+  // `prMergeWait` and the per-platform `prMerge` adapters for state polling
+  // and post-merge URL/sha lookup.
   fetchIssue(args: FetchIssueArgs): Promise<AdapterResult<IssueData>>;
+  fetchPrState(args: FetchPrStateArgs): Promise<AdapterResult<PrStateInfo>>;
 }
 
 // ---------------------------------------------------------------------------
@@ -334,6 +386,7 @@ export const PLATFORM_ADAPTER_METHODS = [
   'specAcceptanceCriteria',
   'specDependencies',
   'fetchIssue',
+  'fetchPrState',
 ] as const;
 
 export type PlatformAdapterMethod = (typeof PLATFORM_ADAPTER_METHODS)[number];

--- a/lib/pr-merge-wait-poll.test.ts
+++ b/lib/pr-merge-wait-poll.test.ts
@@ -1,0 +1,145 @@
+import { describe, test, expect } from 'bun:test';
+
+// Pure-function tests for the platform-agnostic polling loop. Lifted from
+// tests/pr_merge_wait.test.ts during Story 1.11 (#248) — the loop now lives
+// in lib/pr-merge-wait-poll.ts and serves both the GitHub and GitLab
+// pr_merge_wait adapters.
+//
+// No mock.module needed: pollUntilMerged is a pure function that takes its
+// fetcher + clock + sleep as deps, so tests inject thunks directly.
+
+import { pollUntilMerged, type PrStateInfo } from './pr-merge-wait-poll.ts';
+
+function fakeClock(startMs: number = 0) {
+  let nowMs = startMs;
+  let sleepCount = 0;
+  return {
+    now: () => nowMs,
+    sleep: async (ms: number) => {
+      nowMs += ms;
+      sleepCount += 1;
+    },
+    advance: (ms: number) => {
+      nowMs += ms;
+    },
+    sleepCount: () => sleepCount,
+  };
+}
+
+describe('pollUntilMerged (pure)', () => {
+  test('returns success on first fetch when state is already merged', async () => {
+    const clock = fakeClock();
+    const result = await pollUntilMerged({
+      fetchState: async () => ({ state: 'merged', url: 'u', mergeCommitSha: 'abc' }),
+      intervalMs: 10000,
+      timeoutMs: 60000,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.state.state).toBe('merged');
+      expect(result.state.mergeCommitSha).toBe('abc');
+    }
+    expect(clock.sleepCount()).toBe(0);
+  });
+
+  test('polls until merged appears, then returns', async () => {
+    const clock = fakeClock();
+    const states: Array<'open' | 'merged'> = ['open', 'open', 'open', 'merged'];
+    let i = 0;
+    const result = await pollUntilMerged({
+      fetchState: async () => {
+        const state = states[i++] ?? 'merged';
+        return {
+          state,
+          url: 'u',
+          mergeCommitSha: i === states.length ? 'sha' : undefined,
+        } as PrStateInfo;
+      },
+      intervalMs: 10000,
+      timeoutMs: 600000,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+    expect(result.ok).toBe(true);
+    expect(clock.sleepCount()).toBe(3); // three polls returned 'open' before the fourth merged
+  });
+
+  test('returns timeout when budget exhausted before merge', async () => {
+    const clock = fakeClock();
+    const result = await pollUntilMerged({
+      fetchState: async () => ({ state: 'open', url: 'u' }),
+      intervalMs: 10000,
+      timeoutMs: 30000,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.reason === 'timeout') {
+      expect(result.lastState.state).toBe('open');
+    } else {
+      throw new Error('expected timeout variant');
+    }
+  });
+
+  test('fetch_error variant: fetchState throws on first iteration → reason=fetch_error, lastState=null', async () => {
+    const clock = fakeClock();
+    const result = await pollUntilMerged({
+      fetchState: async () => {
+        throw new Error('gh: connection refused');
+      },
+      intervalMs: 1000,
+      timeoutMs: 60000,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.reason === 'fetch_error') {
+      expect(result.error).toContain('connection refused');
+      expect(result.lastState).toBeNull();
+    } else {
+      throw new Error('expected fetch_error variant');
+    }
+  });
+
+  test('fetch_error variant: throws on later iteration → lastState preserved', async () => {
+    const clock = fakeClock();
+    let n = 0;
+    const result = await pollUntilMerged({
+      fetchState: async () => {
+        n += 1;
+        if (n === 1) return { state: 'open' as const, url: 'u' };
+        if (n === 2) return { state: 'open' as const, url: 'u' };
+        throw new Error('gh: rate limited');
+      },
+      intervalMs: 1000,
+      timeoutMs: 60000,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.reason === 'fetch_error') {
+      expect(result.error).toContain('rate limited');
+      expect(result.lastState?.state).toBe('open');
+    } else {
+      throw new Error('expected fetch_error variant');
+    }
+  });
+
+  test('timeout check happens BEFORE sleep (no wasted final interval)', async () => {
+    // With timeoutMs=10000 and intervalMs=10000, after one sleep the clock is
+    // at 10000ms. The next iteration fetches, sees 'open', checks elapsed >=
+    // timeoutMs (10000>=10000) → timeout. Sleep count should be exactly 1, not 2.
+    const clock = fakeClock();
+    const result = await pollUntilMerged({
+      fetchState: async () => ({ state: 'open', url: 'u' }),
+      intervalMs: 10000,
+      timeoutMs: 10000,
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+    expect(result.ok).toBe(false);
+    expect(clock.sleepCount()).toBe(1);
+  });
+});

--- a/lib/pr-merge-wait-poll.ts
+++ b/lib/pr-merge-wait-poll.ts
@@ -1,0 +1,98 @@
+/**
+ * Platform-agnostic polling loop for `pr_merge_wait` (Story 1.11, #248).
+ *
+ * Lifted out of `handlers/pr_merge_wait.ts` so the loop isn't duplicated per
+ * platform — same architectural rule as `lib/pr-wait-ci-poll.ts`. Both
+ * `lib/adapters/pr-merge-wait-github.ts` and `pr-merge-wait-gitlab.ts` import
+ * `pollUntilMerged` and call it with their own state-fetcher.
+ *
+ * The state fetcher itself goes through the platform adapter
+ * (`getAdapter().fetchPrState(...)`), so this module remains free of
+ * subprocess work and platform branching.
+ *
+ * **Async fetcher contract.** `fetchState` is `() => Promise<PrStateInfo>` —
+ * one step looser than the pre-Story-1.11 sync contract — because the routed
+ * `getAdapter().fetchPrState(...)` call is async by design (every adapter
+ * method returns a Promise). Sync helpers (e.g., `fetchPrStateGithubSync`)
+ * still exist and are wrapped trivially (`async () => fetchSync(...)`).
+ */
+
+import type { PrStateInfo } from './adapters/types.js';
+
+export type { PrStateInfo };
+
+export interface PollDeps {
+  fetchState: () => Promise<PrStateInfo>;
+  intervalMs: number;
+  timeoutMs: number;
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+}
+
+export interface PollSuccess {
+  ok: true;
+  state: PrStateInfo;
+  elapsedMs: number;
+}
+
+export interface PollTimeout {
+  ok: false;
+  reason: 'timeout';
+  lastState: PrStateInfo;
+  elapsedMs: number;
+}
+
+export interface PollFetchError {
+  ok: false;
+  reason: 'fetch_error';
+  error: string;
+  lastState: PrStateInfo | null;
+  elapsedMs: number;
+}
+
+// Pure poller — no module-level globals, no platform knowledge. Loops:
+// fetch → return on merged → check timeout → sleep. The sleep happens AFTER
+// the timeout check, so if the budget is already spent we don't waste another
+// interval before reporting it. Injectable now/sleep makes tests instant.
+//
+// fetchState rejections are caught and reported as a `fetch_error` variant so
+// the caller can preserve the "PR was already enrolled" context — distinct
+// from a clean timeout. Without this distinction, a transient `gh` failure
+// mid-poll would surface as a generic outer-catch error and the caller would
+// have no idea whether the merge itself failed or just the polling did.
+export async function pollUntilMerged(
+  deps: PollDeps,
+): Promise<PollSuccess | PollTimeout | PollFetchError> {
+  const start = deps.now();
+  let lastState: PrStateInfo | null = null;
+  while (true) {
+    let info: PrStateInfo;
+    try {
+      info = await deps.fetchState();
+    } catch (err) {
+      return {
+        ok: false,
+        reason: 'fetch_error',
+        error: err instanceof Error ? err.message : String(err),
+        lastState,
+        elapsedMs: deps.now() - start,
+      };
+    }
+    lastState = info;
+    const elapsedMs = deps.now() - start;
+    if (info.state === 'merged') {
+      return { ok: true, state: info, elapsedMs };
+    }
+    if (elapsedMs >= deps.timeoutMs) {
+      return { ok: false, reason: 'timeout', lastState: info, elapsedMs };
+    }
+    await deps.sleep(deps.intervalMs);
+  }
+}
+
+export function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export const DEFAULT_TIMEOUT_SEC = 600;
+export const POLL_INTERVAL_MS = 10_000;

--- a/lib/pr_state.ts
+++ b/lib/pr_state.ts
@@ -1,96 +1,47 @@
 /**
- * Slim cross-platform PR/MR state fetcher.
+ * Slim cross-platform PR/MR state fetcher — DELEGATING SHIM (Story 1.11, #248).
  *
- * Used by `pr_merge` (for post-merge URL + sha lookup) and `pr_merge_wait`
- * (for polling until `state === 'merged'`). Intentionally narrower than
- * `handlers/pr_status.ts` — that handler returns rich check + mergeability
- * data; this lib returns only what the merge flow needs (state, url, sha).
+ * Pre-Story-1.11, this module owned the `gh pr view` and `glab api MR`
+ * subprocess calls directly. Story 1.11 lifted those into the platform
+ * adapter pair (`lib/adapters/fetch-pr-state-{github,gitlab}.ts`) — the FIRST
+ * hybrid sub-call on `PlatformAdapter`. This file now contains ZERO direct
+ * subprocess calls and exists only to:
  *
- * Why a separate lib instead of calling `pr_status` from `pr_merge_wait`:
- * - One exec call vs two (pr_status fetches checks separately).
- * - No JSON-of-JSON unwrap: handler responses are MCP envelopes wrapping
- *   JSON strings, awkward to consume from inside another handler.
- * - Decouples polling from rich-status concerns.
+ *   1. Preserve the legacy import surface for `tests/pr_state.test.ts`
+ *      (sync `fetchPrState`/`fetchGithubPrState`/`fetchGitlabMrState` API).
+ *   2. Re-export `PrState` / `PrStateInfo` for in-tree code that imported
+ *      them from this path historically.
  *
- * Handlers that need the full status (`pr_status`, `pr_wait_ci`) keep their
- * existing wider queries; this module is the minimal-surface alternative for
- * the merge-confirmation use case.
+ * Closes architect F2 (Phase 1 audit).
+ *
+ * Why a sync delegation surface (not just `getAdapter().fetchPrState(...)`):
+ * - Existing callers in `lib/adapters/pr-merge-{github,gitlab}.ts` and the
+ *   `pollUntilMerged` test seam expect a sync call. Wrapping those is a
+ *   wider blast radius than this story owns; the spec allows the file to
+ *   either delegate OR delete-and-update-importers.
+ * - The delegating sync helpers below import the per-platform `*Sync`
+ *   variants from the adapters directly, keeping subprocess calls in the
+ *   adapter layer (gate-grep happy) without forcing every caller to await.
+ *
+ * `lib/adapters/pr-merge-{github,gitlab}.ts` are migrated by this story to
+ * call `getAdapter().fetchPrState(...)` instead of these helpers — the
+ * remaining importers go through the routed adapter (the architecturally
+ * correct path). These shims stay as a public surface for `pr_state.test.ts`,
+ * which validates the underlying adapter sync helpers.
  */
 
-import { execSync } from 'child_process';
-import { gitlabApiMr } from './glab.js';
+import { fetchPrStateGithubSync } from './adapters/fetch-pr-state-github.js';
+import { fetchPrStateGitlabSync } from './adapters/fetch-pr-state-gitlab.js';
+import type { PrState, PrStateInfo } from './adapters/types.js';
 
-export type PrState = 'open' | 'merged' | 'closed';
-
-export interface PrStateInfo {
-  state: PrState;
-  url: string;
-  mergeCommitSha?: string;
-}
-
-interface GithubPrViewResponse {
-  state?: string;
-  url?: string;
-  mergeCommit?: { oid?: string } | null;
-}
-
-// Same charset as merge_queue_detect.ts and wave_previous_merged.ts — GitHub's
-// owner/repo grammar. Defended at the lib boundary (not just at handler entry)
-// so any future caller of fetchGithubPrState gets the same protection without
-// having to remember to validate themselves.
-const GITHUB_REPO_SLUG = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
-
-function repoFlag(repo: string | undefined): string {
-  if (repo === undefined) return '';
-  if (!GITHUB_REPO_SLUG.test(repo)) {
-    throw new Error(`fetchGithubPrState: invalid repo slug ${JSON.stringify(repo)}`);
-  }
-  return ` --repo ${repo}`;
-}
-
-function parseSlugOpts(
-  slug: string | undefined,
-): { owner?: string; repo?: string } | undefined {
-  if (slug === undefined) return undefined;
-  const idx = slug.indexOf('/');
-  if (idx <= 0 || idx === slug.length - 1) return undefined;
-  return { owner: slug.slice(0, idx), repo: slug.slice(idx + 1) };
-}
-
-function normalizeGithubState(raw: string): PrState {
-  const upper = raw.toUpperCase();
-  if (upper === 'MERGED') return 'merged';
-  if (upper === 'CLOSED') return 'closed';
-  return 'open';
-}
-
-function normalizeGitlabState(raw: string): PrState {
-  const lower = raw.toLowerCase();
-  if (lower === 'merged') return 'merged';
-  if (lower === 'closed') return 'closed';
-  return 'open';
-}
+export type { PrState, PrStateInfo };
 
 export function fetchGithubPrState(num: number, repo?: string): PrStateInfo {
-  const raw = execSync(
-    `gh pr view ${num} --json state,url,mergeCommit${repoFlag(repo)}`,
-    { encoding: 'utf8' },
-  );
-  const parsed = JSON.parse(raw) as GithubPrViewResponse;
-  return {
-    state: normalizeGithubState(parsed.state ?? ''),
-    url: parsed.url ?? '',
-    mergeCommitSha: parsed.mergeCommit?.oid,
-  };
+  return fetchPrStateGithubSync(num, repo);
 }
 
 export function fetchGitlabMrState(num: number, repo?: string): PrStateInfo {
-  const mr = gitlabApiMr(num, parseSlugOpts(repo));
-  return {
-    state: normalizeGitlabState(mr.state ?? ''),
-    url: mr.web_url ?? '',
-    mergeCommitSha: mr.merge_commit_sha ?? undefined,
-  };
+  return fetchPrStateGitlabSync(num, repo);
 }
 
 export function fetchPrState(
@@ -99,6 +50,6 @@ export function fetchPrState(
   repo?: string,
 ): PrStateInfo {
   return platform === 'github'
-    ? fetchGithubPrState(num, repo)
-    : fetchGitlabMrState(num, repo);
+    ? fetchPrStateGithubSync(num, repo)
+    : fetchPrStateGitlabSync(num, repo);
 }

--- a/scripts/ci/migration-allowlist.txt
+++ b/scripts/ci/migration-allowlist.txt
@@ -19,7 +19,6 @@ epic_sub_issues.ts
 ibm.ts
 label_create.ts
 label_list.ts
-pr_merge_wait.ts
 spec_acceptance_criteria.ts
 spec_dependencies.ts
 spec_get.ts

--- a/tests/pr_merge_wait.test.ts
+++ b/tests/pr_merge_wait.test.ts
@@ -1,213 +1,59 @@
 import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
 
+// Thin handler-level smoke tests for pr_merge_wait. Story 1.11 (#248) moved
+// the orchestration tests to lib/adapters/pr-merge-wait-{github,gitlab}.test.ts
+// and the pure poll-loop tests to lib/pr-merge-wait-poll.test.ts. The handler
+// is now a ~50-line dispatcher; these tests cover only:
+//   - schema validation (zod rejection paths)
+//   - the HandlerDef export shape
+//   - end-to-end envelope wiring (one happy-path detect-and-skip case)
+//
+// Each test file installs its OWN mock.module BEFORE the dynamic import
+// (56-file convention).
+
 interface ThrowableError extends Error {
   stderr?: string;
-  stdout?: string;
-  status?: number;
 }
 
-type Responder = string | (() => string);
-
-let execRegistry: Array<{ match: string; respond: Responder }> = [];
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
 let execCalls: string[] = [];
 
-function mockExec(cmd: string): string {
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
   execCalls.push(cmd);
   for (const { match, respond } of execRegistry) {
     if (cmd.includes(match)) {
       return typeof respond === 'function' ? respond() : respond;
     }
   }
-  throw new Error(`Unexpected exec call: ${cmd}`);
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: prMergeWaitHandler } = await import('../handlers/pr_merge_wait.ts');
+
+function on(match: string, respond: string | (() => string)) {
+  execRegistry.push({ match, respond });
 }
-
-mock.module('child_process', () => ({
-  execSync: (cmd: string, _opts?: unknown) => mockExec(cmd),
-}));
-
-const { default: prMergeWaitHandler, pollUntilMerged, executeWaitForTest } = await import(
-  '../handlers/pr_merge_wait.ts'
-);
-const { clearMergeQueueCache } = await import('../lib/merge_queue_detect.ts');
 
 function parseResult(result: { content: Array<{ type: string; text: string }> }) {
   return JSON.parse(result.content[0].text) as Record<string, unknown>;
 }
 
-function onExec(match: string, respond: Responder) {
-  execRegistry.push({ match, respond });
-}
-
-function stubNoQueue() {
-  onExec(
-    'gh api graphql',
-    JSON.stringify({ data: { repository: { mergeQueue: null } } }),
-  );
-}
-
-function stubEnforcedQueue() {
-  // Match the actual GitHub GraphQL response shape: detection asks for
-  // `__typename` — see #258 fix in lib/merge_queue_detect.ts.
-  onExec(
-    'gh api graphql',
-    JSON.stringify({ data: { repository: { mergeQueue: { __typename: 'MergeQueue' } } } }),
-  );
-}
-
 beforeEach(() => {
   execRegistry = [];
   execCalls = [];
-  clearMergeQueueCache();
+  on('git remote get-url origin', 'https://github.com/org/repo.git\n');
 });
 
 afterEach(() => {
   execRegistry = [];
   execCalls = [];
-  clearMergeQueueCache();
 });
 
-// Fake clock + sleep for polling tests. Each sleep advances the clock by the
-// requested interval so the timeout check fires at predictable virtual time.
-function fakeClock(startMs: number = 0) {
-  let nowMs = startMs;
-  let sleepCount = 0;
-  return {
-    now: () => nowMs,
-    sleep: async (ms: number) => {
-      nowMs += ms;
-      sleepCount += 1;
-    },
-    advance: (ms: number) => {
-      nowMs += ms;
-    },
-    sleepCount: () => sleepCount,
-  };
-}
-
-// ===========================================================================
-// pollUntilMerged — pure function unit tests
-// ===========================================================================
-
-describe('pollUntilMerged (pure)', () => {
-  test('returns success on first fetch when state is already merged', async () => {
-    const clock = fakeClock();
-    const result = await pollUntilMerged({
-      fetchState: () => ({ state: 'merged', url: 'u', mergeCommitSha: 'abc' }),
-      intervalMs: 10000,
-      timeoutMs: 60000,
-      now: clock.now,
-      sleep: clock.sleep,
-    });
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.state.state).toBe('merged');
-      expect(result.state.mergeCommitSha).toBe('abc');
-    }
-    expect(clock.sleepCount()).toBe(0);
-  });
-
-  test('polls until merged appears, then returns', async () => {
-    const clock = fakeClock();
-    const states: Array<'open' | 'merged'> = ['open', 'open', 'open', 'merged'];
-    let i = 0;
-    const result = await pollUntilMerged({
-      fetchState: () => ({
-        state: states[i++] ?? 'merged',
-        url: 'u',
-        mergeCommitSha: i === states.length ? 'sha' : undefined,
-      }),
-      intervalMs: 10000,
-      timeoutMs: 600000,
-      now: clock.now,
-      sleep: clock.sleep,
-    });
-    expect(result.ok).toBe(true);
-    expect(clock.sleepCount()).toBe(3); // three polls returned 'open' before the fourth merged
-  });
-
-  test('returns timeout when budget exhausted before merge', async () => {
-    const clock = fakeClock();
-    const result = await pollUntilMerged({
-      fetchState: () => ({ state: 'open', url: 'u' }),
-      intervalMs: 10000,
-      timeoutMs: 30000,
-      now: clock.now,
-      sleep: clock.sleep,
-    });
-    expect(result.ok).toBe(false);
-    if (!result.ok && result.reason === 'timeout') {
-      expect(result.lastState.state).toBe('open');
-    } else {
-      throw new Error('expected timeout variant');
-    }
-  });
-
-  test('fetch_error variant: fetchState throws on first iteration → reason=fetch_error, lastState=null', async () => {
-    const clock = fakeClock();
-    const result = await pollUntilMerged({
-      fetchState: () => {
-        throw new Error('gh: connection refused');
-      },
-      intervalMs: 1000,
-      timeoutMs: 60000,
-      now: clock.now,
-      sleep: clock.sleep,
-    });
-    expect(result.ok).toBe(false);
-    if (!result.ok && result.reason === 'fetch_error') {
-      expect(result.error).toContain('connection refused');
-      expect(result.lastState).toBeNull();
-    } else {
-      throw new Error('expected fetch_error variant');
-    }
-  });
-
-  test('fetch_error variant: throws on later iteration → lastState preserved', async () => {
-    const clock = fakeClock();
-    let n = 0;
-    const result = await pollUntilMerged({
-      fetchState: () => {
-        n += 1;
-        if (n === 1) return { state: 'open' as const, url: 'u' };
-        if (n === 2) return { state: 'open' as const, url: 'u' };
-        throw new Error('gh: rate limited');
-      },
-      intervalMs: 1000,
-      timeoutMs: 60000,
-      now: clock.now,
-      sleep: clock.sleep,
-    });
-    expect(result.ok).toBe(false);
-    if (!result.ok && result.reason === 'fetch_error') {
-      expect(result.error).toContain('rate limited');
-      expect(result.lastState?.state).toBe('open');
-    } else {
-      throw new Error('expected fetch_error variant');
-    }
-  });
-
-  test('timeout check happens BEFORE sleep (no wasted final interval)', async () => {
-    // With timeoutMs=10000 and intervalMs=10000, after one sleep the clock is
-    // at 10000ms. The next iteration fetches, sees 'open', checks elapsed >=
-    // timeoutMs (10000>=10000) → timeout. Sleep count should be exactly 1, not 2.
-    const clock = fakeClock();
-    const result = await pollUntilMerged({
-      fetchState: () => ({ state: 'open', url: 'u' }),
-      intervalMs: 10000,
-      timeoutMs: 10000,
-      now: clock.now,
-      sleep: clock.sleep,
-    });
-    expect(result.ok).toBe(false);
-    expect(clock.sleepCount()).toBe(1);
-  });
-});
-
-// ===========================================================================
-// executeWait — full handler flow with mocked clock + execSync
-// ===========================================================================
-
-describe('pr_merge_wait — handler integration', () => {
+describe('pr_merge_wait handler — thin dispatcher', () => {
   test('schema rejection: missing number', async () => {
     const result = await prMergeWaitHandler.execute({});
     const data = parseResult(result);
@@ -220,9 +66,8 @@ describe('pr_merge_wait — handler integration', () => {
     expect(data.ok).toBe(false);
   });
 
-  test('detect-and-skip: PR already merged → no merge call, warning emitted', async () => {
-    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
-    onExec(
+  test('end-to-end envelope: detect-and-skip path returns ok:true with merged:true', async () => {
+    on(
       'gh pr view 50 --json state,url,mergeCommit',
       JSON.stringify({
         state: 'MERGED',
@@ -231,264 +76,14 @@ describe('pr_merge_wait — handler integration', () => {
       }),
     );
 
-    const result = await executeWaitForTest({ number: 50 }, 'github', {
-      now: () => 0,
-      sleep: async () => {},
-      intervalMs: 10000,
-    });
-
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.merged).toBe(true);
-      expect(result.pr_state).toBe('MERGED');
-      expect(result.merge_commit_sha).toBe('preexisting');
-      expect(result.warnings.length).toBe(1);
-      expect(result.warnings[0]).toContain('already merged');
-    }
-    // No merge call should have been issued.
-    expect(execCalls.find(c => c.includes('gh pr merge'))).toBeUndefined();
-  });
-
-  test('direct merge path → returns synchronously, no polling', async () => {
-    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
-    stubNoQueue();
-
-    // First view = pre-merge (OPEN, triggers detect-and-skip "not merged").
-    // Second view = post-merge inside pr_merge (MERGED). Real direct merge
-    // is synchronous, so we mirror that here.
-    let viewCalls = 0;
-    onExec('gh pr view 51 --json state,url,mergeCommit', () => {
-      viewCalls += 1;
-      const merged = viewCalls >= 2;
-      return JSON.stringify({
-        state: merged ? 'MERGED' : 'OPEN',
-        url: 'https://github.com/org/repo/pull/51',
-        mergeCommit: merged ? { oid: 'direct51' } : null,
-      });
-    });
-    onExec('gh pr merge 51 --squash --delete-branch', '');
-
-    const clock = fakeClock();
-    const result = await executeWaitForTest({ number: 51 }, 'github', {
-      now: clock.now,
-      sleep: clock.sleep,
-      intervalMs: 1,
-    });
-
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.merged).toBe(true);
-      expect(result.merge_method).toBe('direct_squash');
-      expect(result.merge_commit_sha).toBe('direct51');
-    }
-    // Critical: zero polling sleeps on the direct path.
-    expect(clock.sleepCount()).toBe(0);
-  });
-
-  // ---------------------------------------------------------------------------
-  // Regression #258 Bug 2: pr_merge_wait must NOT trust pr_merge's merged:true
-  // when the underlying gh pr merge actually only enrolled (queue / auto-merge).
-  // Pre-fix: pr_merge.ts:286 hardcoded merged:true on direct exec exit 0, then
-  // pr_merge_wait short-circuited at line 179-182 — caller saw merged:true but
-  // the PR was actually still OPEN (or in #257's case, closed without merging).
-  // Post-fix: pr_merge reports merged:false; pr_merge_wait polls until landing.
-  test('regression #258: direct path returns merged:false → pr_merge_wait polls until landing', async () => {
-    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
-    stubNoQueue(); // detection misses (e.g. branch-level queue, like the real repo)
-
-    // Pre-state (detect-and-skip): OPEN.
-    // Post-direct-merge view (inside pr_merge): STILL OPEN — gh enrolled, didn't merge.
-    // Polling: OPEN, OPEN, MERGED.
-    let viewCallCount = 0;
-    onExec('gh pr view 257 --json state,url,mergeCommit', () => {
-      viewCallCount += 1;
-      if (viewCallCount >= 5) {
-        return JSON.stringify({
-          state: 'MERGED',
-          url: 'https://github.com/org/repo/pull/257',
-          mergeCommit: { oid: 'eventually-merged' },
-        });
-      }
-      return JSON.stringify({
-        state: 'OPEN',
-        url: 'https://github.com/org/repo/pull/257',
-        mergeCommit: null,
-      });
-    });
-    // Direct merge command exits 0 without throwing — gh decided to enroll.
-    onExec('gh pr merge 257 --squash --delete-branch', '');
-
-    const clock = fakeClock();
-    const result = await executeWaitForTest({ number: 257 }, 'github', {
-      now: clock.now,
-      sleep: clock.sleep,
-      intervalMs: 1000,
-    });
-
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.merged).toBe(true);
-      expect(result.pr_state).toBe('MERGED');
-      expect(result.merge_commit_sha).toBe('eventually-merged');
-    }
-    // Critical: pr_merge_wait must have actually polled (not short-circuited).
-    expect(clock.sleepCount()).toBeGreaterThan(0);
-  });
-
-  test('queue path → polls until state flips to merged', async () => {
-    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
-    stubEnforcedQueue();
-
-    // Pre-state: OPEN. Then merge call (--auto). Post-merge initial fetch
-    // (inside pr_merge): OPEN. Polling fetches: OPEN, OPEN, MERGED.
-    let viewCallCount = 0;
-    onExec('gh pr view 60 --json state,url,mergeCommit', () => {
-      viewCallCount += 1;
-      // Calls 1 (pre-state for detect-and-skip), 2 (post-merge in pr_merge):
-      // OPEN. Calls 3, 4: OPEN. Call 5+: MERGED with sha.
-      if (viewCallCount >= 5) {
-        return JSON.stringify({
-          state: 'MERGED',
-          url: 'https://github.com/org/repo/pull/60',
-          mergeCommit: { oid: 'queued-sha' },
-        });
-      }
-      return JSON.stringify({
-        state: 'OPEN',
-        url: 'https://github.com/org/repo/pull/60',
-        mergeCommit: null,
-      });
-    });
-    onExec('gh pr merge 60 --squash --delete-branch --auto', '');
-
-    const clock = fakeClock();
-    const result = await executeWaitForTest({ number: 60 }, 'github', {
-      now: clock.now,
-      sleep: clock.sleep,
-      intervalMs: 1000,
-    });
-
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.merged).toBe(true);
-      expect(result.pr_state).toBe('MERGED');
-      expect(result.merge_method).toBe('merge_queue');
-      expect(result.merge_commit_sha).toBe('queued-sha');
-    }
-    expect(clock.sleepCount()).toBeGreaterThan(0);
-  });
-
-  test('queue path → timeout returns ok:false with descriptive error', async () => {
-    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
-    stubEnforcedQueue();
-
-    onExec(
-      'gh pr view 70 --json state,url,mergeCommit',
-      JSON.stringify({
-        state: 'OPEN',
-        url: 'https://github.com/org/repo/pull/70',
-        mergeCommit: null,
-      }),
-    );
-    onExec('gh pr merge 70 --squash --delete-branch --auto', '');
-
-    const clock = fakeClock();
-    const result = await executeWaitForTest(
-      { number: 70, timeout_sec: 30 },
-      'github',
-      { now: clock.now, sleep: clock.sleep, intervalMs: 10000 },
-    );
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error).toContain('timed out after 30s');
-      expect(result.error).toContain('PR #70');
-      expect(result.error).toContain('queue.enforced: true');
-    }
-  });
-
-  test('queue path → fetch_error mid-poll surfaces "after enrollment" context', async () => {
-    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
-    stubEnforcedQueue();
-
-    // Pre-state: OPEN. pr_merge's post-merge fetch: OPEN. First poll fetch:
-    // OPEN. Second poll fetch: throws.
-    let viewCallCount = 0;
-    onExec('gh pr view 71 --json state,url,mergeCommit', () => {
-      viewCallCount += 1;
-      if (viewCallCount >= 4) {
-        throw new Error('gh: API rate limit exceeded');
-      }
-      return JSON.stringify({
-        state: 'OPEN',
-        url: 'https://github.com/org/repo/pull/71',
-        mergeCommit: null,
-      });
-    });
-    onExec('gh pr merge 71 --squash --delete-branch --auto', '');
-
-    const clock = fakeClock();
-    const result = await executeWaitForTest({ number: 71 }, 'github', {
-      now: clock.now,
-      sleep: clock.sleep,
-      intervalMs: 1000,
-    });
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error).toContain('after enrollment');
-      expect(result.error).toContain('PR #71');
-      expect(result.error).toContain('rate limit');
-      expect(result.error).toContain('queue.enforced: true');
-    }
-  });
-
-  test('pr_merge failure propagates unchanged', async () => {
-    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
-    stubNoQueue();
-    onExec(
-      'gh pr view 80 --json state,url,mergeCommit',
-      JSON.stringify({
-        state: 'OPEN',
-        url: 'https://github.com/org/repo/pull/80',
-        mergeCommit: null,
-      }),
-    );
-    onExec('gh pr merge 80 --squash --delete-branch', () => {
-      const err = new Error('Pull request is not mergeable: conflicts') as ThrowableError;
-      err.stderr = 'Pull request is not mergeable: conflicts\n';
-      throw err;
-    });
-
-    const result = await executeWaitForTest({ number: 80 }, 'github', {
-      now: () => 0,
-      sleep: async () => {},
-      intervalMs: 1,
-    });
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error).toContain('gh pr merge failed');
-    }
-  });
-
-  test('initial state-fetch failure surfaces a clear error', async () => {
-    onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
-    onExec('gh pr view 90 --json state,url,mergeCommit', () => {
-      throw new Error('PR not found');
-    });
-
-    const result = await executeWaitForTest({ number: 90 }, 'github', {
-      now: () => 0,
-      sleep: async () => {},
-      intervalMs: 1,
-    });
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error).toContain('failed to read initial PR state');
-      expect(result.error).toContain('PR not found');
-    }
+    const result = await prMergeWaitHandler.execute({ number: 50 });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(data.merged).toBe(true);
+    expect(data.pr_state).toBe('MERGED');
+    expect(data.merge_commit_sha).toBe('preexisting');
+    // No merge call should have been issued — detect-and-skip short-circuits.
+    expect(execCalls.find((c) => c.includes('gh pr merge'))).toBeUndefined();
   });
 
   test('handler exports valid HandlerDef shape', () => {


### PR DESCRIPTION
## Summary

Migrates `pr_merge_wait` to the platform adapter pattern, introducing the **first hybrid sub-call** via `fetchPrState` and migrating `lib/pr_state.ts` — closing architect F2. The `performMerge` compat shim is removed now that `pr_merge_wait` is the last consumer to migrate.

## Changes

- `pr_merge_wait` handler routes through the platform adapter, replacing the legacy direct-CLI call path.
- New `fetchPrState` adapter sub-call: the first hybrid pattern call surfaced via the adapter — used by `pr_merge_wait` to poll PR state until merged/timeout. Establishes the precedent for future read-while-polling tools.
- `lib/pr_state.ts` migrated to the adapter (closes F2 from the architect retrofit Dev Spec).
- `performMerge` compatibility shim removed; nothing in-tree depends on it after this migration.
- `MIGRATED_METHODS` count advances from 8 to 10 (pr_merge_wait + fetchPrState).
- Allowlist size now 23 (one entry retired).

## Linked Issues

Closes #248

## Test Plan

- Full Bun suite: 1659 passed / 0 failed.
- Colocated coverage exercises the new `fetchPrState` adapter sub-call and the migrated `lib/pr_state.ts` paths (success, polling, timeout).
- Architecture gate-greps active and green; allowlist now 23 entries (down one).
- `MIGRATED_METHODS` registry asserted at 10 (was 8).