### PR TITLE
docs(devspec): amend §8 with binding Phase 2 + Phase 3 plans (post-Phase-1)

### DIFF
--- a/docs/platform-adapter-retrofit-devspec.md
+++ b/docs/platform-adapter-retrofit-devspec.md
@@ -445,16 +445,16 @@ Detail in Section 6.
 
 | ID | Deliverable | Category | Tier | File Path | Produced In | Status | Notes |
 |----|-------------|----------|------|-----------|-------------|--------|-------|
-| DM-01 | README.md | Docs | 1 | `README.md` | Phase 3 | required | Updated with adapter architecture section |
+| DM-01 | README.md | Docs | 1 | `README.md` | Phase 3, Wave 3.3 (Story 3.4) | required | Updated with adapter architecture section |
 | DM-02 | Unified build system | Code | 1 | N/A — because Bun-native build via `package.json` scripts + `scripts/ci/validate.sh`; no Makefile needed | — | N/A | Bun convention |
 | DM-03 | CI/CD pipeline + gate-greps | Code | 1 | `.github/workflows/ci.yml` (existing) + `scripts/ci/validate.sh` (gate-greps added) | Phase 1, Wave 1.2 | required | Two new gate-grep steps |
-| DM-04 | Automated test suite | Test | 1 | `tests/` + `lib/adapters/*.test.ts` + `lib/adapters/types.test.ts` | Phase 1, Waves 1.2-1.6; Phase 2 | required | Per-method colocated tests |
+| DM-04 | Automated test suite | Test | 1 | `tests/` + `lib/adapters/*.test.ts` + `lib/adapters/types.test.ts` | Phase 1, Waves 1.2–1.8 (landed); Phase 2, Waves 2.0–2.6 (per-story additions); Phase 3, Waves 3.1–3.5 | required | Per-method colocated tests |
 | DM-05 | Test results (JUnit XML) | Test | 1 | N/A — because `bun test` reports to stdout only; JUnit XML reporter is a separate cross-cutting follow-up, not part of retrofit scope | — | N/A | Future enhancement |
 | DM-06 | Coverage report | Test | 1 | N/A — because no coverage tooling is configured today; adding it is a separate cross-cutting follow-up, not part of retrofit scope | — | N/A | Future enhancement |
-| DM-07 | CHANGELOG | Docs | 1 | GitHub release notes on tag (per Wave-Engineering convention) | Phase 3 | required | Established by v1.6.0/v1.7.0 |
-| DM-08 | VRTM | Trace | 1 | Dev Spec Appendix V | Phase 3 (closing story) | required | Standard |
-| DM-09 | Architecture/audience-facing docs | Docs | 1, 2 (architecture trigger fired) | `docs/adapters/README.md` (new), `docs/handlers/origin-operations-guide.md` §2.4 (rewritten), `docs/adapters/survey.md` (Phase 1 deliverable) | Phase 1, Wave 1.7 (survey); Phase 3 (others) | required | Architecture doc trigger fired (>2 components) |
-| DM-10 | Manual test procedures document | Docs | 2 (MV-XX trigger fired) | `docs/platform-adapter-retrofit-devspec.md` §6.4 (inline) | Phase 1, Wave 1.8 (MV-01..04 execution); Phase 3 (MV-05, MV-06 execution) | required | Procedures defined inline in §6.4; executed in closing stories |
+| DM-07 | CHANGELOG | Docs | 1 | GitHub release notes on tag (per Wave-Engineering convention) | Phase 3, Wave 3.4 (Story 3.5) | required | Established by v1.6.0/v1.7.0; v1.8.0 notes written in Story 3.5 |
+| DM-08 | VRTM | Trace | 1 | Dev Spec Appendix V | Phase 3, Wave 3.5 (Story 3.6) | required | Populated in closing story |
+| DM-09 | Architecture/audience-facing docs | Docs | 1, 2 (architecture trigger fired) | `docs/adapters/README.md` (new, Story 3.3), `docs/handlers/origin-operations-guide.md` §2.4 (rewritten, Story 3.2), `docs/adapters/survey.md` (Phase 1 deliverable, shipped) | Phase 1, Wave 1.7 (survey — shipped); Phase 3, Wave 3.2 (README.md + §2.4 rewrite) | required | Architecture doc trigger fired (>2 components) |
+| DM-10 | Manual test procedures document | Docs | 2 (MV-XX trigger fired) | `docs/platform-adapter-retrofit-devspec.md` §6.4 (inline) | Phase 1, Wave 1.8 (MV-01..04 — closed 2026-04-26; MV-01 deferred per §6.4); Phase 3, Wave 3.5 (MV-05, MV-06) | required | Procedures defined inline in §6.4; executed in closing stories |
 
 ### 5.B Installation & Deployment
 
@@ -553,7 +553,7 @@ The MCP server has no UI; "end-to-end" for this project means tool-call-through-
 
 - [x] Every Tier 1 row in the Deliverables Manifest (5.A) has a file path or "N/A — because [reason]"
 - [x] Every Tier 2 trigger that fires has a corresponding row in the Deliverables Manifest (architecture doc trigger fired → DM-09)
-- [⚠️] Every Deliverables Manifest row has a "Produced In" wave assignment — **Phase 1 rows have wave assignments; Phase 2/3 rows have phase-only assignments pending detailed plans (per CP-01 strangler-fig with Phase 1 survey deliverable). This is intentional and called out in Section 8.**
+- [x] Every Deliverables Manifest row has a "Produced In" wave assignment — Phase 1, Phase 2, and Phase 3 rows all carry specific wave assignments as of the 2026-04-26 amendment (§8 Phase 2 bound post-survey; §8 Phase 3 bound in the same pass per "plan end-to-end" rule).
 - [x] Every MV-XX in Section 6.4 has a procedure document — they're inline in this Dev Spec; no separate doc needed
 - [x] No deliverable is referenced only as a verb without a corresponding noun (file path)
 - [x] At least one audience-facing doc (DM-09) has a file path assigned (`docs/adapters/README.md`, `docs/adapters/survey.md`)
@@ -601,8 +601,32 @@ Wave 1.7  ─── Story 1.12: Phase 1 survey (docs/adapters/survey.md)
                   │
 Wave 1.8  ─── Story 1.13: Phase 1 closing — manual verification (MV-01 through MV-04)
 
