### PR TITLE
fix(pr_merge): fall back to --auto on queue-strategy error (#280)

### DIFF
--- a/lib/adapters/pr-merge-github.test.ts
+++ b/lib/adapters/pr-merge-github.test.ts
@@ -124,6 +124,7 @@ describe('prMergeGithub — subprocess boundary', () => {
       url: 'https://github.com/org/repo/pull/42',
       merge_commit_sha: 'abc123def456',
       warnings: [],
+      queue_fallback: false,
     });
   });
 
@@ -309,5 +310,100 @@ describe('prMergeGithub — subprocess boundary', () => {
     const graphqlCall = findCall('gh api graphql');
     expect(graphqlCall).toContain('-F owner=Wave-Engineering');
     expect(graphqlCall).toContain('-F name=mcp-server-sdlc');
+  });
+
+  // =========================================================================
+  // Bug #280 / Story 2.0 (#294) — skip_train + queue-strategy error fallback
+  // =========================================================================
+
+  test('pr-merge-github — queue-strategy error triggers --auto fallback', async () => {
+    // Detection returns false-negative (no queue), skip_train:true requested,
+    // direct merge fails with queue-strategy error. Expected: retry with --auto
+    // rather than surface gh_pr_merge_skip_train_failed to the caller.
+    stubNoQueue();
+    let directCalled = false;
+    on('gh pr merge 280 --squash --delete-branch', () => {
+      if (!directCalled) {
+        directCalled = true;
+        throw mergeQueueError();
+      }
+      return '';
+    });
+    on(
+      'gh pr view 280 --json state,url,mergeCommit',
+      JSON.stringify({
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/280',
+        mergeCommit: null,
+      }),
+    );
+
+    const result = await prMergeGithub({ number: 280, skip_train: true });
+    expectOk(result);
+    expect(result.data.merge_method).toBe('merge_queue');
+    expect(result.data.enrolled).toBe(true);
+    expect(result.data.queue).toEqual({ enabled: true, position: null, enforced: true });
+    // The --auto retry must have fired after the queue-strategy error.
+    const autoCall = execCalls.find(
+      (c) => c.includes('gh pr merge 280') && c.includes('--auto'),
+    );
+    expect(autoCall).toBeDefined();
+    // skip_train warning must be emitted (folded from the #224 preservation).
+    expect(result.data.warnings.length).toBe(1);
+    expect(result.data.warnings[0]).toContain('skip_train ignored');
+    expect(result.data.warnings[0]).toContain('merge queue');
+  });
+
+  test('pr-merge-github — queue_fallback: true in response when fallback fires', async () => {
+    // Same scenario as above but focused on the new response-shape field.
+    stubNoQueue();
+    let directCalled = false;
+    on('gh pr merge 281 --squash --delete-branch', () => {
+      if (!directCalled) {
+        directCalled = true;
+        throw mergeQueueError();
+      }
+      return '';
+    });
+    on(
+      'gh pr view 281 --json state,url,mergeCommit',
+      JSON.stringify({
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/281',
+        mergeCommit: null,
+      }),
+    );
+
+    const result = await prMergeGithub({ number: 281, skip_train: true });
+    expectOk(result);
+    expect(result.data.queue_fallback).toBe(true);
+  });
+
+  test('pr-merge-github — no fallback when merge-admin succeeds', async () => {
+    // Happy path: skip_train:true + no queue enforcement + direct merge
+    // succeeds synchronously. queue_fallback must stay false — the field is a
+    // signal that the silent retry fired, not that skip_train was requested.
+    stubNoQueue();
+    on('gh pr merge 282 --squash --delete-branch', '');
+    on(
+      'gh pr view 282 --json state,url,mergeCommit',
+      JSON.stringify({
+        state: 'MERGED',
+        url: 'https://github.com/org/repo/pull/282',
+        mergeCommit: { oid: 'happy282' },
+      }),
+    );
+
+    const result = await prMergeGithub({ number: 282, skip_train: true });
+    expectOk(result);
+    expect(result.data.merge_method).toBe('direct_squash');
+    expect(result.data.merged).toBe(true);
+    expect(result.data.queue_fallback).toBe(false);
+    expect(result.data.warnings).toEqual([]);
+    // No --auto call on the happy path.
+    const autoCall = execCalls.find(
+      (c) => c.includes('gh pr merge 282') && c.includes('--auto'),
+    );
+    expect(autoCall).toBeUndefined();
   });
 });

--- a/lib/adapters/pr-merge-github.ts
+++ b/lib/adapters/pr-merge-github.ts
@@ -142,6 +142,7 @@ function aggregateOk(args: {
   url: string;
   mergeCommitSha?: string;
   warnings: string[];
+  queueFallback?: boolean;
 }): PrMergeResponse {
   return {
     number: args.number,
@@ -153,6 +154,7 @@ function aggregateOk(args: {
     url: args.url,
     merge_commit_sha: args.mergeCommitSha,
     warnings: args.warnings,
+    queue_fallback: args.queueFallback === true,
   };
 }
 
@@ -274,28 +276,39 @@ async function mergeGithubDirect(
     };
   } catch (err) {
     const fail = extractFailure(err);
-    if (args.skip_train === true) {
+    const indicatesQueue =
+      stderrIndicatesMergeQueue(fail.stderr) || stderrIndicatesMergeQueue(fail.message);
+    // skip_train callers opt out of the queue path when possible, but a
+    // queue-enforced repo (bug #280) will reject the direct merge with a
+    // queue-strategy error that detection missed. When the stderr matches,
+    // fold skip_train into the same fallback path as non-skip_train — emit
+    // the #224 "skip_train ignored" warning and re-invoke with --auto so the
+    // PR enrolls instead of surfacing a user-facing error.
+    if (args.skip_train === true && !indicatesQueue) {
       return {
         ok: false,
         code: 'gh_pr_merge_skip_train_failed',
         error: `gh pr merge failed (skip_train): ${fail.message}`,
       };
     }
-    if (
-      !stderrIndicatesMergeQueue(fail.stderr) &&
-      !stderrIndicatesMergeQueue(fail.message)
-    ) {
+    if (args.skip_train !== true && !indicatesQueue) {
       return {
         ok: false,
         code: 'gh_pr_merge_failed',
         error: `gh pr merge failed: ${fail.message}`,
       };
     }
+    if (args.skip_train === true) {
+      warnings.push(
+        'skip_train ignored — merge queue enforced; merge proceeded via merge_queue strategy',
+      );
+    }
   }
 
   // Stderr-fallback path: detection thought no queue, but the API rejected
   // the direct merge with a queue-related error. Promote the queue state so
-  // the response reflects what we just learned.
+  // the response reflects what we just learned. Mark `queue_fallback: true`
+  // so callers can log the silent retry (bug #280 / #294).
   const fallbackQueue: PrMergeQueueState = { enabled: true, position: null, enforced: true };
   const autoCmd = buildGithubMergeCommand(args.number, true, args.squash_message, args.repo);
   try {
@@ -319,6 +332,7 @@ async function mergeGithubDirect(
       url: info.url,
       mergeCommitSha: info.mergeCommitSha,
       warnings,
+      queueFallback: true,
     }),
   };
 }

--- a/lib/adapters/pr-merge-gitlab.test.ts
+++ b/lib/adapters/pr-merge-gitlab.test.ts
@@ -111,6 +111,7 @@ describe('prMergeGitlab — subprocess boundary', () => {
       url: 'https://gitlab.com/org/repo/-/merge_requests/17',
       merge_commit_sha: 'deadbeef1234',
       warnings: [],
+      queue_fallback: false,
     });
     // No `gh api graphql` call should ever fire on the GitLab path.
     expect(execCalls.find((c) => c.includes('gh api graphql'))).toBeUndefined();

--- a/lib/adapters/pr-merge-gitlab.ts
+++ b/lib/adapters/pr-merge-gitlab.ts
@@ -141,6 +141,9 @@ export async function prMergeGitlab(
         url: info.url,
         merge_commit_sha: info.mergeCommitSha,
         warnings: [],
+        // GitLab has no queue concept — queue_fallback always false. Required
+        // by PrMergeResponse since bug #280 / #294 added the field.
+        queue_fallback: false,
       },
     };
   } catch (err) {

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -87,6 +87,13 @@ export interface PrMergeResponse {
   url: string;
   merge_commit_sha?: string;
   warnings: string[];
+  /**
+   * True when a direct-merge invocation failed with the GitHub queue-strategy
+   * error and the adapter silently retried via `--auto` (queue-enqueue path).
+   * Defaults to `false` on every other path — including the eager
+   * enforced-queue path where `--auto` was chosen upfront. Bug #280 / #294.
+   */
+  queue_fallback: boolean;
 }
 export interface PrMergeWaitArgs {
   number: number;

--- a/tests/pr_merge.test.ts
+++ b/tests/pr_merge.test.ts
@@ -409,22 +409,44 @@ describe('pr_merge handler — aggregate response (#225)', () => {
     expect(directOnly).toBeUndefined();
   });
 
-  test('skip_train + non-enforced repo + queue stderr — surfaces error (no fallback)', async () => {
+  test('skip_train + non-enforced repo + queue stderr — silently falls back to --auto (bug #280)', async () => {
+    // Bug #280 / Story 2.0 (#294): when detection misses the queue upfront but
+    // gh rejects the direct merge with the queue-strategy error, fold
+    // skip_train into the same stderr-fallback path used for the non-skip_train
+    // case. Emit the #224 skip_train-ignored warning and set queue_fallback:true
+    // so callers can log the silent retry.
     onExec('git remote get-url origin', 'https://github.com/org/repo.git\n');
     stubNoQueue();
+    let directCalled = false;
     onExec('gh pr merge 202 --squash --delete-branch', () => {
-      throw mergeQueueError();
+      if (!directCalled) {
+        directCalled = true;
+        throw mergeQueueError();
+      }
+      return '';
     });
+    onExec(
+      'gh pr view 202 --json state,url,mergeCommit',
+      JSON.stringify({
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/202',
+        mergeCommit: null,
+      }),
+    );
 
     const result = await prMergeHandler.execute({ number: 202, skip_train: true });
     const data = parseResult(result);
 
-    expect(data.ok).toBe(false);
-    expect((data.error as string)).toContain('skip_train');
+    expect(data.ok).toBe(true);
+    expect(data.merge_method).toBe('merge_queue');
+    expect(data.queue_fallback).toBe(true);
+    const warnings = data.warnings as string[];
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain('skip_train ignored');
     const autoCall = execCalls.find(
       c => c.includes('gh pr merge 202') && c.includes('--auto'),
     );
-    expect(autoCall).toBeUndefined();
+    expect(autoCall).toBeDefined();
   });
 
   // ===========================================================================


### PR DESCRIPTION
## Summary

Fixes bug #280 where `pr_merge({skip_train: true})` on a GitHub merge-queue-enforced repo surfaced a queue-strategy error (`gh_pr_merge_skip_train_failed`) instead of falling back to `--auto` the way the non-skip_train path already did. Adds a typed `queue_fallback: boolean` on `PrMergeResponse` so callers can log the silent retry.

## Changes

- `lib/adapters/pr-merge-github.ts` — when `skip_train: true` AND stderr matches the merge-queue heuristic, fall through to the existing `--auto` fallback instead of short-circuiting to an error. Preserves the `skip_train ignored — merge queue enforced` warning from #224.
- `lib/adapters/types.ts` — add `queue_fallback: boolean` to `PrMergeResponse`. Defaults to `false` on every path except the stderr-fallback retry.
- `lib/adapters/pr-merge-gitlab.ts` — mechanical update to return `queue_fallback: false` (GitLab has no merge-queue fallback path).
- `lib/adapters/pr-merge-github.test.ts` — 3 new unit tests (fallback triggers, response flag, no-fallback path). 12/12 pass.
- `lib/adapters/pr-merge-gitlab.test.ts` — mechanical `.toEqual` update for new field.
- `tests/pr_merge.test.ts` — repurpose one test that previously codified the #280 bug (`ok:false` + error contains `skip_train`) as a regression test for the corrected behavior. 25/25 pass.

## Linked Issues

Closes #294
Closes #280

## Test Plan

- `./scripts/ci/validate.sh` — exit 0 (codegen OK, tsc clean, gate-greps OK, shellcheck OK, contract 73/73)
- `bun test` — 1662 pass / 0 fail across 105 files (4162 expect calls); baseline 1659 + 3 new unit tests
- CI on this PR must pass before merge

## Self-Review Concerns (per Flight)

1. Spec-code drift: spec described `--admin` flag not in actual adapter; implemented against current code.
2. AC4 literal wording ("integration tests pass unchanged") vs. reality — one test encoded the bug itself and had to be repurposed to a regression for #280.
3. Scope-creep: touched `types.ts`, gitlab adapter + test, and `tests/pr_merge.test.ts` in addition to the two files the spec scoped; all edits forced by the new required field / the repurposed regression test.
4. `queue_fallback` made required (non-optional) per spec wording "Default to `false`"; optional-with-omit was rejected as less explicit. Can be relaxed in a follow-up if desired.