-PHASE 2 — Migrate remaining 22 handlers (TBD pending Phase 1 survey)
-PHASE 3 — Cleanup, docs, release (outline below; refined post-Phase 2)
+PHASE 2 — Bug pre-work + 23 remaining migrations (bound 2026-04-26)
+Wave 2.0  ─── Story 2.0: Fix pr_merge skip_train queue-strategy error (#280)
+                  │
+Wave 2.1  ─── Story 2.1: Land fetchIssue adapter (keystone sub-call)
+                  │
+Wave 2.2  ─┬─ Stories 2.2–2.6: spec_* family + epic_sub_issues (5 parallel)
+            │
+Wave 2.3  ─┬─ Stories 2.7–2.10: dod_load_manifest (+#283) + wave_* read family (4 parallel)
+            │
+Wave 2.4  ─┬─ Stories 2.11–2.14: ci_* full-migrations (4 parallel)
+            │
+Wave 2.5  ─┬─ Stories 2.15–2.17: label_* + work_item (+#281) (3 parallel)
+            │
+Wave 2.6  ─── Stories 2.18–2.24: sub-call-heavy migrations (serial; closes #282)
+
+PHASE 3 — Cleanup, docs, release (bound 2026-04-26)
+Wave 3.1  ─── Story 3.1: Delete lib/glab.ts
+                  │
+Wave 3.2  ─┬─ Story 3.2: Rewrite origin-ops-guide §2.4
+            └─ Story 3.3: Write docs/adapters/README.md  (2 parallel)
+                  │
+Wave 3.3  ─── Story 3.4: Update root README.md
+                  │
+Wave 3.4  ─── Story 3.5: Tag v1.8.0 + release notes
+                  │
+Wave 3.5  ─── Story 3.6: Phase 3 closing — MV-05, MV-06, VRTM
 ```
 
 | Wave | Stories | Master Issue | Parallel? |
@@ -1228,43 +1252,1415 @@ Execute MV-01 through MV-04. File any bugs as separate issues. Update Phase 1 Do
 
 ---
 
-### Phase 2: Migrate remaining 22 handlers (TBD)
+### Phase 2: Migrate remaining 23 handlers + close Phase-1 bug follow-ups (Epic)
 
-**Status:** Plan deferred pending Phase 1 survey output (Story 1.12). Re-run `/devspec` after Phase 1 closes to amend this section with detailed wave plan and stories.
+**Goal:** Complete the platform-aware handler migration. Land `fetchIssue` as the keystone sub-call, migrate the four non-`pr_*` handler families (CI, label/work-item, spec, wave), and close the four in-repo bug follow-ups from Phase 1 either as pre-work (bug blocking every migration) or inline with the handler they concern.
 
-**Anticipated structure** (informational only — NOT binding):
-- Multiple waves grouped by handler family (CI, label/issue, spec, wave-*) and by hybrid sub-call sharing
-- Each story = one method-pair migration (same template as Phase 1 canaries)
-- Every story carries the standard template AC: handler ≤80 lines, gate-greps pass, contract test passes
+#### Phase 2 Definition of Done
 
-**Phase 2 DoD** (will firm up post-survey):
-- [ ] All 22 remaining platform-aware handlers migrated
-- [ ] All hybrid sub-calls implemented for both platforms
-- [ ] Zero gate-grep matches in `handlers/`
-- [ ] `lib/glab.ts` retains only re-export shims (full deletion in Phase 3)
+- [ ] Every handler in `scripts/ci/migration-allowlist.txt` (23 entries as of Phase 1 close) migrated; allowlist has zero `handlers/` entries remaining
+- [ ] `PlatformAdapter` interface extended by 16 new methods (7 full-migration + 9 hybrid sub-calls); `PLATFORM_ADAPTER_METHODS` runtime registry and `MIGRATED_METHODS` contract-test set both include every new method (Phase 1 shipped 10 → Phase 2 close has 26 total)
+- [ ] Every migrated handler is ≤80 lines; no platform branching; no direct subprocess calls
+- [ ] Gate-greps pass on the full handlers tree (non-allowlisted handlers is now all handlers)
+- [ ] Colocated adapter tests exist for every new adapter method-pair and hybrid sub-call [R-15]
+- [ ] All pre-Phase-2 integration tests (1659 baseline) pass unchanged [R-11]
+- [ ] Bug #280 (`pr_merge skip_train` queue-strategy error) fixed and closed via Wave 2.0
+- [ ] Bug #281 (`work_item` type-vs-platform routing) fixed and closed via Story 2.17
+- [ ] Bug #282 (`wave_reconcile_mrs` 50-item scan cap) addressed and closed via Story 2.21
+- [ ] Bug #283 (`dod_load_manifest` cross-repo GitLab gap) closed via Story 2.7
+- [ ] `lib/glab.ts` retains only re-export shims (full deletion in Phase 3, Story 3.1)
+- [ ] Full suite ≥ 1659 + per-story added tests; zero regressions
 
 ---
 
-### Phase 3: Cleanup, docs, release (outline)
+### Wave Map (Phase 2)
 
-**Status:** Outline-only. Refined post-Phase 2.
+```
+PHASE 2 — Bug pre-work + 23 remaining migrations
+─────────────────────────────────────────────────
+Wave 2.0  ─── Story 2.0: Fix pr_merge skip_train on queue-enforced repos (#280)
+                  │      (standalone, pre-pa-6; unblocks every subsequent wave-merge)
+                  ▼
+Wave 2.1  ─── Story 2.1: Land fetchIssue adapter + types refinement
+                  │      (keystone sub-call; 10 downstream consumers)
+                  ▼
+Wave 2.2  ─┬─ Story 2.2: Migrate spec_get
+            ├─ Story 2.3: Migrate spec_validate_structure      (5 parallel —
+            ├─ Story 2.4: Migrate spec_acceptance_criteria      fetchIssue consumers,
+            ├─ Story 2.5: Migrate spec_dependencies             disjoint files)
+            └─ Story 2.6: Migrate epic_sub_issues
+                  │
+Wave 2.3  ─┬─ Story 2.7: Migrate dod_load_manifest (+close #283)
+            ├─ Story 2.8: Migrate wave_compute                  (4 parallel —
+            ├─ Story 2.9: Migrate wave_dependency_graph          fetchIssue consumers
+            └─ Story 2.10: Migrate wave_topology                 round 2)
+                  │
+Wave 2.4  ─┬─ Story 2.11: Migrate ci_failed_jobs                (4 parallel — CI
+            ├─ Story 2.12: Migrate ci_run_logs                   full-migrations,
+            ├─ Story 2.13: Migrate ci_run_status                 disjoint files)
+            └─ Story 2.14: Migrate ci_runs_for_branch
+                  │
+Wave 2.5  ─┬─ Story 2.15: Migrate label_create                  (3 parallel —
+            ├─ Story 2.16: Migrate label_list                    remaining full-
+            └─ Story 2.17: Migrate work_item (+close #281)       migrations)
+                  │
+Wave 2.6  ─┬─ Story 2.18: Migrate ibm (+fetchPrForBranch)       (serial — sub-call
+            ├─ Story 2.19: Migrate ci_wait_run                    churn in types.ts;
+            │             (+ciListRuns, +resolveBranchSha)        each story adds
+            ├─ Story 2.20: Migrate wave_previous_merged           ≥1 new method)
+            │             (+fetchIssueClosure)
+            ├─ Story 2.21: Migrate wave_reconcile_mrs
+            │             (+findMergedPrForBranchPrefix; close #282)
+            ├─ Story 2.22: Migrate wave_init
+            │             (+resolveBranchSha reused, +createBranch)
+            ├─ Story 2.23: Migrate wave_finalize
+            │             (+findExistingPr; reuses prCreate)
+            └─ Story 2.24: Migrate wave_ci_trust_level
+                          (+fetchCiTrustSignal)
+```
 
-**Anticipated stories:**
-- Story 3.1: Delete `lib/glab.ts` (verify zero importers) [R-16]
-- Story 3.2: Rewrite `docs/handlers/origin-operations-guide.md` §2.4 with supersession note [R-14]
-- Story 3.3: Write `docs/adapters/README.md` — contract docs + "where to add a method" workflow [R-13]
-- Story 3.4: Update root `README.md` with adapter architecture section
-- Story 3.5: Tag and release v1.8.0
-- Story 3.6: Phase 3 closing — execute MV-05 + MV-06; complete VRTM (Appendix V)
+| Wave | Stories | Master Issue | Parallel? |
+|------|---------|-------------|-----------|
+| 2.0 | 2.0 | Story 2.0 | Single story (bug pre-work) |
+| 2.1 | 2.1 | Story 2.1 | Single story (keystone sub-call) |
+| 2.2 | 2.2, 2.3, 2.4, 2.5, 2.6 | Wave 2.2 Master | Yes — 5 parallel |
+| 2.3 | 2.7, 2.8, 2.9, 2.10 | Wave 2.3 Master | Yes — 4 parallel |
+| 2.4 | 2.11, 2.12, 2.13, 2.14 | Wave 2.4 Master | Yes — 4 parallel |
+| 2.5 | 2.15, 2.16, 2.17 | Wave 2.5 Master | Yes — 3 parallel |
+| 2.6 | 2.18, 2.19, 2.20, 2.21, 2.22, 2.23, 2.24 | Wave 2.6 Master | No — serial (types.ts churn) |
 
-**Phase 3 DoD** (preliminary):
-- [ ] `lib/glab.ts` deleted
-- [ ] All docs updated per R-13, R-14
-- [ ] v1.8.0 tagged + released
-- [ ] MV-05, MV-06 executed and recorded
-- [ ] VRTM complete in Appendix V
-- [ ] All 17 requirements have at least one verification entry
-- [ ] `scripts/ci/migration-allowlist.txt` is empty or deleted (gate-greps now enforce against ALL handlers globally)
+**Story count:** 25 (1 bug pre-work + 1 keystone + 23 handler migrations). Three migration stories embed a bug close (#281, #282, #283). `Wave 2.1` is structurally identical to Wave 1.2 — single foundational story before the consumer cluster.
+
+**File-overlap note.** Every Wave 2.2–2.5 flight touches disjoint handler files; the only shared file across any two flights in the same wave is `scripts/ci/migration-allowlist.txt` (single-line removal, commutes cleanly per Phase 1 precedent). Wave 2.6 is serial because each story mutates `lib/adapters/types.ts` (interface additions) and `lib/adapters/types.test.ts::MIGRATED_METHODS` (registry additions) — linearizing avoids interface-shape merge conflicts.
+
+---
+
+#### Story 2.0: Fix `pr_merge skip_train` queue-strategy error on queue-enforced repos (bug #280)
+
+**Wave:** 2.0
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** none (Phase 1 closed)
+
+Close bug #280 before any Phase 2 migration begins. The bug: on a repo with GitHub merge-queue enforcement, `pr_merge({skip_train: true})` errors with a queue-strategy message instead of silently falling back to the queue path. Every Phase 2 migration lands via `pr_merge` and would hit this path; fixing it first keeps every subsequent wave unblocked.
+
+**Implementation Steps:**
+
+1. Read `lib/adapters/pr-merge-github.ts` — the handler branch that runs `gh pr merge --merge --admin` when `skip_train: true` and the branch that runs `gh pr merge --auto --squash` when `skip_train: false`
+2. Detect the queue-strategy error signature returned by `gh` on queue-enforced repos (the error body mentions "merge strategy not allowed")
+3. On detection, drop `--admin` and re-invoke with `--auto` (queue-enqueue path) — the eager success semantics from `lesson_merge_queue_pattern.md` still apply
+4. Add typed response field `queue_fallback: boolean` when the fallback triggers so callers can log the decision
+5. Add unit test: given a `gh pr merge --admin` invocation that returns the queue-strategy error, the adapter retries with `--auto` and returns `{ok: true, queue_fallback: true}`
+6. Close issue #280 in PR body via `Closes #280`
+
+**Test Procedures:**
+
+*Unit Tests:*
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `pr-merge-github — queue-strategy error triggers --auto fallback` | Regression for #280 | `lib/adapters/pr-merge-github.test.ts` |
+| `pr-merge-github — queue_fallback: true in response when fallback fires` | Response shape | `lib/adapters/pr-merge-github.test.ts` |
+| `pr-merge-github — no fallback when merge-admin succeeds` | Happy path unchanged | `lib/adapters/pr-merge-github.test.ts` |
+
+*Integration/E2E Coverage:*
+- IT-02 — adapter→subprocess argv shape for both initial and retry invocation
+- IT-04 — existing `tests/pr_merge.test.ts` integration tests preserved unchanged
+
+**Acceptance Criteria:**
+
+- [ ] `lib/adapters/pr-merge-github.ts` detects the queue-strategy error and re-invokes with `--auto` [bug #280]
+- [ ] Response shape includes `queue_fallback: boolean` field; defaults `false`
+- [ ] Three new unit tests cover fallback, response shape, and no-fallback paths
+- [ ] Existing `tests/pr_merge.test.ts` integration tests pass unchanged [R-11]
+- [ ] Gate-greps pass [R-09, R-10]
+- [ ] Contract test still passes [R-04]
+- [ ] Full suite passes (≥1659 + 3 new unit tests)
+- [ ] Issue #280 closed via PR
+
+---
+
+#### Story 2.1: Land `fetchIssue` adapter + types refinement (keystone sub-call)
+
+**Wave:** 2.1
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Story 2.0
+
+Add the `fetchIssue` sub-call to the adapter — the single widest-reach platform operation in the retrofit, consumed by 10 downstream handlers (`ibm`, `spec_get`, `spec_validate_structure`, `spec_acceptance_criteria`, `spec_dependencies`, `epic_sub_issues`, `wave_compute`, `wave_dependency_graph`, `wave_topology`, `dod_load_manifest`). Landing it first makes Waves 2.2 and 2.3 near-mechanical handler lifts.
+
+**Implementation Steps:**
+
+1. Add `fetchIssue(args: { number: number, repo?: string }): Promise<AdapterResult<{ number: number, title: string, state: 'OPEN' | 'CLOSED', url: string, body: string, labels: string[] }>>` to `PlatformAdapter` in `lib/adapters/types.ts`
+2. Create `lib/adapters/fetch-issue-github.ts` — uses `gh issue view --json number,title,state,url,body,labels`; normalize state enum
+3. Create `lib/adapters/fetch-issue-gitlab.ts` — uses `glab api projects/:id/issues/:iid` via the existing `gitlabApiIssue()` helper in `lib/glab.ts` (consumer migration in Phase 3 Story 3.1 deletes `lib/glab.ts`; pre-deletion this is the supported path)
+4. Wire into `lib/adapters/github.ts` and `lib/adapters/gitlab.ts` assemblers
+5. Add `'fetchIssue'` to `MIGRATED_METHODS` in `lib/adapters/types.test.ts`
+6. Add colocated tests: argv-shape for both platforms, response-parsing for both, error-path `AdapterResult.error` for both
+
+**Test Procedures:**
+
+*Unit Tests:*
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `fetch-issue-github — argv shape: gh issue view --json ... <number>` | Subprocess-boundary mock for GitHub | `lib/adapters/fetch-issue-github.test.ts` |
+| `fetch-issue-github — normalizes state + labels array` | Output parsing correctness | `lib/adapters/fetch-issue-github.test.ts` |
+| `fetch-issue-github — returns AdapterResult.error on gh failure` | Error-path discriminator | `lib/adapters/fetch-issue-github.test.ts` |
+| `fetch-issue-gitlab — argv shape via gitlabApiIssue helper` | Subprocess-boundary mock for GitLab | `lib/adapters/fetch-issue-gitlab.test.ts` |
+| `fetch-issue-gitlab — parses glab api response into normalized shape` | Output parsing correctness | `lib/adapters/fetch-issue-gitlab.test.ts` |
+
+*Integration/E2E Coverage:*
+- IT-03 — contract test: `MIGRATED_METHODS` now 11/26 after this story (10 shipped Phase 1 + `fetchIssue`)
+
+**Acceptance Criteria:**
+
+- [ ] `PlatformAdapter.fetchIssue` signature added to `lib/adapters/types.ts` [R-01]
+- [ ] `lib/adapters/fetch-issue-{github,gitlab}.ts` both exist and return `AdapterResult<FetchIssueResponse>` [R-05]
+- [ ] Assemblers wire `fetchIssue` for both platforms
+- [ ] `'fetchIssue'` added to `MIGRATED_METHODS` in contract test [R-04]
+- [ ] Colocated tests exist for both adapters [R-15]
+- [ ] Gate-greps still pass [R-09, R-10]
+- [ ] Full suite passes (≥ 1659 + 5 new unit tests)
+- [ ] No handler migrated yet — Wave 2.2 lands the first consumer
+
+---
+
+#### Story 2.2: Migrate `spec_get`
+
+**Wave:** 2.2
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Story 2.1 (requires `fetchIssue` adapter)
+
+Migrate `spec_get` to consume the `fetchIssue` sub-call. The handler's markdown section-parsing logic (`parseSections` in `lib/spec_parser`) stays in `lib/`; only the platform-specific `fetchBody` call is replaced.
+
+**Implementation Steps:**
+
+1. Refactor `handlers/spec_get.ts` to call `getAdapter({repo}).fetchIssue({number, repo})` instead of the inline `fetchBody` helper
+2. Delete the handler-local `fetchBody(ref)` helper; all 4 spec handlers share this helper today — deletion happens here and Stories 2.3-2.5 each remove their own duplicate copy
+3. Validate `handlers/spec_get.ts` is ≤80 lines after refactor
+4. Remove `spec_get.ts` from `scripts/ci/migration-allowlist.txt`
+5. Preserve `tests/spec_get.test.ts` integration tests unchanged (mock the adapter if needed; adapter mock pattern matches `fetch-issue-github.test.ts`)
+
+**Test Procedures:**
+
+*Unit Tests:* none new — the adapter is already covered by Story 2.1's tests; `spec_get` is now a thin dispatcher.
+
+*Integration/E2E Coverage:*
+- IT-01 — `tests/spec_get.test.ts` verifies handler→adapter dispatch via adapter mock
+- IT-04 — existing integration tests preserved unchanged [R-11]
+- IT-05 — gate-greps now active for `spec_get.ts`
+
+**Acceptance Criteria:**
+
+- [ ] `handlers/spec_get.ts` is ≤80 lines; no platform branching; no direct subprocess calls [R-05, R-09, R-10]
+- [ ] `fetchBody` helper removed from `handlers/spec_get.ts`
+- [ ] `spec_get.ts` removed from `scripts/ci/migration-allowlist.txt`
+- [ ] `tests/spec_get.test.ts` integration tests pass unchanged [R-11]
+- [ ] Gate-greps pass [R-09, R-10]
+- [ ] Contract test still passes [R-04]
+- [ ] Full suite passes
+
+---
+
+#### Story 2.3: Migrate `spec_validate_structure`
+
+**Wave:** 2.2
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Story 2.1
+
+Migrate `spec_validate_structure` to consume `fetchIssue`. H2-section validation logic stays in the handler; only `fetchBody` is replaced.
+
+**Implementation Steps:**
+
+1. Refactor `handlers/spec_validate_structure.ts` to call `getAdapter({repo}).fetchIssue({number, repo})`
+2. Delete handler-local `fetchBody` helper
+3. Verify ≤80 lines
+4. Remove from `scripts/ci/migration-allowlist.txt`
+5. Preserve `tests/spec_validate_structure.test.ts` integration tests unchanged
+
+**Test Procedures:**
+
+*Unit Tests:* none new.
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+
+**Acceptance Criteria:**
+
+- [ ] `handlers/spec_validate_structure.ts` is ≤80 lines; no platform branching; no direct subprocess [R-05, R-09, R-10]
+- [ ] Handler-local `fetchBody` removed
+- [ ] Removed from migration allowlist
+- [ ] Existing integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+#### Story 2.4: Migrate `spec_acceptance_criteria`
+
+**Wave:** 2.2
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Story 2.1
+
+Migrate `spec_acceptance_criteria` to consume `fetchIssue`. Checklist-regex parsing stays in the handler.
+
+**Implementation Steps:**
+
+1. Refactor `handlers/spec_acceptance_criteria.ts` to call `getAdapter({repo}).fetchIssue(...)`
+2. Delete handler-local `fetchBody`
+3. Verify ≤80 lines
+4. Remove from `scripts/ci/migration-allowlist.txt`
+5. Preserve integration tests unchanged
+
+**Test Procedures:**
+
+*Unit Tests:* none new.
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+
+**Acceptance Criteria:**
+
+- [ ] Handler ≤80 lines; no platform branching; no direct subprocess [R-05, R-09, R-10]
+- [ ] `fetchBody` removed
+- [ ] Removed from allowlist
+- [ ] Integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+#### Story 2.5: Migrate `spec_dependencies`
+
+**Wave:** 2.2
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Story 2.1
+
+Migrate `spec_dependencies` to consume `fetchIssue`. `## Dependencies` section parsing and bold-label fallback stay in the handler.
+
+**Implementation Steps:**
+
+1. Refactor `handlers/spec_dependencies.ts` to call `getAdapter({repo}).fetchIssue(...)`
+2. Delete handler-local `fetchBody`
+3. Verify ≤80 lines
+4. Remove from `scripts/ci/migration-allowlist.txt`
+5. Preserve integration tests unchanged
+
+**Test Procedures:**
+
+*Unit Tests:* none new.
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+
+**Acceptance Criteria:**
+
+- [ ] Handler ≤80 lines; no platform branching; no direct subprocess [R-05, R-09, R-10]
+- [ ] `fetchBody` removed
+- [ ] Removed from allowlist
+- [ ] Integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+#### Story 2.6: Migrate `epic_sub_issues`
+
+**Wave:** 2.2
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Story 2.1
+
+Migrate `epic_sub_issues` to consume `fetchIssue`. The ~200 LoC of markdown table / checklist / reference-normalization parsing (`parseTableRows`, `parseChecklistOrBullets`, `normalizeRef`) stays in the handler — only `fetchBody` is replaced.
+
+**Implementation Steps:**
+
+1. Refactor `handlers/epic_sub_issues.ts` to call `getAdapter({repo}).fetchIssue(...)`
+2. Delete handler-local `fetchBody`
+3. Verify handler ≤80 lines is NOT expected for this story (the markdown parsers alone exceed 80 lines) — confirm ≤80 lines post-refactor by counting only dispatch + envelope logic and promoting parsers to `lib/epic-sub-issues-parser.ts` if needed
+4. Remove from `scripts/ci/migration-allowlist.txt`
+5. Preserve integration tests unchanged
+
+**Test Procedures:**
+
+*Unit Tests:*
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `epic-sub-issues-parser — table row extraction` | Preserve parser correctness post-extraction | `lib/epic-sub-issues-parser.test.ts` |
+| `epic-sub-issues-parser — checklist/bullet extraction` | Preserve parser correctness | `lib/epic-sub-issues-parser.test.ts` |
+| `epic-sub-issues-parser — ref normalization` | Preserve parser correctness | `lib/epic-sub-issues-parser.test.ts` |
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+
+**Acceptance Criteria:**
+
+- [ ] `handlers/epic_sub_issues.ts` is ≤80 lines after promoting parsers; no platform branching; no direct subprocess [R-05, R-09, R-10]
+- [ ] Parsers extracted to `lib/epic-sub-issues-parser.ts` if needed; colocated tests live alongside
+- [ ] `fetchBody` removed
+- [ ] Removed from allowlist
+- [ ] Integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+#### Story 2.7: Migrate `dod_load_manifest` + close #283 (cross-repo GitLab gap)
+
+**Wave:** 2.3
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Story 2.1
+
+Migrate `dod_load_manifest` to consume `fetchIssue`. **Close #283 in the same PR:** today the cross-repo `ISSUE_REF` branch fires only when `platform === 'github'`, leaving GitLab silently broken for `org/project#N` manifest refs; migrating to `fetchIssue` (which accepts `repo` per its signature) closes the gap.
+
+**Implementation Steps:**
+
+1. Refactor `handlers/dod_load_manifest.ts` to call `getAdapter({repo}).fetchIssue(...)` — pass the parsed `repo` through so cross-repo refs on GitLab resolve correctly
+2. Delete the GitHub-only `m1` branch; the adapter dispatch handles both platforms uniformly
+3. Verify ≤80 lines (markdown manifest extraction promotes to `lib/dod-manifest-parser.ts` if needed)
+4. Remove from `scripts/ci/migration-allowlist.txt`
+5. Close #283 in PR body via `Closes #283`
+6. Add integration test: `org/project#N` manifest ref on GitLab resolves correctly (regression for #283)
+
+**Test Procedures:**
+
+*Unit Tests:*
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `dod-manifest-parser — reads cross-repo refs on GitLab` | Regression for #283 | `lib/dod-manifest-parser.test.ts` |
+| `dod-manifest-parser — reads cross-repo refs on GitHub (unchanged)` | Behavior preservation | `lib/dod-manifest-parser.test.ts` |
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+
+**Acceptance Criteria:**
+
+- [ ] `handlers/dod_load_manifest.ts` is ≤80 lines; no platform branching; no direct subprocess [R-05, R-09, R-10]
+- [ ] Cross-repo refs resolve on both GitHub and GitLab via `fetchIssue`
+- [ ] Regression test for #283 passes
+- [ ] Removed from allowlist
+- [ ] Issue #283 closed via PR
+- [ ] Integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+#### Story 2.8: Migrate `wave_compute`
+
+**Wave:** 2.3
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Story 2.1
+
+Migrate `wave_compute` to consume `fetchIssue`. All wave-computation, sub-issue parsing, dependency-parsing, and story-self-fallback logic stays in the handler (~300 LoC of platform-agnostic orchestration).
+
+**Implementation Steps:**
+
+1. Refactor `handlers/wave_compute.ts` to call `getAdapter({repo}).fetchIssue(...)` where the handler currently imports its local `fetchIssue`
+2. Delete handler-local `fetchIssue` helper
+3. Verify handler ≤80 lines is not expected (wave-computation exceeds); promote wave-computation to `lib/wave-compute.ts` if needed
+4. Remove from `scripts/ci/migration-allowlist.txt`
+5. Preserve integration tests unchanged
+
+**Test Procedures:**
+
+*Unit Tests:* none new if wave-computation stays in handler; if promoted to `lib/`, colocate unit tests for the moved functions.
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+
+**Acceptance Criteria:**
+
+- [ ] `handlers/wave_compute.ts` is ≤80 lines after promoting wave-computation to `lib/` if needed; no platform branching; no direct subprocess [R-05, R-09, R-10]
+- [ ] Handler-local `fetchIssue` removed
+- [ ] Removed from allowlist
+- [ ] Integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+#### Story 2.9: Migrate `wave_dependency_graph`
+
+**Wave:** 2.3
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Story 2.1
+
+Migrate `wave_dependency_graph` to consume `fetchIssue`. Dependency-parsing logic stays (near-duplicate of `wave_compute`'s; a future refactor could share — not part of this story).
+
+**Implementation Steps:**
+
+1. Refactor `handlers/wave_dependency_graph.ts` to call `getAdapter({repo}).fetchIssue(...)`
+2. Delete handler-local `fetchIssue`
+3. Verify ≤80 lines (promote graph logic to `lib/wave-dependency-graph.ts` if needed)
+4. Remove from `scripts/ci/migration-allowlist.txt`
+5. Preserve integration tests unchanged
+
+**Test Procedures:**
+
+*Unit Tests:* none new.
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+
+**Acceptance Criteria:**
+
+- [ ] Handler ≤80 lines; no platform branching; no direct subprocess [R-05, R-09, R-10]
+- [ ] `fetchIssue` removed
+- [ ] Removed from allowlist
+- [ ] Integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+#### Story 2.10: Migrate `wave_topology`
+
+**Wave:** 2.3
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Story 2.1
+
+Migrate `wave_topology` to consume `fetchIssue`. Same shape as `wave_dependency_graph`.
+
+**Implementation Steps:**
+
+1. Refactor `handlers/wave_topology.ts` to call `getAdapter({repo}).fetchIssue(...)`
+2. Delete handler-local `fetchIssue`
+3. Verify ≤80 lines
+4. Remove from `scripts/ci/migration-allowlist.txt`
+5. Preserve integration tests unchanged
+
+**Test Procedures:**
+
+*Unit Tests:* none new.
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+
+**Acceptance Criteria:**
+
+- [ ] Handler ≤80 lines; no platform branching; no direct subprocess [R-05, R-09, R-10]
+- [ ] `fetchIssue` removed
+- [ ] Removed from allowlist
+- [ ] Integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+#### Story 2.11: Migrate `ci_failed_jobs` (full-migration)
+
+**Wave:** 2.4
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Phase 2 Wave 2.0, 2.1 (foundational); no inter-Wave 2.4 deps
+
+Full-migration: lift entire handler into adapter pair. The handler is a thin platform wrapper around `gh run view --json jobs` / `glab api projects/:id/pipelines/<id>/jobs` with identical `FailedJob[]` normalization.
+
+**Implementation Steps:**
+
+1. Add `ciFailedJobs(args: { run_id: string, repo?: string }): Promise<AdapterResult<{ failed_jobs: FailedJob[] }>>` to `PlatformAdapter` in `lib/adapters/types.ts`
+2. Create `lib/adapters/ci-failed-jobs-github.ts` — lift `fetchGithubFailedJobs` logic
+3. Create `lib/adapters/ci-failed-jobs-gitlab.ts` — lift `fetchGitlabFailedJobs` logic
+4. Wire into `lib/adapters/{github,gitlab}.ts` assemblers
+5. Add `'ciFailedJobs'` to `MIGRATED_METHODS`
+6. Refactor `handlers/ci_failed_jobs.ts` to ~40 lines: validate + dispatch + envelope
+7. Move subprocess-boundary mocks from `tests/ci_failed_jobs.test.ts` into colocated adapter test files; preserve integration tests
+8. Remove from `scripts/ci/migration-allowlist.txt`
+
+**Test Procedures:**
+
+*Unit Tests:*
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `ci-failed-jobs-github — argv: gh run view <id> --json jobs` | Subprocess-boundary mock | `lib/adapters/ci-failed-jobs-github.test.ts` |
+| `ci-failed-jobs-github — normalizes failed jobs` | Output parsing | `lib/adapters/ci-failed-jobs-github.test.ts` |
+| `ci-failed-jobs-github — returns AdapterResult.error on gh failure` | Error-path | `lib/adapters/ci-failed-jobs-github.test.ts` |
+| `ci-failed-jobs-gitlab — argv: glab api projects/:id/pipelines/<id>/jobs` | Subprocess-boundary mock | `lib/adapters/ci-failed-jobs-gitlab.test.ts` |
+| `ci-failed-jobs-gitlab — normalizes failed jobs` | Output parsing | `lib/adapters/ci-failed-jobs-gitlab.test.ts` |
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+
+**Acceptance Criteria:**
+
+- [ ] `PlatformAdapter.ciFailedJobs` signature added [R-01]
+- [ ] `lib/adapters/ci-failed-jobs-{github,gitlab}.ts` both exist; return `AdapterResult<FailedJobsResponse>` [R-05]
+- [ ] `handlers/ci_failed_jobs.ts` ≤80 lines; no platform branching; no direct subprocess [R-05, R-09, R-10]
+- [ ] Removed from allowlist
+- [ ] Colocated tests added [R-15]
+- [ ] `'ciFailedJobs'` in `MIGRATED_METHODS` [R-04]
+- [ ] Integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+#### Story 2.12: Migrate `ci_run_logs` (full-migration)
+
+**Wave:** 2.4
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Phase 2 Wave 2.0, 2.1
+
+Full-migration: `fetchGithub()` (gh run view --log / --log-failed) vs `fetchGitlab()` (glab api to find failed job + glab ci trace). `truncateLogs()` helper is platform-agnostic; extract to `lib/shared/truncate-logs.ts`.
+
+**Implementation Steps:**
+
+1. Add `ciRunLogs(args: { run_id: string, failed_only: boolean, repo?: string }): Promise<AdapterResult<{ logs: string, job_id?: string, url: string }>>` to `PlatformAdapter`
+2. Extract `truncateLogs` to `lib/shared/truncate-logs.ts` with colocated test
+3. Create `lib/adapters/ci-run-logs-{github,gitlab}.ts`
+4. Wire into assemblers
+5. Add to `MIGRATED_METHODS`
+6. Refactor `handlers/ci_run_logs.ts` to ~50 lines; the truncation step composes against the adapter response
+7. Move subprocess-boundary mocks into adapter tests; preserve integration tests
+8. Remove from `scripts/ci/migration-allowlist.txt`
+
+**Test Procedures:**
+
+*Unit Tests:*
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `ci-run-logs-github — argv: gh run view <id> --log / --log-failed` | Subprocess-boundary mock | `lib/adapters/ci-run-logs-github.test.ts` |
+| `ci-run-logs-github — returns AdapterResult with logs + url` | Output parsing | `lib/adapters/ci-run-logs-github.test.ts` |
+| `ci-run-logs-gitlab — argv: glab api + glab ci trace` | Subprocess-boundary mock | `lib/adapters/ci-run-logs-gitlab.test.ts` |
+| `ci-run-logs-gitlab — resolves failed job then fetches trace` | Two-step flow | `lib/adapters/ci-run-logs-gitlab.test.ts` |
+| `shared/truncate-logs — truncates to configured limit, preserves tail` | Behavior preservation | `lib/shared/truncate-logs.test.ts` |
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+
+**Acceptance Criteria:**
+
+- [ ] `PlatformAdapter.ciRunLogs` signature added [R-01]
+- [ ] `lib/adapters/ci-run-logs-{github,gitlab}.ts` exist [R-05]
+- [ ] `lib/shared/truncate-logs.ts` extracted; imported by handler [R-17]
+- [ ] `handlers/ci_run_logs.ts` ≤80 lines; no platform branching; no direct subprocess [R-05, R-09, R-10]
+- [ ] Removed from allowlist
+- [ ] Colocated tests added [R-15]
+- [ ] `'ciRunLogs'` in `MIGRATED_METHODS` [R-04]
+- [ ] Integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+#### Story 2.13: Migrate `ci_run_status` (full-migration)
+
+**Wave:** 2.4
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Phase 2 Wave 2.0, 2.1
+
+Full-migration: `ghQueryRuns` / `glQueryRuns` + `normalizeGh` / `normalizeGl` status-enum mapping. Enum mapping belongs with each platform adapter (platform-shape-to-normalized-shape glue).
+
+**Implementation Steps:**
+
+1. Add `ciRunStatus(args: { ref: string, workflow_name?: string, repo?: string }): Promise<AdapterResult<NormalizedRun | null>>` to `PlatformAdapter`
+2. Create `lib/adapters/ci-run-status-{github,gitlab}.ts` — lift platform query + normalization
+3. Move `gitlabApiCiList` call from `lib/glab.ts` into `ci-run-status-gitlab.ts` (consistent with R-16; `lib/glab.ts` deletion in Phase 3 Story 3.1)
+4. Wire into assemblers; add to `MIGRATED_METHODS`
+5. Refactor `handlers/ci_run_status.ts` to ~40 lines
+6. Move subprocess-boundary mocks; preserve integration tests
+7. Remove from `scripts/ci/migration-allowlist.txt`
+
+**Test Procedures:**
+
+*Unit Tests:*
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `ci-run-status-github — argv + normalization for success/failure/in-progress` | Full enum coverage | `lib/adapters/ci-run-status-github.test.ts` |
+| `ci-run-status-github — null return when no matching run` | Empty-result path | `lib/adapters/ci-run-status-github.test.ts` |
+| `ci-run-status-gitlab — argv + normalization` | Full enum coverage | `lib/adapters/ci-run-status-gitlab.test.ts` |
+| `ci-run-status-gitlab — null return` | Empty-result path | `lib/adapters/ci-run-status-gitlab.test.ts` |
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+
+**Acceptance Criteria:**
+
+- [ ] `PlatformAdapter.ciRunStatus` signature added [R-01]
+- [ ] `lib/adapters/ci-run-status-{github,gitlab}.ts` exist [R-05]
+- [ ] `handlers/ci_run_status.ts` ≤80 lines; no platform branching; no direct subprocess [R-05, R-09, R-10]
+- [ ] Removed from allowlist
+- [ ] Colocated tests added [R-15]
+- [ ] `'ciRunStatus'` in `MIGRATED_METHODS` [R-04]
+- [ ] Integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+#### Story 2.14: Migrate `ci_runs_for_branch` (full-migration)
+
+**Wave:** 2.4
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Phase 2 Wave 2.0, 2.1
+
+Full-migration: `githubStatusFlag` / `gitlabStatusFlag` translation + platform list queries + platform normalization.
+
+**Implementation Steps:**
+
+1. Add `ciRunsForBranch(args: { branch: string, limit?: number, status?: 'in_progress'|'completed'|'queued'|'all', repo?: string }): Promise<AdapterResult<{ runs: RunRecord[] }>>` to `PlatformAdapter`
+2. Create `lib/adapters/ci-runs-for-branch-{github,gitlab}.ts` — lift the status-flag translation and queries
+3. Wire into assemblers; add to `MIGRATED_METHODS`
+4. Refactor `handlers/ci_runs_for_branch.ts` to ~40 lines
+5. Move subprocess-boundary mocks; preserve integration tests
+6. Remove from `scripts/ci/migration-allowlist.txt`
+
+**Test Procedures:**
+
+*Unit Tests:*
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `ci-runs-for-branch-github — argv for each status flag` | Status flag translation | `lib/adapters/ci-runs-for-branch-github.test.ts` |
+| `ci-runs-for-branch-github — normalizes response` | Output parsing | `lib/adapters/ci-runs-for-branch-github.test.ts` |
+| `ci-runs-for-branch-gitlab — argv for each status flag` | Status flag translation | `lib/adapters/ci-runs-for-branch-gitlab.test.ts` |
+| `ci-runs-for-branch-gitlab — normalizes response` | Output parsing | `lib/adapters/ci-runs-for-branch-gitlab.test.ts` |
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+
+**Acceptance Criteria:**
+
+- [ ] `PlatformAdapter.ciRunsForBranch` signature added [R-01]
+- [ ] `lib/adapters/ci-runs-for-branch-{github,gitlab}.ts` exist [R-05]
+- [ ] `handlers/ci_runs_for_branch.ts` ≤80 lines; no platform branching; no direct subprocess [R-05, R-09, R-10]
+- [ ] Removed from allowlist
+- [ ] Colocated tests added [R-15]
+- [ ] `'ciRunsForBranch'` in `MIGRATED_METHODS` [R-04]
+- [ ] Integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+#### Story 2.15: Migrate `label_create` (full-migration)
+
+**Wave:** 2.5
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Phase 2 Wave 2.0, 2.1
+
+Full-migration: create-with-idempotent-duplicate-fallback. Platform-specific color normalization (`#RRGGBB` vs bare hex) lives inside each adapter per `lesson_origin_ops_pitfalls.md`.
+
+**Implementation Steps:**
+
+1. Add `labelCreate(args: { name: string, color?: string, description?: string, repo?: string }): Promise<AdapterResult<NormalizedLabel>>` to `PlatformAdapter`
+2. Create `lib/adapters/label-create-{github,gitlab}.ts` — lift `createGithubLabel` + `lookupGithubLabel` fallback / `createGitlabLabel` + `lookupGitlabLabel` fallback
+3. Adapter internalizes the duplicate-lookup retry
+4. Wire into assemblers; add to `MIGRATED_METHODS`
+5. Refactor `handlers/label_create.ts` to ~40 lines
+6. Adapter test stubs MUST fail loudly on wrong argv (gh accepts `#RRGGBB` bare; glab requires leading `#` — per `lesson_origin_ops_pitfalls.md`)
+7. Move subprocess-boundary mocks; preserve integration tests
+8. Remove from `scripts/ci/migration-allowlist.txt`
+
+**Test Procedures:**
+
+*Unit Tests:*
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `label-create-github — argv: gh label create (bare-hex color)` | Subprocess-boundary, argv strictness | `lib/adapters/label-create-github.test.ts` |
+| `label-create-github — duplicate-lookup fallback on "already exists"` | Idempotency | `lib/adapters/label-create-github.test.ts` |
+| `label-create-gitlab — argv: glab api ... (leading-# color)` | Subprocess-boundary, argv strictness | `lib/adapters/label-create-gitlab.test.ts` |
+| `label-create-gitlab — duplicate-lookup fallback` | Idempotency | `lib/adapters/label-create-gitlab.test.ts` |
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+
+**Acceptance Criteria:**
+
+- [ ] `PlatformAdapter.labelCreate` signature added [R-01]
+- [ ] `lib/adapters/label-create-{github,gitlab}.ts` exist [R-05]
+- [ ] Color format enforced per platform (bare-hex GitHub, leading-# GitLab); stubs fail loudly on wrong format
+- [ ] `handlers/label_create.ts` ≤80 lines; no platform branching; no direct subprocess [R-05, R-09, R-10]
+- [ ] Removed from allowlist
+- [ ] Colocated tests added [R-15]
+- [ ] `'labelCreate'` in `MIGRATED_METHODS` [R-04]
+- [ ] Integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+#### Story 2.16: Migrate `label_list` (full-migration)
+
+**Wave:** 2.5
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Phase 2 Wave 2.0, 2.1
+
+Full-migration: smallest handler in the survey (~108 LoC). Trivial lift with color normalization to bare hex in adapter.
+
+**Implementation Steps:**
+
+1. Add `labelList(args: { repo?: string }): Promise<AdapterResult<{ labels: NormalizedLabel[], count: number }>>` to `PlatformAdapter`
+2. Create `lib/adapters/label-list-{github,gitlab}.ts` — lift `listGithubLabels` / `listGitlabLabels`
+3. Normalize color to bare hex inside each adapter
+4. Wire into assemblers; add to `MIGRATED_METHODS`
+5. Refactor `handlers/label_list.ts` to ~30 lines
+6. Move subprocess-boundary mocks; preserve integration tests
+7. Remove from `scripts/ci/migration-allowlist.txt`
+
+**Test Procedures:**
+
+*Unit Tests:*
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `label-list-github — argv + normalization` | Subprocess-boundary + output | `lib/adapters/label-list-github.test.ts` |
+| `label-list-gitlab — argv + normalization` | Subprocess-boundary + output | `lib/adapters/label-list-gitlab.test.ts` |
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+
+**Acceptance Criteria:**
+
+- [ ] `PlatformAdapter.labelList` signature added [R-01]
+- [ ] `lib/adapters/label-list-{github,gitlab}.ts` exist [R-05]
+- [ ] `handlers/label_list.ts` ≤80 lines; no platform branching; no direct subprocess [R-05, R-09, R-10]
+- [ ] Removed from allowlist
+- [ ] Colocated tests added [R-15]
+- [ ] `'labelList'` in `MIGRATED_METHODS` [R-04]
+- [ ] Integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+#### Story 2.17: Migrate `work_item` (full-migration) + close #281
+
+**Wave:** 2.5
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Phase 2 Wave 2.0, 2.1
+
+Full-migration: today the handler dispatches to one of four create functions (`createGithubIssue` / `createGitlabIssue` / `createGithubPR` / `createGitlabMR`) based on `args.type` with a bug — `createGithubPR` runs on GitLab when `type: 'pr'`, `createGitlabMR` runs on GitHub when `type: 'mr'`. Migration collapses dispatch into one `workItem` adapter method that picks the right gh/glab subcommand internally AND closes #281 with typed asymmetry.
+
+**Implementation Steps:**
+
+1. Add `workItem(args: { type: 'epic'|'story'|'feature'|'chore'|'docs'|'fix'|'pr'|'mr', title: string, body?: string, labels?: string[], head_branch?: string, base_branch?: string, draft?: boolean, repo?: string }): Promise<AdapterResult<{ url: string, number: number }>>` to `PlatformAdapter`
+2. Create `lib/adapters/work-item-github.ts` — `type: 'mr'` returns `{platform_unsupported: true, hint: 'use type="pr" on GitHub'}`; `type: 'pr'` creates a PR; other types create an issue
+3. Create `lib/adapters/work-item-gitlab.ts` — `type: 'pr'` returns `{platform_unsupported: true, hint: 'use type="mr" on GitLab'}`; `type: 'mr'` creates an MR; other types create an issue
+4. Wire into assemblers; add to `MIGRATED_METHODS`
+5. Refactor `handlers/work_item.ts` to ~50 lines: validate + dispatch + envelope
+6. Close #281 in PR body via `Closes #281`
+7. Add regression test for #281: `work_item({type:'pr', ...})` on a GitLab project returns `platform_unsupported` with hint; same for `type:'mr'` on GitHub
+
+**Test Procedures:**
+
+*Unit Tests:*
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `work-item-github — type:'pr' creates PR via gh pr create` | Happy path | `lib/adapters/work-item-github.test.ts` |
+| `work-item-github — type:'mr' returns platform_unsupported` | Regression for #281 | `lib/adapters/work-item-github.test.ts` |
+| `work-item-github — issue types create via gh issue create` | Happy path | `lib/adapters/work-item-github.test.ts` |
+| `work-item-gitlab — type:'mr' creates MR via glab mr create` | Happy path | `lib/adapters/work-item-gitlab.test.ts` |
+| `work-item-gitlab — type:'pr' returns platform_unsupported` | Regression for #281 | `lib/adapters/work-item-gitlab.test.ts` |
+| `work-item-gitlab — issue types create via glab issue create` | Happy path | `lib/adapters/work-item-gitlab.test.ts` |
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+
+**Acceptance Criteria:**
+
+- [ ] `PlatformAdapter.workItem` signature added [R-01]
+- [ ] `lib/adapters/work-item-{github,gitlab}.ts` exist with typed `platform_unsupported` return for cross-platform type [R-03]
+- [ ] `handlers/work_item.ts` ≤80 lines; no platform branching; no direct subprocess [R-05, R-09, R-10]
+- [ ] Removed from allowlist
+- [ ] Colocated tests added including #281 regressions [R-15]
+- [ ] `'workItem'` in `MIGRATED_METHODS` [R-04]
+- [ ] Issue #281 closed via PR
+- [ ] Integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+#### Story 2.18: Migrate `ibm` (+ land `fetchPrForBranch` sub-call)
+
+**Wave:** 2.6
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Phase 2 Wave 2.0, 2.1
+
+Hybrid migration: branch-name parsing, protected-branch check, branch-to-issue-number extraction stay in the handler. Two sub-calls are platform-specific: `fetchIssue` (already shipped, Story 2.1) and `fetchPrForBranch` (new).
+
+**Implementation Steps:**
+
+1. Add `fetchPrForBranch(args: { branch: string, state?: 'open'|'closed'|'merged'|'all', repo?: string }): Promise<AdapterResult<{ url: string, number: number } | null>>` to `PlatformAdapter`
+2. Create `lib/adapters/fetch-pr-for-branch-{github,gitlab}.ts` — GitHub uses `gh pr list --head <branch> --state <state> --json url,number`; GitLab uses `glab mr list --source-branch <branch>` with state filter
+3. Wire into assemblers; add `'fetchPrForBranch'` to `MIGRATED_METHODS`
+4. Refactor `handlers/ibm.ts` to call `getAdapter({repo}).fetchIssue(...)` and `getAdapter({repo}).fetchPrForBranch(...)`
+5. Delete handler-local `findOpenPr` helper
+6. Verify `handlers/ibm.ts` ≤80 lines; no platform branching; no direct subprocess
+7. Remove from `scripts/ci/migration-allowlist.txt`
+
+**Test Procedures:**
+
+*Unit Tests:*
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `fetch-pr-for-branch-github — argv + state filter` | Subprocess-boundary + state translation | `lib/adapters/fetch-pr-for-branch-github.test.ts` |
+| `fetch-pr-for-branch-github — null when no matching PR` | Empty-result path | `lib/adapters/fetch-pr-for-branch-github.test.ts` |
+| `fetch-pr-for-branch-gitlab — argv + state filter` | Subprocess-boundary + state translation | `lib/adapters/fetch-pr-for-branch-gitlab.test.ts` |
+| `fetch-pr-for-branch-gitlab — null when no matching MR` | Empty-result path | `lib/adapters/fetch-pr-for-branch-gitlab.test.ts` |
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+
+**Acceptance Criteria:**
+
+- [ ] `PlatformAdapter.fetchPrForBranch` signature added [R-01]
+- [ ] `lib/adapters/fetch-pr-for-branch-{github,gitlab}.ts` exist [R-05]
+- [ ] `handlers/ibm.ts` ≤80 lines; no platform branching; no direct subprocess [R-05, R-09, R-10]
+- [ ] Handler-local `findOpenPr` removed
+- [ ] Removed from allowlist
+- [ ] Colocated tests added [R-15]
+- [ ] `'fetchPrForBranch'` in `MIGRATED_METHODS` [R-04]
+- [ ] Integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+#### Story 2.19: Migrate `ci_wait_run` (+ land `ciListRuns` + `resolveBranchSha` sub-calls)
+
+**Wave:** 2.6
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Story 2.18
+
+Hybrid migration: owner of the non-platform polling loop (Phase 0 merge-queue pre-flight, Phase 1 no-run-yet window, Phase 2 poll-until-completed, Phase 3 conclusion normalization). Polling loop stays in the handler or moves to `lib/ci-wait-run-poll.ts`. Platform surface: `ciListRuns` + `resolveBranchSha` (GitHub-only with typed asymmetry on GitLab).
+
+**Implementation Steps:**
+
+1. Add `ciListRuns(args: { ref: string, workflow_name?: string, repo?: string, expected_sha?: string, limit: number }): Promise<AdapterResult<NormalizedRun[]>>` to `PlatformAdapter` (response shape must include `event` for `merge_group` detection and `head_sha` for defense-in-depth filter; GitLab returns `event: null`)
+2. Add `resolveBranchSha(args: { branch: string, repo?: string }): Promise<AdapterResult<{ sha: string } | null>>` to `PlatformAdapter` — nullable return on missing branch; collapses `fetchBranchSha` into a single signature per §4-row-8 resolution from the survey
+3. Create `lib/adapters/ci-list-runs-{github,gitlab}.ts` (lift `fetchGithubRuns` / `fetchGitlabPipelines`)
+4. Create `lib/adapters/resolve-branch-sha-{github,gitlab}.ts` — GitHub: `gh api repos/<slug>/branches/<b> --jq .commit.sha`; GitLab: `{platform_unsupported: true, hint: 'branch→SHA not needed — GitLab CI pipelines attach to branch names directly'}` [R-03]
+5. Wire into assemblers; add both methods to `MIGRATED_METHODS`
+6. Extract polling loop to `lib/ci-wait-run-poll.ts` (peer of `lib/pr-merge-wait-poll.ts`) with colocated test
+7. Refactor `handlers/ci_wait_run.ts` to ~50 lines: validate + dispatch to polling loop + envelope
+8. Remove from `scripts/ci/migration-allowlist.txt`
+
+**Test Procedures:**
+
+*Unit Tests:*
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `ci-list-runs-github — argv + response shape includes event, head_sha` | Subprocess-boundary + shape | `lib/adapters/ci-list-runs-github.test.ts` |
+| `ci-list-runs-github — filters by expected_sha` | Argv translation | `lib/adapters/ci-list-runs-github.test.ts` |
+| `ci-list-runs-gitlab — event null; head_sha populated` | GitLab shape | `lib/adapters/ci-list-runs-gitlab.test.ts` |
+| `resolve-branch-sha-github — argv: gh api ... --jq` | Subprocess-boundary | `lib/adapters/resolve-branch-sha-github.test.ts` |
+| `resolve-branch-sha-github — null on missing branch` | Error-path | `lib/adapters/resolve-branch-sha-github.test.ts` |
+| `resolve-branch-sha-gitlab — platform_unsupported with hint` | Typed asymmetry [R-03] | `lib/adapters/resolve-branch-sha-gitlab.test.ts` |
+| `ci-wait-run-poll — polling loop honors timeout + two-phase window` | Polling correctness | `lib/ci-wait-run-poll.test.ts` |
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+
+**Acceptance Criteria:**
+
+- [ ] `PlatformAdapter.ciListRuns` + `PlatformAdapter.resolveBranchSha` added [R-01]
+- [ ] `lib/adapters/ci-list-runs-{github,gitlab}.ts` + `lib/adapters/resolve-branch-sha-{github,gitlab}.ts` all exist [R-05]
+- [ ] GitLab `resolveBranchSha` returns `platform_unsupported` [R-03]
+- [ ] `handlers/ci_wait_run.ts` ≤80 lines; polling loop extracted to `lib/ci-wait-run-poll.ts` [R-05, R-09, R-10]
+- [ ] Removed from allowlist
+- [ ] Colocated tests added [R-15]
+- [ ] `'ciListRuns'`, `'resolveBranchSha'` in `MIGRATED_METHODS` [R-04]
+- [ ] Integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+#### Story 2.20: Migrate `wave_previous_merged` (+ land `fetchIssueClosure` sub-call)
+
+**Wave:** 2.6
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Story 2.19
+
+Hybrid migration: state-file parsing + deferral filtering stays. Platform surface is the GitHub GraphQL query for `closedByPullRequestsReferences`/`timelineItems` and the GitLab state-only closure fetch.
+
+**Implementation Steps:**
+
+1. Add `fetchIssueClosure(args: { number: number, repo?: string }): Promise<AdapterResult<{ state: 'OPEN'|'CLOSED', closedByMergedPR: boolean }>>` to `PlatformAdapter`
+2. Create `lib/adapters/fetch-issue-closure-github.ts` — existing GraphQL query verbatim
+3. Create `lib/adapters/fetch-issue-closure-gitlab.ts` — `gitlabApiIssue()` state-only rule per current handler comment
+4. Wire into assemblers; add to `MIGRATED_METHODS`
+5. Refactor `handlers/wave_previous_merged.ts` to call `getAdapter({repo}).fetchIssueClosure(...)`
+6. Delete handler-local `queryIssueClosure` helper
+7. Verify ≤80 lines; remove from allowlist
+
+**Test Procedures:**
+
+*Unit Tests:*
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `fetch-issue-closure-github — GraphQL query argv` | Subprocess-boundary | `lib/adapters/fetch-issue-closure-github.test.ts` |
+| `fetch-issue-closure-github — closedByMergedPR:true when closing PR is merged` | Output parsing | `lib/adapters/fetch-issue-closure-github.test.ts` |
+| `fetch-issue-closure-github — closedByMergedPR:false when closed without PR` | Edge case | `lib/adapters/fetch-issue-closure-github.test.ts` |
+| `fetch-issue-closure-gitlab — argv via gitlabApiIssue + state translation` | Subprocess-boundary | `lib/adapters/fetch-issue-closure-gitlab.test.ts` |
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+
+**Acceptance Criteria:**
+
+- [ ] `PlatformAdapter.fetchIssueClosure` signature added [R-01]
+- [ ] `lib/adapters/fetch-issue-closure-{github,gitlab}.ts` exist [R-05]
+- [ ] `handlers/wave_previous_merged.ts` ≤80 lines; no platform branching; no direct subprocess [R-05, R-09, R-10]
+- [ ] Handler-local `queryIssueClosure` removed
+- [ ] Removed from allowlist
+- [ ] Colocated tests added [R-15]
+- [ ] `'fetchIssueClosure'` in `MIGRATED_METHODS` [R-04]
+- [ ] Integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+#### Story 2.21: Migrate `wave_reconcile_mrs` (+ land `findMergedPrForBranchPrefix` sub-call) + address #282
+
+**Wave:** 2.6
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Story 2.20
+
+Hybrid migration: state read + per-issue branch-prefix search + `wave-status record-mr` shell-out. Platform surface: prefix-match search. **Addresses #282:** the 50-item client-side scan cap is a known limitation — adapter uses a configurable `limit` argument (default 100; wave caller passes through) and documents the fallback in `docs/adapters/README.md` (Phase 3 Story 3.3).
+
+**Implementation Steps:**
+
+1. Add `findMergedPrForBranchPrefix(args: { prefix: string, limit?: number, repo?: string }): Promise<AdapterResult<{ url: string } | null>>` to `PlatformAdapter`
+2. Create `lib/adapters/find-merged-pr-for-branch-prefix-{github,gitlab}.ts` — lift `queryGithubMergedPrs` / `queryGitlabMergedMrs`; use `limit` arg (default 100) instead of hardcoded 50
+3. Wire into assemblers; add to `MIGRATED_METHODS`
+4. Refactor `handlers/wave_reconcile_mrs.ts` to call the adapter
+5. Handler passes `limit` from caller or uses default 100 (addresses the scan-cap concern; documented in adapter README Phase 3)
+6. Delete handler-local query helpers
+7. Verify ≤80 lines; remove from allowlist
+8. Close #282 in PR body via `Closes #282` (addressed via larger limit + documented fallback)
+
+**Test Procedures:**
+
+*Unit Tests:*
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `find-merged-pr-for-branch-prefix-github — argv + prefix filter` | Subprocess-boundary | `lib/adapters/find-merged-pr-for-branch-prefix-github.test.ts` |
+| `find-merged-pr-for-branch-prefix-github — honors limit arg` | Cap configurability | `lib/adapters/find-merged-pr-for-branch-prefix-github.test.ts` |
+| `find-merged-pr-for-branch-prefix-github — null when no match within limit` | Fallback return | `lib/adapters/find-merged-pr-for-branch-prefix-github.test.ts` |
+| `find-merged-pr-for-branch-prefix-gitlab — argv + prefix filter` | Subprocess-boundary | `lib/adapters/find-merged-pr-for-branch-prefix-gitlab.test.ts` |
+| `find-merged-pr-for-branch-prefix-gitlab — honors limit arg` | Cap configurability | `lib/adapters/find-merged-pr-for-branch-prefix-gitlab.test.ts` |
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+
+**Acceptance Criteria:**
+
+- [ ] `PlatformAdapter.findMergedPrForBranchPrefix` signature added [R-01]
+- [ ] `lib/adapters/find-merged-pr-for-branch-prefix-{github,gitlab}.ts` exist [R-05]
+- [ ] Limit arg honored; default 100 (was hardcoded 50) [bug #282]
+- [ ] `handlers/wave_reconcile_mrs.ts` ≤80 lines; no platform branching; no direct subprocess [R-05, R-09, R-10]
+- [ ] Removed from allowlist
+- [ ] Colocated tests added [R-15]
+- [ ] `'findMergedPrForBranchPrefix'` in `MIGRATED_METHODS` [R-04]
+- [ ] Issue #282 closed via PR
+- [ ] Integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+#### Story 2.22: Migrate `wave_init` (+ land `createBranch` sub-call; reuses `resolveBranchSha`)
+
+**Wave:** 2.6
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Story 2.21
+
+Hybrid migration: state.json writes + `wave-status` CLI shell-out stay. Platform surface is the KAHUNA branch bootstrap: read `main` HEAD SHA (reuses `resolveBranchSha` from Story 2.19) + create branch (new `createBranch` sub-call).
+
+**Implementation Steps:**
+
+1. Add `createBranch(args: { branch: string, sha: string, repo?: string }): Promise<AdapterResult<void>>` to `PlatformAdapter`
+2. Create `lib/adapters/create-branch-{github,gitlab}.ts` — GitHub: `gh api .../git/refs -X POST`; GitLab: `glab api projects/:id/repository/branches -X POST`
+3. Wire into assemblers; add to `MIGRATED_METHODS`
+4. Refactor `handlers/wave_init.ts` to call `resolveBranchSha('main')` + `createBranch(name, sha)`
+5. Delete handler-local `readMainSha` + `createKahunaBranch` helpers
+6. `branchExistsOnRemote()` uses `git ls-remote` — stays in `lib/shared/git-remote.ts` (extract if still inline)
+7. Verify ≤80 lines; remove from allowlist
+
+**Test Procedures:**
+
+*Unit Tests:*
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `create-branch-github — argv: gh api .../git/refs POST` | Subprocess-boundary | `lib/adapters/create-branch-github.test.ts` |
+| `create-branch-github — void return on success` | Response shape | `lib/adapters/create-branch-github.test.ts` |
+| `create-branch-gitlab — argv: glab api branches POST` | Subprocess-boundary | `lib/adapters/create-branch-gitlab.test.ts` |
+| `create-branch-gitlab — void return on success` | Response shape | `lib/adapters/create-branch-gitlab.test.ts` |
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+
+**Acceptance Criteria:**
+
+- [ ] `PlatformAdapter.createBranch` signature added [R-01]
+- [ ] `lib/adapters/create-branch-{github,gitlab}.ts` exist [R-05]
+- [ ] `handlers/wave_init.ts` ≤80 lines; no platform branching; no direct subprocess [R-05, R-09, R-10]
+- [ ] Handler-local `readMainSha` + `createKahunaBranch` removed
+- [ ] `branchExistsOnRemote` in `lib/shared/git-remote.ts` (if it wasn't already)
+- [ ] Removed from allowlist
+- [ ] Colocated tests added [R-15]
+- [ ] `'createBranch'` in `MIGRATED_METHODS` [R-04]
+- [ ] Integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+#### Story 2.23: Migrate `wave_finalize` (+ land `findExistingPr` sub-call; reuses `prCreate`)
+
+**Wave:** 2.6
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Story 2.22
+
+Hybrid migration: 509 LoC handler with artifact-tree walker, body composition, SHA hashing, idempotent find-or-create PR flow. Platform surface: `findExistingPr` (new) composed with `prCreate` (Phase 1).
+
+**Implementation Steps:**
+
+1. Add `findExistingPr(args: { head: string, base: string, state: 'open'|'closed'|'merged', repo?: string }): Promise<AdapterResult<NormalizedPr | null>>` to `PlatformAdapter`
+2. Create `lib/adapters/find-existing-pr-{github,gitlab}.ts` — generalizes today's `findExistingGithubPr` / `findExistingGitlabMr` with a state enum param
+3. Wire into assemblers; add to `MIGRATED_METHODS`
+4. Refactor `handlers/wave_finalize.ts` to compose `findExistingPr` with existing `prCreate` adapter (idempotent find-or-create)
+5. Promote `assembleBody` and SHA-hashing logic to `lib/wave-finalize.ts` if needed for ≤80-line target
+6. Delete handler-local `findExistingGithubPr` / `findExistingGitlabMr` helpers
+7. Remove from allowlist
+
+**Test Procedures:**
+
+*Unit Tests:*
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `find-existing-pr-github — argv + state filter` | Subprocess-boundary | `lib/adapters/find-existing-pr-github.test.ts` |
+| `find-existing-pr-github — null when no matching PR` | Empty-result | `lib/adapters/find-existing-pr-github.test.ts` |
+| `find-existing-pr-gitlab — argv + state filter` | Subprocess-boundary | `lib/adapters/find-existing-pr-gitlab.test.ts` |
+| `find-existing-pr-gitlab — null when no matching MR` | Empty-result | `lib/adapters/find-existing-pr-gitlab.test.ts` |
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+
+**Acceptance Criteria:**
+
+- [ ] `PlatformAdapter.findExistingPr` signature added [R-01]
+- [ ] `lib/adapters/find-existing-pr-{github,gitlab}.ts` exist [R-05]
+- [ ] `handlers/wave_finalize.ts` ≤80 lines (after promoting body-assembly helpers if needed); no platform branching; no direct subprocess [R-05, R-09, R-10]
+- [ ] Handler-local find helpers removed
+- [ ] Removed from allowlist
+- [ ] Colocated tests added [R-15]
+- [ ] `'findExistingPr'` in `MIGRATED_METHODS` [R-04]
+- [ ] Integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+#### Story 2.24: Migrate `wave_ci_trust_level` (+ land `fetchCiTrustSignal` sub-call; final migration)
+
+**Wave:** 2.6
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Story 2.23
+
+Hybrid migration (final Phase 2 story): platform-specific ruleset/branch-protection API calls vs GitLab `merge_trains_enabled` flag. Chose coarse-grained sub-call per survey §3.4 recommendation.
+
+**Implementation Steps:**
+
+1. Add `fetchCiTrustSignal(args: { repo?: string }): Promise<AdapterResult<{ level: 'pre_merge_authoritative'|'post_merge_required'|'unknown', reason: string }>>` to `PlatformAdapter`
+2. Create `lib/adapters/fetch-ci-trust-signal-github.ts` — runs ruleset + branch-protection queries; computes trust level
+3. Create `lib/adapters/fetch-ci-trust-signal-gitlab.ts` — uses `gitlabApiRepo()` for `merge_trains_enabled`; computes trust level
+4. Wire into assemblers; add to `MIGRATED_METHODS`
+5. Trust-level cache stays in `handlers/wave_ci_trust_level.ts`; adapter is cache-miss path
+6. Refactor handler to call the adapter on cache miss
+7. Verify ≤80 lines; remove from allowlist
+8. **Confirm `gitlabApi*` importers from `handlers/` tree are zero** — this is the last consumer; grep `handlers/ | grep gitlabApi` should return nothing. Cue for Phase 3 Story 3.1 `lib/glab.ts` deletion.
+
+**Test Procedures:**
+
+*Unit Tests:*
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `fetch-ci-trust-signal-github — ruleset API → pre_merge_authoritative` | Happy path | `lib/adapters/fetch-ci-trust-signal-github.test.ts` |
+| `fetch-ci-trust-signal-github — no ruleset → post_merge_required` | Fallback | `lib/adapters/fetch-ci-trust-signal-github.test.ts` |
+| `fetch-ci-trust-signal-gitlab — merge_trains_enabled:true → pre_merge_authoritative` | Happy path | `lib/adapters/fetch-ci-trust-signal-gitlab.test.ts` |
+| `fetch-ci-trust-signal-gitlab — merge_trains_enabled:false → post_merge_required` | Fallback | `lib/adapters/fetch-ci-trust-signal-gitlab.test.ts` |
+
+*Integration/E2E Coverage:*
+- IT-01, IT-04, IT-05 per template
+- Final grep: `grep -rE "gitlabApi" handlers/` returns zero lines
+
+**Acceptance Criteria:**
+
+- [ ] `PlatformAdapter.fetchCiTrustSignal` signature added [R-01]
+- [ ] `lib/adapters/fetch-ci-trust-signal-{github,gitlab}.ts` exist [R-05]
+- [ ] `handlers/wave_ci_trust_level.ts` ≤80 lines; no platform branching; no direct subprocess [R-05, R-09, R-10]
+- [ ] Trust-level cache preserved in handler
+- [ ] Removed from allowlist — **migration-allowlist.txt is now empty (0 handlers left to migrate)**
+- [ ] Colocated tests added [R-15]
+- [ ] `'fetchCiTrustSignal'` in `MIGRATED_METHODS` [R-04]
+- [ ] Zero `gitlabApi*` importers in `handlers/` tree (final-migration gate for Phase 3 Story 3.1)
+- [ ] Integration tests pass [R-11]
+- [ ] Gate-greps + contract test + full suite pass
+
+---
+
+### Phase 3: Cleanup, docs, release (Epic)
+
+**Goal:** Delete `lib/glab.ts`, write the adapter-architecture reference doc, supersede the origin-operations guide, tag v1.8.0, and execute the final manual verification gates (MV-05, MV-06) plus VRTM population.
+
+#### Phase 3 Definition of Done
+
+- [ ] `lib/glab.ts` deleted; zero importers in the tree [R-16]
+- [ ] `docs/adapters/README.md` exists; documents the `PlatformAdapter` contract, `AdapterResult<T>` shape, file layout, testing strategy, and "where to add a method" workflow [R-13]
+- [ ] `docs/handlers/origin-operations-guide.md` §2.4 rewritten with supersession note pointing to `docs/adapters/README.md` [R-14]
+- [ ] Root `README.md` has a new "Adapter architecture" section
+- [ ] `v1.8.0` tagged and released; `install-remote.sh` picks up the new binary
+- [ ] MV-05 executed and PASSED (grep handlers/ returns zero platform-branch + zero direct subprocess)
+- [ ] MV-06 executed and PASSED (`/precheck` + `/scpmmr` smoke tests on v1.8.0)
+- [ ] VRTM (Appendix V) populated with verification entries for all 17 requirements
+- [ ] `scripts/ci/migration-allowlist.txt` is empty or deleted (gate-greps now globally-applied to `handlers/`)
+- [ ] CHANGELOG / GitHub release notes on the v1.8.0 tag summarize the full retrofit
+- [ ] Full suite passes
+
+---
+
+### Wave Map (Phase 3)
+
+```
+PHASE 3 — Cleanup + docs + release
+───────────────────────────────────
+Wave 3.1  ─── Story 3.1: Delete lib/glab.ts
+                  │
+Wave 3.2  ─┬─ Story 3.2: Rewrite origin-operations-guide §2.4
+            └─ Story 3.3: Write docs/adapters/README.md         (2 parallel — disjoint docs)
+                  │
+Wave 3.3  ─── Story 3.4: Update root README.md
+                  │
+Wave 3.4  ─── Story 3.5: Tag v1.8.0 + release notes
+                  │
+Wave 3.5  ─── Story 3.6: Phase 3 closing — MV-05 + MV-06 + VRTM
+```
+
+| Wave | Stories | Master Issue | Parallel? |
+|------|---------|-------------|-----------|
+| 3.1 | 3.1 | Story 3.1 | Single story (deletion) |
+| 3.2 | 3.2, 3.3 | Wave 3.2 Master | Yes — 2 parallel |
+| 3.3 | 3.4 | Story 3.4 | Single story |
+| 3.4 | 3.5 | Story 3.5 | Single story (release) |
+| 3.5 | 3.6 | Story 3.6 | Single story (closing) |
+
+---
+
+#### Story 3.1: Delete `lib/glab.ts`
+
+**Wave:** 3.1
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Phase 2 complete (Story 2.24 confirmed zero `gitlabApi*` importers in `handlers/`)
+
+Remove `lib/glab.ts` — the `gitlabApi*` helpers it exports have been fully consumed by adapter migrations and have no remaining importers.
+
+**Implementation Steps:**
+
+1. Run `grep -rnE "from ['\"].*lib/glab['\"]|gitlabApi[A-Z]" lib/ handlers/` — confirm zero importers outside `lib/adapters/` (adapter files may still import for transitional reasons; this story resolves them)
+2. Move any remaining `gitlabApi*` helper implementations still needed by adapters into the relevant `lib/adapters/*-gitlab.ts` file, inlined
+3. Delete `lib/glab.ts`
+4. Remove `lib/glab.test.ts` if it exists
+5. Confirm `tsc --noEmit` passes
+6. Run full suite
+
+**Test Procedures:**
+
+*Unit Tests:* none new — existing adapter tests inherit the inlined helpers.
+
+*Integration/E2E Coverage:*
+- IT-04 — full suite passes post-deletion [R-11]
+- Direct grep: `grep -rn "lib/glab" .` returns zero hits
+
+**Acceptance Criteria:**
+
+- [ ] `lib/glab.ts` file absent [R-16]
+- [ ] `lib/glab.test.ts` absent (if it existed)
+- [ ] Zero importers of `lib/glab` across the repo
+- [ ] `tsc --noEmit` passes
+- [ ] Full suite passes [R-11]
+- [ ] Gate-greps + contract test pass
+
+---
+
+#### Story 3.2: Rewrite `docs/handlers/origin-operations-guide.md` §2.4 with supersession note
+
+**Wave:** 3.2
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Story 3.1
+
+Update the Origin Operations guide to reflect the new architecture. §2.4 previously documented the inline platform-branching convention; it must now point consumers to `docs/adapters/README.md` and flag that inline branching is gate-grep-enforced off-limits.
+
+**Implementation Steps:**
+
+1. Open `docs/handlers/origin-operations-guide.md` §2.4
+2. Replace the inline-convention prose with a short "Superseded — see `docs/adapters/README.md`" note that preserves section numbering but redirects to the new doc
+3. Add a summary: every new platform-aware operation now adds a method to `PlatformAdapter` interface + impls in both `lib/adapters/*-{github,gitlab}.ts` files; handlers must not branch on platform or shell out directly
+4. Cross-link to `scripts/ci/gate-greps.sh` with a note that CI enforces this
+
+**Test Procedures:**
+
+*Unit Tests:* none (docs-only).
+
+*Integration/E2E Coverage:*
+- Manual review — a future reader lands on §2.4 and finds the right entry point
+- Link check: internal references resolve
+
+**Acceptance Criteria:**
+
+- [ ] `docs/handlers/origin-operations-guide.md` §2.4 rewritten with supersession note [R-14]
+- [ ] Internal link to `docs/adapters/README.md` present
+- [ ] Internal link to `scripts/ci/gate-greps.sh` present
+- [ ] No orphan references to the old inline convention elsewhere in the doc
+
+---
+
+#### Story 3.3: Write `docs/adapters/README.md`
+
+**Wave:** 3.2
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Story 3.1
+
+Author the canonical adapter-architecture reference. Target audience: maintainers adding a new method, fixing a platform bug, or auditing a method's cross-platform behavior.
+
+**Implementation Steps:**
+
+1. Create `docs/adapters/README.md` with sections:
+   - **1. The Contract** — `PlatformAdapter` interface + `AdapterResult<T>` discriminated union; copy TypeScript signatures verbatim from `lib/adapters/types.ts`
+   - **2. File Layout** — `lib/adapters/*.ts` (interface, route, index, per-method pairs); `lib/shared/*.ts`; handler file structure; colocated test convention
+   - **3. Dispatch Model** — `getAdapter({repo})` cwd-based `detectPlatform()`; how a handler uses the adapter
+   - **4. Typed Asymmetries** — `platform_unsupported: true` pattern with examples from `pr_merge skip_train`, `work_item type cross-platform`, `resolve-branch-sha-gitlab`
+   - **5. Where to add a new method** — step-by-step: add signature to `types.ts`, create `<method>-{github,gitlab}.ts` pair, wire into assemblers, add to `MIGRATED_METHODS`, write colocated tests
+   - **6. Gate-greps** — what they enforce, how to regenerate the allowlist, what the `scripts/ci/migration-allowlist.txt` file does
+   - **7. Hybrid handlers + sub-calls** — when a handler owns non-platform orchestration (state files, markdown parsers, polling loops), extract only the platform sub-call; reference `fetchPrState` + `fetchIssue` as exemplars
+   - **8. Testing** — subprocess-boundary mocks; contract test; integration tests preservation; `lesson_origin_ops_pitfalls.md` on argv strictness
+   - **9. Cross-reference** — Dev Spec, VRTM, `docs/adapters/survey.md`
+
+2. Include a "no server-side prefix filter? fall back to generous limit + client filter" example (per survey §5.5 #2)
+
+**Test Procedures:**
+
+*Unit Tests:* none (docs-only).
+
+*Integration/E2E Coverage:*
+- Manual review for completeness
+- Link check: all internal references resolve
+- Fresh-reader test: a maintainer with no retrofit context can add a new method using only this doc
+
+**Acceptance Criteria:**
+
+- [ ] `docs/adapters/README.md` exists with all 9 sections [R-13]
+- [ ] Every `PlatformAdapter` method from `types.ts` is listed (can be scripted)
+- [ ] "Where to add a new method" is a complete, numbered procedure
+- [ ] Gate-greps documented with file:line pointer to `scripts/ci/gate-greps.sh`
+- [ ] Typed-asymmetry pattern documented with ≥3 concrete examples
+- [ ] Hybrid sub-call pattern documented with ≥2 exemplars
+
+---
+
+#### Story 3.4: Update root `README.md` with adapter architecture section
+
+**Wave:** 3.3
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Story 3.3
+
+Surface the adapter architecture at the project root. A one-paragraph summary + link to `docs/adapters/README.md`.
+
+**Implementation Steps:**
+
+1. Open root `README.md`
+2. Add a new section near the top (after "Overview", before "Installation") titled "Adapter architecture"
+3. Write 2-3 paragraphs: what the adapter pattern gives the project, where to find the contract doc, how the gate-greps enforce it, and the canonical exemplar file (`lib/adapters/pr-merge-{github,gitlab}.ts` per R-03)
+4. Cross-link to `docs/adapters/README.md`
+
+**Test Procedures:**
+
+*Unit Tests:* none (docs-only).
+
+*Integration/E2E Coverage:*
+- Manual review: renders correctly on GitHub; links resolve
+
+**Acceptance Criteria:**
+
+- [ ] Root `README.md` has a new "Adapter architecture" section [DM-01]
+- [ ] Section links to `docs/adapters/README.md`
+- [ ] Canonical exemplar files named
+- [ ] Existing `README.md` sections unmodified unless directly adjacent
+
+---
+
+#### Story 3.5: Tag `v1.8.0` + write release notes
+
+**Wave:** 3.4
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Stories 3.2, 3.3, 3.4
+
+Create the `v1.8.0` release. CI builds the binaries via existing `release.yml`. Release notes summarize the retrofit as a single coherent shipment.
+
+**Implementation Steps:**
+
+1. Verify `main` is green (full suite + gate-greps)
+2. Draft release notes covering:
+   - High-level summary: "Internal refactor — platform adapter retrofit. All 25 platform-aware handlers migrated to `PlatformAdapter`; gate-greps prevent regression."
+   - What users see: "No behavioral changes. `lib/glab.ts` removed from exports (internal-only change)."
+   - Links: Dev Spec, `docs/adapters/README.md`, survey, VRTM
+   - Statistics: `MIGRATED_METHODS` 10/25 → 27/27, `migration-allowlist.txt` 31 → 0, test suite 1466 → final count
+3. Tag via `git tag -a v1.8.0 -m "Platform adapter retrofit — see release notes"` then `git push origin v1.8.0`
+4. `release.yml` triggers; verify the release draft on GitHub
+5. Publish the release (attach the binaries produced by CI per DM-07)
+
+**Test Procedures:**
+
+*Unit Tests:* none (release-only).
+
+*Integration/E2E Coverage:*
+- Manual: `install-remote.sh` with `SDLC_VERSION=v1.8.0` installs the new binary cleanly
+- Smoke: Claude Code restarted with v1.8.0 can run basic tool calls (covered by MV-06 in Story 3.6)
+
+**Acceptance Criteria:**
+
+- [ ] `v1.8.0` tag exists on `main`
+- [ ] GitHub release published with release notes and platform binaries attached [DM-07]
+- [ ] Release notes link to Dev Spec + survey + adapter README
+- [ ] `install-remote.sh` installs v1.8.0 without error on a test machine
+
+---
+
+#### Story 3.6: Phase 3 Closing — MV-05, MV-06, VRTM
+
+**Wave:** 3.5
+**Repository:** `Wave-Engineering/mcp-server-sdlc`
+**Dependencies:** Story 3.5
+
+Final closing: execute MV-05 and MV-06 from §6.4; populate Appendix V VRTM with one verification entry per requirement (R-01 through R-17).
+
+**Implementation Steps:**
+
+1. **MV-05 — grep handlers/ for platform branching and direct subprocess:**
+   - Run `grep -rnE "platform === '(github|gitlab)'" handlers/` — expect zero matches
+   - Run `grep -rnE "execSync\(['\"\`](gh|glab) |Bun\.spawnSync" handlers/` — expect zero matches
+   - Record results on the closing issue
+2. **MV-06 — v1.8.0 smoke test:**
+   - Install v1.8.0 via `install-remote.sh`
+   - Restart Claude Code; run `/precheck` on a small PR candidate in this repo — verify it completes without error
+   - Run `/scpmmr` on a small PR candidate — verify it completes without error
+   - Record results on the closing issue
+3. **VRTM population (Appendix V):**
+   - For each of R-01 through R-17: add the verification status (Passing/Deferred) and the verification item(s) — PR SHAs, story issue numbers, test-file names, MV entries
+   - Fill the "Status" column for every row; "Pending" entries become "Verified" with evidence or "Deferred" with rationale (MV-01 already)
+4. **Close the Phase 3 epic** with the MV-05/MV-06 results and the populated VRTM
+
+**Test Procedures:**
+
+*Unit Tests:* none (verification + tracing only).
+
+*Integration/E2E Coverage:*
+- MV-05 greps per §6.4
+- MV-06 smoke tests per §6.4
+
+**Acceptance Criteria:**
+
+- [ ] MV-05 executed and PASSED (both greps return zero matches)
+- [ ] MV-06 executed and PASSED (`/precheck` + `/scpmmr` on v1.8.0 complete without error)
+- [ ] Appendix V VRTM populated: every R-XX row has Status = Verified or Deferred (with rationale)
+- [ ] Closing issue documents every MV result with evidence (timestamps, command output, PR URLs)
+- [ ] Phase 3 epic closed via the closing story PR
+- [ ] Retrofit marked complete
 
 ---
 


### PR DESCRIPTION
## Summary

Amend `docs/platform-adapter-retrofit-devspec.md` §8 Phase 2 and §8 Phase 3 from TBD/outline-only placeholders to binding plans. Follows the spec's own directive at §5.N row 7 ("Re-run `/devspec` post-survey to amend Section 8 with Phase 2 detail") and @rules-lawyer's confirmation (cc-workflow#499 Plan-vs-Epic taxonomy) that Phase 3 can be bound end-to-end per BJ's "plan end-to-end" rule.

## Changes

- **§5.A Deliverables Manifest** — backfilled specific wave assignments for every active row (Phase 1 through Phase 3). §7.2 `⚠️` checklist item cleared to `[x]`.
- **§8 Wave Map ASCII block** — Phase 2/3 stubs replaced with the actual 7-wave + 5-wave layouts.
- **§8 Phase 2** — full binding: DoD (12 items), Wave Map (7 waves 2.0–2.6), 25 stories (2.0–2.24). Wave 2.0 is pre-work fixing bug #280 (queue-enforced `pr_merge skip_train` path); Stories 2.7/2.17/2.21 each close #283/#281/#282 inline.
- **§8 Phase 3** — full binding: DoD, Wave Map (5 waves 3.1–3.5), 6 stories (3.1–3.6). Story 3.6 executes MV-05 + MV-06 + VRTM population.

## Test Plan

- [x] `mcp__sdlc-server__devspec_finalize` returns **7/7** passing post-amendment
- [x] `mcp__sdlc-server__devspec_summary`: 9 sections · 44 stories · 7 active deliverables · 3 N/A
- [x] `./scripts/ci/validate.sh` → 73/73 per-tool assertions pass (docs-only change; validated as regression probe)
- [x] `trivy fs --scanners vuln --severity HIGH,CRITICAL` → 0 findings
- [x] `feature-dev:code-reviewer` pass: caught 1 high-confidence arithmetic error (Phase 2 DoD claimed 17 new methods / `fetchIssue` denominator was `/42`; corrected to **16 methods** + **/26 denominator** — `resolveBranchSha` and `fetchBranchSha` were collapsed into one signature in Story 2.19 per survey §4-row-8 recommendation)
- [x] Post-fix `devspec_finalize` still returns 7/7
- [ ] Post-merge: `/devspec approve` re-approval gate (§8 changed materially), then `/devspec upshift`

## Story inventory

| Phase | Waves | Stories | Notes |
|-------|-------|---------|-------|
| Phase 1 (shipped) | 8 | 13 | Epic #237 closed 2026-04-26 |
| Phase 2 (binding) | 7 | 25 | Stories 2.0–2.24; 2.0 = bug #280 pre-work; 2.7/2.17/2.21 close #283/#281/#282 |
| Phase 3 (binding) | 5 | 6 | Stories 3.1–3.6; 3.1 deletes `lib/glab.ts`; 3.6 is retrofit closer (MV-05, MV-06, VRTM) |
| **Total** | **20** | **44** | |

At Phase 2 close: `MIGRATED_METHODS` 10 → **26** (10 Phase 1 + 16 new); `migration-allowlist.txt` 23 → **0**.

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)