### PR TITLE
refactor(ci_failed_jobs): migrate to platform adapter (#305)

### DIFF
--- a/handlers/ci_failed_jobs.ts
+++ b/handlers/ci_failed_jobs.ts
@@ -1,11 +1,11 @@
-// Origin Operations family handler.
-// See docs/handlers/origin-operations-guide.md for the canonical pattern,
-// gh ↔ glab field mappings, and normalized response schemas.
+// Origin Operations family handler — adapter-dispatching shell.
+// Subprocess + platform branching live in lib/adapters/ci-failed-jobs-{github,gitlab}.ts;
+// see docs/handlers/origin-operations-guide.md for the canonical pattern and
+// docs/platform-adapter-retrofit-devspec.md §5 for the contract.
 
-import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { getAdapter } from '../lib/adapters/index.js';
 
 const inputSchema = z
   .object({
@@ -17,101 +17,8 @@ const inputSchema = z
   })
   .strict();
 
-type Input = z.infer<typeof inputSchema>;
-
-interface FailedJob {
-  job_id: number;
-  name: string;
-  stage: string | null;
-  conclusion: string;
-  started_at: string | null;
-  finished_at: string | null;
-  url: string;
-}
-
-function exec(cmd: string): string {
-  return execSync(cmd, { encoding: 'utf8' });
-}
-
-// GitHub job shape from `gh run view <id> --json jobs`.
-interface GithubJob {
-  databaseId?: number;
-  name?: string;
-  status?: string;
-  conclusion?: string;
-  startedAt?: string;
-  completedAt?: string;
-  url?: string;
-}
-
-// GitLab job shape from `glab api projects/:id/pipelines/<id>/jobs`.
-interface GitlabJob {
-  id?: number;
-  name?: string;
-  status?: string;
-  stage?: string;
-  started_at?: string | null;
-  finished_at?: string | null;
-  web_url?: string;
-}
-
-function normalizeGithubConclusion(raw: string | undefined): string {
-  // GitHub conclusion values: success, failure, cancelled, timed_out,
-  // action_required, neutral, skipped, stale, startup_failure.
-  if (!raw) return 'failure';
-  return raw;
-}
-
-function normalizeGitlabConclusion(raw: string | undefined): string {
-  // GitLab job status after filtering to `failed`. Map onto GitHub-style
-  // conclusions so `/jfail` can reason about both uniformly.
-  if (!raw) return 'failure';
-  if (raw === 'failed') return 'failure';
-  return raw;
-}
-
-function fetchGithubFailedJobs(runId: number, repo: string | undefined): FailedJob[] {
-  const repoFlag = repo ? ` --repo ${repo}` : '';
-  const raw = exec(`gh run view ${runId} --json jobs${repoFlag}`);
-  const parsed = JSON.parse(raw) as { jobs?: GithubJob[] };
-  const jobs = parsed.jobs ?? [];
-  const failed: FailedJob[] = [];
-  for (const j of jobs) {
-    if (j.status !== 'completed') continue;
-    if (j.conclusion === 'success') continue;
-    failed.push({
-      job_id: j.databaseId ?? 0,
-      name: j.name ?? '',
-      stage: null,
-      conclusion: normalizeGithubConclusion(j.conclusion),
-      started_at: j.startedAt ?? null,
-      finished_at: j.completedAt ?? null,
-      url: j.url ?? '',
-    });
-  }
-  return failed;
-}
-
-function fetchGitlabFailedJobs(runId: number, repo: string | undefined): FailedJob[] {
-  // When repo is provided, URL-encode it as the explicit project slug; otherwise
-  // fall back to `:id` which glab substitutes with the cwd project's numeric id.
-  const projectId = repo ? encodeURIComponent(repo) : ':id';
-  const raw = exec(`glab api projects/${projectId}/pipelines/${runId}/jobs`);
-  const parsed = JSON.parse(raw) as GitlabJob[];
-  const failed: FailedJob[] = [];
-  for (const j of parsed) {
-    if (j.status !== 'failed') continue;
-    failed.push({
-      job_id: j.id ?? 0,
-      name: j.name ?? '',
-      stage: j.stage ?? null,
-      conclusion: normalizeGitlabConclusion(j.status),
-      started_at: j.started_at ?? null,
-      finished_at: j.finished_at ?? null,
-      url: j.web_url ?? '',
-    });
-  }
-  return failed;
+function envelope(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] };
 }
 
 const ciFailedJobsHandler: HandlerDef = {
@@ -120,41 +27,25 @@ const ciFailedJobsHandler: HandlerDef = {
     'List failed jobs for a specific CI run with per-job reason summaries. Used by /jfail to know which jobs to pull logs for.',
   inputSchema,
   async execute(rawArgs: unknown) {
-    let args: Input;
+    let args;
     try {
       args = inputSchema.parse(rawArgs);
     } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
 
-    try {
-      const platform = detectPlatform();
-      const failed =
-        platform === 'github'
-          ? fetchGithubFailedJobs(args.run_id, args.repo)
-          : fetchGitlabFailedJobs(args.run_id, args.repo);
+    const adapter = getAdapter({ repo: args.repo });
+    const result = await adapter.ciFailedJobs(args);
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({
-              ok: true,
-              run_id: args.run_id,
-              failed_jobs: failed,
-            }),
-          },
-        ],
-      };
-    } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+    // Per dev spec §4.4 step 4: surface `platform_unsupported` as a typed
+    // signal alongside `ok: true` — NOT as an error. The dispatch succeeded;
+    // the platform just doesn't have the concept. Callers branch on the
+    // discriminator instead of confusing it with a runtime failure.
+    if ('platform_unsupported' in result) {
+      return envelope({ ok: true, platform_unsupported: true, hint: result.hint });
     }
+    if (!result.ok) return envelope({ ok: false, error: result.error });
+    return envelope({ ok: true, run_id: args.run_id, ...result.data });
   },
 };
 

--- a/lib/adapters/ci-failed-jobs-github.test.ts
+++ b/lib/adapters/ci-failed-jobs-github.test.ts
@@ -1,0 +1,256 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { AdapterResult, CiFailedJobsResponse } from './types.ts';
+
+// Subprocess-boundary tests for the GitHub ci_failed_jobs adapter (R-15).
+// Integration-level coverage (handler dispatch, envelope shape) stays in
+// tests/ci_failed_jobs.test.ts; this file owns the argv-shape and
+// response-parsing assertions that prove the adapter speaks `gh` correctly.
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { ciFailedJobsGithub } = await import('./ci-failed-jobs-github.ts');
+
+function on(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
+function expectOk(
+  r: AdapterResult<CiFailedJobsResponse>,
+): asserts r is { ok: true; data: CiFailedJobsResponse } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectErr(
+  r: AdapterResult<CiFailedJobsResponse>,
+): asserts r is { ok: false; error: string; code: string } {
+  if (!('ok' in r) || r.ok) {
+    throw new Error(`expected error result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('ciFailedJobsGithub — subprocess boundary', () => {
+  test('argv: gh run view <id> --json jobs', async () => {
+    on('gh run view', JSON.stringify({ jobs: [] }));
+
+    const result = await ciFailedJobsGithub({ run_id: 12345 });
+    expectOk(result);
+
+    const call = findCall('gh run view');
+    expect(call).toContain('12345');
+    expect(call).toContain('--json');
+    expect(call).toContain('jobs');
+    // No --repo flag absent an explicit slug.
+    expect(call).not.toContain('--repo');
+  });
+
+  test('normalizes failed jobs — mixed success/failure/timed_out', async () => {
+    on(
+      'gh run view',
+      JSON.stringify({
+        jobs: [
+          {
+            databaseId: 101,
+            name: 'lint',
+            status: 'completed',
+            conclusion: 'success',
+            startedAt: '2025-01-01T00:00:00Z',
+            completedAt: '2025-01-01T00:01:00Z',
+            url: 'https://github.com/o/r/actions/runs/12345/job/101',
+          },
+          {
+            databaseId: 102,
+            name: 'test',
+            status: 'completed',
+            conclusion: 'failure',
+            startedAt: '2025-01-01T00:00:00Z',
+            completedAt: '2025-01-01T00:02:00Z',
+            url: 'https://github.com/o/r/actions/runs/12345/job/102',
+          },
+          {
+            databaseId: 103,
+            name: 'build',
+            status: 'completed',
+            conclusion: 'timed_out',
+            startedAt: '2025-01-01T00:00:00Z',
+            completedAt: '2025-01-01T00:10:00Z',
+            url: 'https://github.com/o/r/actions/runs/12345/job/103',
+          },
+        ],
+      }),
+    );
+
+    const result = await ciFailedJobsGithub({ run_id: 12345 });
+    expectOk(result);
+    expect(result.data.failed_jobs).toHaveLength(2);
+    expect(result.data.failed_jobs[0]).toEqual({
+      job_id: 102,
+      name: 'test',
+      stage: null,
+      conclusion: 'failure',
+      started_at: '2025-01-01T00:00:00Z',
+      finished_at: '2025-01-01T00:02:00Z',
+      url: 'https://github.com/o/r/actions/runs/12345/job/102',
+    });
+    expect(result.data.failed_jobs[1]).toEqual({
+      job_id: 103,
+      name: 'build',
+      stage: null,
+      conclusion: 'timed_out',
+      started_at: '2025-01-01T00:00:00Z',
+      finished_at: '2025-01-01T00:10:00Z',
+      url: 'https://github.com/o/r/actions/runs/12345/job/103',
+    });
+  });
+
+  test('skips in-progress jobs (status !== "completed")', async () => {
+    on(
+      'gh run view',
+      JSON.stringify({
+        jobs: [
+          {
+            databaseId: 20,
+            name: 'still-running',
+            status: 'in_progress',
+            conclusion: null,
+            startedAt: '2025-01-01T00:00:00Z',
+            completedAt: null,
+            url: 'https://github.com/o/r/actions/runs/555/job/20',
+          },
+          {
+            databaseId: 21,
+            name: 'done-failed',
+            status: 'completed',
+            conclusion: 'failure',
+            startedAt: '2025-01-01T00:00:00Z',
+            completedAt: '2025-01-01T00:02:00Z',
+            url: 'https://github.com/o/r/actions/runs/555/job/21',
+          },
+        ],
+      }),
+    );
+
+    const result = await ciFailedJobsGithub({ run_id: 555 });
+    expectOk(result);
+    expect(result.data.failed_jobs).toHaveLength(1);
+    expect(result.data.failed_jobs[0].name).toBe('done-failed');
+  });
+
+  test('all success returns empty list', async () => {
+    on(
+      'gh run view',
+      JSON.stringify({
+        jobs: [
+          {
+            databaseId: 1,
+            name: 'lint',
+            status: 'completed',
+            conclusion: 'success',
+            startedAt: '2025-01-01T00:00:00Z',
+            completedAt: '2025-01-01T00:01:00Z',
+            url: 'https://github.com/o/r/actions/runs/999/job/1',
+          },
+        ],
+      }),
+    );
+
+    const result = await ciFailedJobsGithub({ run_id: 999 });
+    expectOk(result);
+    expect(result.data.failed_jobs).toEqual([]);
+  });
+
+  test('missing jobs field defaults to empty list', async () => {
+    on('gh run view', JSON.stringify({}));
+
+    const result = await ciFailedJobsGithub({ run_id: 1 });
+    expectOk(result);
+    expect(result.data.failed_jobs).toEqual([]);
+  });
+
+  test('returns AdapterResult.error on gh failure (not thrown)', async () => {
+    on('gh run view', () => {
+      const err = new Error('gh: run not found') as ThrowableError;
+      err.stderr = 'gh: run not found';
+      err.status = 1;
+      throw err;
+    });
+
+    const result = await ciFailedJobsGithub({ run_id: 404 });
+    expectErr(result);
+    expect(result.code).toBe('gh_run_view_failed');
+    expect(result.error).toContain('gh run view failed');
+  });
+
+  test('--repo flag forwarded when args.repo provided', async () => {
+    on('gh run view', JSON.stringify({ jobs: [] }));
+
+    await ciFailedJobsGithub({ run_id: 777, repo: 'other-org/other-repo' });
+    const call = findCall('gh run view');
+    expect(call).toContain('--repo');
+    expect(call).toContain('other-org/other-repo');
+  });
+
+  test('missing databaseId / missing fields coerce to safe defaults', async () => {
+    on(
+      'gh run view',
+      JSON.stringify({
+        jobs: [
+          {
+            // databaseId omitted
+            status: 'completed',
+            conclusion: 'failure',
+          },
+        ],
+      }),
+    );
+
+    const result = await ciFailedJobsGithub({ run_id: 5 });
+    expectOk(result);
+    expect(result.data.failed_jobs[0]).toEqual({
+      job_id: 0,
+      name: '',
+      stage: null,
+      conclusion: 'failure',
+      started_at: null,
+      finished_at: null,
+      url: '',
+    });
+  });
+});

--- a/lib/adapters/ci-failed-jobs-github.ts
+++ b/lib/adapters/ci-failed-jobs-github.ts
@@ -1,0 +1,92 @@
+/**
+ * GitHub `ci_failed_jobs` adapter implementation.
+ *
+ * Lifted from `handlers/ci_failed_jobs.ts` per Story 2.11 (#305). The handler
+ * is now a thin dispatcher; this module owns the GitHub-specific subprocess
+ * work and normalizes the response into `AdapterResult<CiFailedJobsResponse>`.
+ *
+ * Errors that come back from `gh` are converted into `{ok: false, error, code}`
+ * — never thrown — so the handler doesn't need a try/catch around the dispatch.
+ */
+
+import { execSync } from 'child_process';
+import { runArgv } from '../shared/error-norm.js';
+import type {
+  AdapterResult,
+  CiFailedJobsArgs,
+  CiFailedJobsResponse,
+  FailedJob,
+} from './types.js';
+
+// GitHub job shape from `gh run view <id> --json jobs`.
+interface GithubJob {
+  databaseId?: number;
+  name?: string;
+  status?: string;
+  conclusion?: string;
+  startedAt?: string;
+  completedAt?: string;
+  url?: string;
+}
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function normalizeGithubConclusion(raw: string | undefined): string {
+  // GitHub conclusion values: success, failure, cancelled, timed_out,
+  // action_required, neutral, skipped, stale, startup_failure.
+  if (!raw) return 'failure';
+  return raw;
+}
+
+export async function ciFailedJobsGithub(
+  args: CiFailedJobsArgs,
+): Promise<AdapterResult<CiFailedJobsResponse>> {
+  // Bound any exception that escapes the helpers below into a typed result —
+  // adapter callers must not have to try/catch.
+  try {
+    const cwd = projectDir();
+
+    const cmd = ['gh', 'run', 'view', String(args.run_id), '--json', 'jobs'];
+    if (args.repo !== undefined) cmd.push('--repo', args.repo);
+    const result = runArgv(cmd, cwd);
+    if (result.exitCode !== 0) {
+      return {
+        ok: false,
+        code: 'gh_run_view_failed',
+        error: `gh run view failed: ${result.stderr.trim() || result.stdout.trim()}`,
+      };
+    }
+
+    const parsed = JSON.parse(result.stdout) as { jobs?: GithubJob[] };
+    const jobs = parsed.jobs ?? [];
+    const failed: FailedJob[] = [];
+    for (const j of jobs) {
+      if (j.status !== 'completed') continue;
+      if (j.conclusion === 'success') continue;
+      failed.push({
+        job_id: j.databaseId ?? 0,
+        name: j.name ?? '',
+        stage: null,
+        conclusion: normalizeGithubConclusion(j.conclusion),
+        started_at: j.startedAt ?? null,
+        finished_at: j.completedAt ?? null,
+        url: j.url ?? '',
+      });
+    }
+
+    return { ok: true, data: { failed_jobs: failed } };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'unexpected_error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// `execSync` is intentionally re-imported above so that adapter-level test
+// files can `mock.module('child_process', ...)` and intercept this module's
+// subprocess calls without needing access to the handler's mock setup.
+void execSync;

--- a/lib/adapters/ci-failed-jobs-gitlab.test.ts
+++ b/lib/adapters/ci-failed-jobs-gitlab.test.ts
@@ -1,0 +1,218 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { AdapterResult, CiFailedJobsResponse } from './types.ts';
+
+// Subprocess-boundary tests for the GitLab ci_failed_jobs adapter (R-15).
+// Integration-level coverage stays in tests/ci_failed_jobs.test.ts; this file
+// covers argv-shape, REST-payload parsing, the status filter (failed vs.
+// canceled/skipped/pending), and the encoded-slug vs. `:id` dispatch.
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { ciFailedJobsGitlab } = await import('./ci-failed-jobs-gitlab.ts');
+
+function on(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
+function expectOk(
+  r: AdapterResult<CiFailedJobsResponse>,
+): asserts r is { ok: true; data: CiFailedJobsResponse } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectErr(
+  r: AdapterResult<CiFailedJobsResponse>,
+): asserts r is { ok: false; error: string; code: string } {
+  if (!('ok' in r) || r.ok) {
+    throw new Error(`expected error result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('ciFailedJobsGitlab — subprocess boundary', () => {
+  test('argv: glab api projects/:id/pipelines/<id>/jobs (no repo)', async () => {
+    on('glab api projects/:id/pipelines/42/jobs', JSON.stringify([]));
+
+    const result = await ciFailedJobsGitlab({ run_id: 42 });
+    expectOk(result);
+
+    const call = findCall('glab api');
+    expect(call).toContain('projects/:id/pipelines/42/jobs');
+  });
+
+  test('argv: explicit repo URL-encoded into path', async () => {
+    on(
+      'glab api projects/other-org%2Fother-repo/pipelines/101/jobs',
+      JSON.stringify([]),
+    );
+
+    const result = await ciFailedJobsGitlab({
+      run_id: 101,
+      repo: 'other-org/other-repo',
+    });
+    expectOk(result);
+
+    const call = findCall('glab api');
+    expect(call).toContain('projects/other-org%2Fother-repo/pipelines/101/jobs');
+    expect(call).not.toContain('projects/:id/');
+  });
+
+  test('normalizes failed jobs — mixed statuses, stage populated', async () => {
+    on(
+      'glab api projects/:id/pipelines/42/jobs',
+      JSON.stringify([
+        {
+          id: 201,
+          name: 'lint',
+          status: 'success',
+          stage: 'test',
+          started_at: '2025-02-01T00:00:00Z',
+          finished_at: '2025-02-01T00:01:00Z',
+          web_url: 'https://gitlab.com/o/r/-/jobs/201',
+        },
+        {
+          id: 202,
+          name: 'unit-test',
+          status: 'failed',
+          stage: 'test',
+          started_at: '2025-02-01T00:00:00Z',
+          finished_at: '2025-02-01T00:03:00Z',
+          web_url: 'https://gitlab.com/o/r/-/jobs/202',
+        },
+        {
+          id: 203,
+          name: 'deploy',
+          status: 'failed',
+          stage: 'deploy',
+          started_at: '2025-02-01T00:04:00Z',
+          finished_at: '2025-02-01T00:05:00Z',
+          web_url: 'https://gitlab.com/o/r/-/jobs/203',
+        },
+      ]),
+    );
+
+    const result = await ciFailedJobsGitlab({ run_id: 42 });
+    expectOk(result);
+    expect(result.data.failed_jobs).toHaveLength(2);
+    expect(result.data.failed_jobs[0]).toEqual({
+      job_id: 202,
+      name: 'unit-test',
+      stage: 'test',
+      conclusion: 'failure',
+      started_at: '2025-02-01T00:00:00Z',
+      finished_at: '2025-02-01T00:03:00Z',
+      url: 'https://gitlab.com/o/r/-/jobs/202',
+    });
+    expect(result.data.failed_jobs[1].stage).toBe('deploy');
+  });
+
+  test('skips canceled/skipped/pending jobs (only "failed" passes)', async () => {
+    on(
+      'glab api projects/:id/pipelines/66/jobs',
+      JSON.stringify([
+        { id: 1, name: 'cancelled-job', status: 'canceled', stage: 'test' },
+        { id: 2, name: 'pending-job', status: 'pending', stage: 'test' },
+        { id: 3, name: 'skipped-job', status: 'skipped', stage: 'test' },
+        {
+          id: 4,
+          name: 'real-failure',
+          status: 'failed',
+          stage: 'test',
+          started_at: null,
+          finished_at: null,
+          web_url: 'https://gitlab.com/o/r/-/jobs/4',
+        },
+      ]),
+    );
+
+    const result = await ciFailedJobsGitlab({ run_id: 66 });
+    expectOk(result);
+    expect(result.data.failed_jobs).toHaveLength(1);
+    expect(result.data.failed_jobs[0].name).toBe('real-failure');
+    expect(result.data.failed_jobs[0].started_at).toBeNull();
+    expect(result.data.failed_jobs[0].finished_at).toBeNull();
+  });
+
+  test('all success returns empty list', async () => {
+    on(
+      'glab api projects/:id/pipelines/1/jobs',
+      JSON.stringify([
+        { id: 1, name: 'lint', status: 'success', stage: 'test' },
+      ]),
+    );
+
+    const result = await ciFailedJobsGitlab({ run_id: 1 });
+    expectOk(result);
+    expect(result.data.failed_jobs).toEqual([]);
+  });
+
+  test('returns AdapterResult.error on glab failure (not thrown)', async () => {
+    on('glab api', () => {
+      const err = new Error('glab: not authenticated') as ThrowableError;
+      err.stderr = 'glab: not authenticated';
+      err.status = 1;
+      throw err;
+    });
+
+    const result = await ciFailedJobsGitlab({ run_id: 77 });
+    expectErr(result);
+    expect(result.code).toBe('glab_api_jobs_failed');
+    expect(result.error).toContain('glab api failed');
+  });
+
+  test('missing fields coerce to safe defaults', async () => {
+    on(
+      'glab api projects/:id/pipelines/9/jobs',
+      JSON.stringify([{ status: 'failed' }]),
+    );
+
+    const result = await ciFailedJobsGitlab({ run_id: 9 });
+    expectOk(result);
+    expect(result.data.failed_jobs[0]).toEqual({
+      job_id: 0,
+      name: '',
+      stage: null,
+      conclusion: 'failure',
+      started_at: null,
+      finished_at: null,
+      url: '',
+    });
+  });
+});

--- a/lib/adapters/ci-failed-jobs-gitlab.ts
+++ b/lib/adapters/ci-failed-jobs-gitlab.ts
@@ -1,0 +1,95 @@
+/**
+ * GitLab `ci_failed_jobs` adapter implementation.
+ *
+ * Lifted from `handlers/ci_failed_jobs.ts` per Story 2.11 (#305). Mirrors
+ * `ci-failed-jobs-github.ts` — the handler dispatches to either depending on
+ * cwd platform.
+ *
+ * GitLab divergences from the GitHub flow:
+ * - `glab api projects/<id>/pipelines/<pid>/jobs` (REST endpoint) rather than
+ *   a `gh`-style CLI subcommand.
+ * - When `args.repo` is provided it's URL-encoded as the explicit project
+ *   slug; otherwise `:id` is passed and `glab` substitutes the cwd project's
+ *   numeric id.
+ * - `stage` is populated from the job record (GitHub has no equivalent and
+ *   returns `null` in the normalized shape).
+ * - Status filtering uses `status === 'failed'` (GitLab) vs. GitHub's
+ *   `status === 'completed' && conclusion !== 'success'`.
+ */
+
+import { execSync } from 'child_process';
+import { runArgv } from '../shared/error-norm.js';
+import type {
+  AdapterResult,
+  CiFailedJobsArgs,
+  CiFailedJobsResponse,
+  FailedJob,
+} from './types.js';
+
+// GitLab job shape from `glab api projects/:id/pipelines/<id>/jobs`.
+interface GitlabJob {
+  id?: number;
+  name?: string;
+  status?: string;
+  stage?: string;
+  started_at?: string | null;
+  finished_at?: string | null;
+  web_url?: string;
+}
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function normalizeGitlabConclusion(raw: string | undefined): string {
+  // GitLab job status after filtering to `failed`. Map onto GitHub-style
+  // conclusions so `/jfail` can reason about both uniformly.
+  if (!raw) return 'failure';
+  if (raw === 'failed') return 'failure';
+  return raw;
+}
+
+export async function ciFailedJobsGitlab(
+  args: CiFailedJobsArgs,
+): Promise<AdapterResult<CiFailedJobsResponse>> {
+  try {
+    const cwd = projectDir();
+    const projectId = args.repo ? encodeURIComponent(args.repo) : ':id';
+    const apiPath = `projects/${projectId}/pipelines/${args.run_id}/jobs`;
+
+    const result = runArgv(['glab', 'api', apiPath], cwd);
+    if (result.exitCode !== 0) {
+      return {
+        ok: false,
+        code: 'glab_api_jobs_failed',
+        error: `glab api failed: ${result.stderr.trim() || result.stdout.trim()}`,
+      };
+    }
+
+    const parsed = JSON.parse(result.stdout) as GitlabJob[];
+    const failed: FailedJob[] = [];
+    for (const j of parsed) {
+      if (j.status !== 'failed') continue;
+      failed.push({
+        job_id: j.id ?? 0,
+        name: j.name ?? '',
+        stage: j.stage ?? null,
+        conclusion: normalizeGitlabConclusion(j.status),
+        started_at: j.started_at ?? null,
+        finished_at: j.finished_at ?? null,
+        url: j.web_url ?? '',
+      });
+    }
+
+    return { ok: true, data: { failed_jobs: failed } };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'unexpected_error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// See ci-failed-jobs-github.ts for the rationale.
+void execSync;

--- a/lib/adapters/github.ts
+++ b/lib/adapters/github.ts
@@ -14,6 +14,7 @@
  */
 
 import type { PlatformAdapter } from './types.js';
+import { ciFailedJobsGithub } from './ci-failed-jobs-github.js';
 import { fetchIssueGithub } from './fetch-issue-github.js';
 import { fetchPrStateGithub } from './fetch-pr-state-github.js';
 import { prCommentGithub } from './pr-comment-github.js';
@@ -44,7 +45,7 @@ export const githubAdapter: PlatformAdapter = {
   ciWaitRun: stubMethod,
   ciRunStatus: stubMethod,
   ciRunLogs: stubMethod,
-  ciFailedJobs: stubMethod,
+  ciFailedJobs: ciFailedJobsGithub,
   ciRunsForBranch: stubMethod,
   labelCreate: stubMethod,
   labelList: stubMethod,

--- a/lib/adapters/gitlab.ts
+++ b/lib/adapters/gitlab.ts
@@ -15,6 +15,7 @@
  */
 
 import type { PlatformAdapter } from './types.js';
+import { ciFailedJobsGitlab } from './ci-failed-jobs-gitlab.js';
 import { fetchIssueGitlab } from './fetch-issue-gitlab.js';
 import { fetchPrStateGitlab } from './fetch-pr-state-gitlab.js';
 import { prCommentGitlab } from './pr-comment-gitlab.js';
@@ -45,7 +46,7 @@ export const gitlabAdapter: PlatformAdapter = {
   ciWaitRun: stubMethod,
   ciRunStatus: stubMethod,
   ciRunLogs: stubMethod,
-  ciFailedJobs: stubMethod,
+  ciFailedJobs: ciFailedJobsGitlab,
   ciRunsForBranch: stubMethod,
   labelCreate: stubMethod,
   labelList: stubMethod,

--- a/lib/adapters/types.test.ts
+++ b/lib/adapters/types.test.ts
@@ -47,6 +47,7 @@ describe('PlatformAdapter contract', () => {
   // Story 1.10 (#247): prMerge
   // Story 1.11 (#248): prMergeWait + fetchPrState (first hybrid sub-call)
   // Story 2.1 (#295): fetchIssue (keystone hybrid sub-call for Phase 2)
+  // Story 2.11 (#305): ciFailedJobs
   const MIGRATED_METHODS = new Set<string>([
     'prCreate',
     'prDiff',
@@ -59,6 +60,7 @@ describe('PlatformAdapter contract', () => {
     'prMergeWait',
     'fetchPrState',
     'fetchIssue',
+    'ciFailedJobs',
   ]);
 
   test('still-stubbed methods return platform_unsupported', async () => {

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -279,8 +279,34 @@ export type CiRunStatusArgs = unknown;
 export type CiRunStatusResponse = unknown;
 export type CiRunLogsArgs = unknown;
 export type CiRunLogsResponse = unknown;
-export type CiFailedJobsArgs = unknown;
-export type CiFailedJobsResponse = unknown;
+
+/**
+ * `ci_failed_jobs` args/response (Story 2.11, #305). Thin platform wrapper
+ * around `gh run view --json jobs` / `glab api projects/:id/pipelines/<id>/jobs`
+ * with identical `FailedJob[]` normalization on both sides.
+ *
+ * `run_id` is a positive integer — on GitHub it's the workflow run id,
+ * on GitLab the pipeline id.
+ */
+export interface CiFailedJobsArgs {
+  run_id: number;
+  repo?: string;
+}
+
+export interface FailedJob {
+  job_id: number;
+  name: string;
+  stage: string | null;
+  conclusion: string;
+  started_at: string | null;
+  finished_at: string | null;
+  url: string;
+}
+
+export interface CiFailedJobsResponse {
+  failed_jobs: FailedJob[];
+}
+
 export type CiRunsForBranchArgs = unknown;
 export type CiRunsForBranchResponse = unknown;
 

--- a/scripts/ci/migration-allowlist.txt
+++ b/scripts/ci/migration-allowlist.txt
@@ -9,7 +9,6 @@
 # off-by-one that was reconciled to disk reality).
 #
 # Format: one basename per line. Comments (#) and blank lines ignored.
-ci_failed_jobs.ts
 ci_run_logs.ts
 ci_run_status.ts
 ci_runs_for_branch.ts

--- a/tests/ci_failed_jobs.test.ts
+++ b/tests/ci_failed_jobs.test.ts
@@ -1,11 +1,27 @@
 import { describe, test, expect, mock, beforeEach } from 'bun:test';
 
 // --- Mock child_process.execSync at module level ---
+//
+// ci_failed_jobs now dispatches through the platform adapter (Story 2.11 /
+// #305). The per-platform adapters call subprocess via `runArgv`, which
+// shell-escapes its argv (`'gh' 'run' 'view' '12345' '--json' 'jobs'`). The
+// `unquote` shim strips that quoting so test match-keys can stay as plain
+// `gh run view 12345 --json jobs` strings — same pattern adopted by
+// tests/pr_files.test.ts.
+//
+// Integration coverage: schema validation, handler envelope shape, cross-repo
+// (`repo` flag forwarding). Subprocess-boundary argv assertions live in the
+// colocated adapter tests (lib/adapters/ci-failed-jobs-{github,gitlab}.test.ts).
+
 let execMockFn: (cmd: string) => string = () => '';
 const mockExecSync = mock((cmd: string, _opts?: unknown) => execMockFn(cmd));
 mock.module('child_process', () => ({ execSync: mockExecSync }));
 
 const { default: ciFailedJobsHandler } = await import('../handlers/ci_failed_jobs.ts');
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
 
 function parseResult(result: { content: Array<{ type: string; text: string }> }) {
   return JSON.parse(result.content[0].text) as Record<string, unknown>;
@@ -42,22 +58,14 @@ describe('ci_failed_jobs handler', () => {
     expect(data.ok).toBe(false);
   });
 
-  // --- GitHub: mixed success/fail ---
-  test('github_mixed — returns only non-success completed jobs', async () => {
+  // --- End-to-end: handler → adapter → subprocess → envelope ---
+  test('github_end_to_end — returns failed jobs in standard envelope', async () => {
     execMockFn = (cmd: string) => {
+      const flat = unquote(cmd);
       if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
-      if (cmd.startsWith('gh run view 12345 --json jobs')) {
+      if (flat.includes('gh run view 12345 --json jobs')) {
         return JSON.stringify({
           jobs: [
-            {
-              databaseId: 101,
-              name: 'lint',
-              status: 'completed',
-              conclusion: 'success',
-              startedAt: '2025-01-01T00:00:00Z',
-              completedAt: '2025-01-01T00:01:00Z',
-              url: 'https://github.com/org/repo/actions/runs/12345/job/101',
-            },
             {
               databaseId: 102,
               name: 'test',
@@ -67,15 +75,6 @@ describe('ci_failed_jobs handler', () => {
               completedAt: '2025-01-01T00:02:00Z',
               url: 'https://github.com/org/repo/actions/runs/12345/job/102',
             },
-            {
-              databaseId: 103,
-              name: 'build',
-              status: 'completed',
-              conclusion: 'timed_out',
-              startedAt: '2025-01-01T00:00:00Z',
-              completedAt: '2025-01-01T00:10:00Z',
-              url: 'https://github.com/org/repo/actions/runs/12345/job/103',
-            },
           ],
         });
       }
@@ -84,157 +83,21 @@ describe('ci_failed_jobs handler', () => {
 
     const result = await ciFailedJobsHandler.execute({ run_id: 12345 });
     const data = parseResult(result);
-
     expect(data.ok).toBe(true);
     expect(data.run_id).toBe(12345);
     const jobs = data.failed_jobs as Array<Record<string, unknown>>;
-    expect(jobs).toHaveLength(2);
+    expect(jobs).toHaveLength(1);
     expect(jobs[0].name).toBe('test');
     expect(jobs[0].conclusion).toBe('failure');
-    expect(jobs[0].job_id).toBe(102);
     expect(jobs[0].stage).toBeNull();
-    expect(jobs[0].started_at).toBe('2025-01-01T00:00:00Z');
-    expect(jobs[0].finished_at).toBe('2025-01-01T00:02:00Z');
-    expect(jobs[0].url).toBe('https://github.com/org/repo/actions/runs/12345/job/102');
-    expect(jobs[1].name).toBe('build');
-    expect(jobs[1].conclusion).toBe('timed_out');
   });
 
-  // --- GitHub: all success → empty ---
-  test('github_all_success — returns empty list', async () => {
+  test('gitlab_end_to_end — returns failed jobs with stage populated', async () => {
     execMockFn = (cmd: string) => {
-      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
-      if (cmd.startsWith('gh run view 999 --json jobs')) {
-        return JSON.stringify({
-          jobs: [
-            {
-              databaseId: 1,
-              name: 'lint',
-              status: 'completed',
-              conclusion: 'success',
-              startedAt: '2025-01-01T00:00:00Z',
-              completedAt: '2025-01-01T00:01:00Z',
-              url: 'https://github.com/org/repo/actions/runs/999/job/1',
-            },
-            {
-              databaseId: 2,
-              name: 'test',
-              status: 'completed',
-              conclusion: 'success',
-              startedAt: '2025-01-01T00:00:00Z',
-              completedAt: '2025-01-01T00:01:00Z',
-              url: 'https://github.com/org/repo/actions/runs/999/job/2',
-            },
-          ],
-        });
-      }
-      throw new Error(`Unexpected exec: ${cmd}`);
-    };
-
-    const result = await ciFailedJobsHandler.execute({ run_id: 999 });
-    const data = parseResult(result);
-
-    expect(data.ok).toBe(true);
-    expect(data.run_id).toBe(999);
-    expect(data.failed_jobs).toEqual([]);
-  });
-
-  // --- GitHub: all failed ---
-  test('github_all_failed — returns every job', async () => {
-    execMockFn = (cmd: string) => {
-      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
-      if (cmd.startsWith('gh run view 777 --json jobs')) {
-        return JSON.stringify({
-          jobs: [
-            {
-              databaseId: 10,
-              name: 'lint',
-              status: 'completed',
-              conclusion: 'failure',
-              startedAt: '2025-01-01T00:00:00Z',
-              completedAt: '2025-01-01T00:01:00Z',
-              url: 'https://github.com/org/repo/actions/runs/777/job/10',
-            },
-            {
-              databaseId: 11,
-              name: 'test',
-              status: 'completed',
-              conclusion: 'failure',
-              startedAt: '2025-01-01T00:00:00Z',
-              completedAt: '2025-01-01T00:02:00Z',
-              url: 'https://github.com/org/repo/actions/runs/777/job/11',
-            },
-          ],
-        });
-      }
-      throw new Error(`Unexpected exec: ${cmd}`);
-    };
-
-    const result = await ciFailedJobsHandler.execute({ run_id: 777 });
-    const data = parseResult(result);
-
-    expect(data.ok).toBe(true);
-    const jobs = data.failed_jobs as Array<Record<string, unknown>>;
-    expect(jobs).toHaveLength(2);
-    expect(jobs[0].name).toBe('lint');
-    expect(jobs[1].name).toBe('test');
-  });
-
-  // --- GitHub: excludes in-progress jobs (status != completed) ---
-  test('github_skips_in_progress — excludes jobs that have not completed', async () => {
-    execMockFn = (cmd: string) => {
-      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
-      if (cmd.startsWith('gh run view 555 --json jobs')) {
-        return JSON.stringify({
-          jobs: [
-            {
-              databaseId: 20,
-              name: 'still-running',
-              status: 'in_progress',
-              conclusion: null,
-              startedAt: '2025-01-01T00:00:00Z',
-              completedAt: null,
-              url: 'https://github.com/org/repo/actions/runs/555/job/20',
-            },
-            {
-              databaseId: 21,
-              name: 'done-failed',
-              status: 'completed',
-              conclusion: 'failure',
-              startedAt: '2025-01-01T00:00:00Z',
-              completedAt: '2025-01-01T00:02:00Z',
-              url: 'https://github.com/org/repo/actions/runs/555/job/21',
-            },
-          ],
-        });
-      }
-      throw new Error(`Unexpected exec: ${cmd}`);
-    };
-
-    const result = await ciFailedJobsHandler.execute({ run_id: 555 });
-    const data = parseResult(result);
-
-    expect(data.ok).toBe(true);
-    const jobs = data.failed_jobs as Array<Record<string, unknown>>;
-    expect(jobs).toHaveLength(1);
-    expect(jobs[0].name).toBe('done-failed');
-  });
-
-  // --- GitLab: mixed success/fail ---
-  test('gitlab_mixed — returns only failed jobs with stage field populated', async () => {
-    execMockFn = (cmd: string) => {
+      const flat = unquote(cmd);
       if (cmd.startsWith('git remote')) return 'https://gitlab.com/org/repo.git\n';
-      if (cmd.startsWith('glab api projects/:id/pipelines/42/jobs')) {
+      if (flat.includes('glab api projects/:id/pipelines/42/jobs')) {
         return JSON.stringify([
-          {
-            id: 201,
-            name: 'lint',
-            status: 'success',
-            stage: 'test',
-            started_at: '2025-02-01T00:00:00Z',
-            finished_at: '2025-02-01T00:01:00Z',
-            web_url: 'https://gitlab.com/org/repo/-/jobs/201',
-          },
           {
             id: 202,
             name: 'unit-test',
@@ -244,15 +107,6 @@ describe('ci_failed_jobs handler', () => {
             finished_at: '2025-02-01T00:03:00Z',
             web_url: 'https://gitlab.com/org/repo/-/jobs/202',
           },
-          {
-            id: 203,
-            name: 'deploy',
-            status: 'failed',
-            stage: 'deploy',
-            started_at: '2025-02-01T00:04:00Z',
-            finished_at: '2025-02-01T00:05:00Z',
-            web_url: 'https://gitlab.com/org/repo/-/jobs/203',
-          },
         ]);
       }
       throw new Error(`Unexpected exec: ${cmd}`);
@@ -260,120 +114,13 @@ describe('ci_failed_jobs handler', () => {
 
     const result = await ciFailedJobsHandler.execute({ run_id: 42 });
     const data = parseResult(result);
-
     expect(data.ok).toBe(true);
     expect(data.run_id).toBe(42);
     const jobs = data.failed_jobs as Array<Record<string, unknown>>;
-    expect(jobs).toHaveLength(2);
+    expect(jobs).toHaveLength(1);
     expect(jobs[0].name).toBe('unit-test');
     expect(jobs[0].stage).toBe('test');
     expect(jobs[0].conclusion).toBe('failure');
-    expect(jobs[0].job_id).toBe(202);
-    expect(jobs[0].started_at).toBe('2025-02-01T00:00:00Z');
-    expect(jobs[0].finished_at).toBe('2025-02-01T00:03:00Z');
-    expect(jobs[0].url).toBe('https://gitlab.com/org/repo/-/jobs/202');
-    expect(jobs[1].name).toBe('deploy');
-    expect(jobs[1].stage).toBe('deploy');
-  });
-
-  // --- GitLab: all success → empty ---
-  test('gitlab_all_success — returns empty list', async () => {
-    execMockFn = (cmd: string) => {
-      if (cmd.startsWith('git remote')) return 'https://gitlab.com/org/repo.git\n';
-      if (cmd.startsWith('glab api projects/:id/pipelines/1/jobs')) {
-        return JSON.stringify([
-          {
-            id: 1,
-            name: 'lint',
-            status: 'success',
-            stage: 'test',
-            started_at: '2025-02-01T00:00:00Z',
-            finished_at: '2025-02-01T00:01:00Z',
-            web_url: 'https://gitlab.com/org/repo/-/jobs/1',
-          },
-        ]);
-      }
-      throw new Error(`Unexpected exec: ${cmd}`);
-    };
-
-    const result = await ciFailedJobsHandler.execute({ run_id: 1 });
-    const data = parseResult(result);
-
-    expect(data.ok).toBe(true);
-    expect(data.failed_jobs).toEqual([]);
-  });
-
-  // --- GitLab: all failed ---
-  test('gitlab_all_failed — returns every job', async () => {
-    execMockFn = (cmd: string) => {
-      if (cmd.startsWith('git remote')) return 'https://gitlab.com/org/repo.git\n';
-      if (cmd.startsWith('glab api projects/:id/pipelines/88/jobs')) {
-        return JSON.stringify([
-          {
-            id: 301,
-            name: 'lint',
-            status: 'failed',
-            stage: 'test',
-            started_at: '2025-02-01T00:00:00Z',
-            finished_at: '2025-02-01T00:01:00Z',
-            web_url: 'https://gitlab.com/org/repo/-/jobs/301',
-          },
-          {
-            id: 302,
-            name: 'unit-test',
-            status: 'failed',
-            stage: 'test',
-            started_at: '2025-02-01T00:00:00Z',
-            finished_at: '2025-02-01T00:02:00Z',
-            web_url: 'https://gitlab.com/org/repo/-/jobs/302',
-          },
-        ]);
-      }
-      throw new Error(`Unexpected exec: ${cmd}`);
-    };
-
-    const result = await ciFailedJobsHandler.execute({ run_id: 88 });
-    const data = parseResult(result);
-
-    expect(data.ok).toBe(true);
-    const jobs = data.failed_jobs as Array<Record<string, unknown>>;
-    expect(jobs).toHaveLength(2);
-    expect(jobs[0].conclusion).toBe('failure');
-    expect(jobs[1].conclusion).toBe('failure');
-  });
-
-  // --- GitLab: skips non-failed statuses (canceled, skipped, pending) ---
-  test('gitlab_skips_non_failed — excludes canceled, skipped, pending jobs', async () => {
-    execMockFn = (cmd: string) => {
-      if (cmd.startsWith('git remote')) return 'https://gitlab.com/org/repo.git\n';
-      if (cmd.startsWith('glab api projects/:id/pipelines/66/jobs')) {
-        return JSON.stringify([
-          { id: 1, name: 'cancelled-job', status: 'canceled', stage: 'test' },
-          { id: 2, name: 'pending-job', status: 'pending', stage: 'test' },
-          { id: 3, name: 'skipped-job', status: 'skipped', stage: 'test' },
-          {
-            id: 4,
-            name: 'real-failure',
-            status: 'failed',
-            stage: 'test',
-            started_at: null,
-            finished_at: null,
-            web_url: 'https://gitlab.com/org/repo/-/jobs/4',
-          },
-        ]);
-      }
-      throw new Error(`Unexpected exec: ${cmd}`);
-    };
-
-    const result = await ciFailedJobsHandler.execute({ run_id: 66 });
-    const data = parseResult(result);
-
-    expect(data.ok).toBe(true);
-    const jobs = data.failed_jobs as Array<Record<string, unknown>>;
-    expect(jobs).toHaveLength(1);
-    expect(jobs[0].name).toBe('real-failure');
-    expect(jobs[0].started_at).toBeNull();
-    expect(jobs[0].finished_at).toBeNull();
   });
 
   // --- Issue #197: cross-repo orchestration via explicit `repo` ---
@@ -381,10 +128,11 @@ describe('ci_failed_jobs handler', () => {
   test('github_explicit_repo — appends --repo flag to gh run view', async () => {
     let sawRepoFlag = false;
     execMockFn = (cmd: string) => {
+      const flat = unquote(cmd);
       if (cmd.startsWith('git remote'))
         return 'https://github.com/cwd-org/cwd-repo.git\n';
-      if (cmd.startsWith('gh run view 777 --json jobs')) {
-        if (cmd.includes('--repo other-org/other-repo')) sawRepoFlag = true;
+      if (flat.includes('gh run view 777 --json jobs')) {
+        if (flat.includes('--repo other-org/other-repo')) sawRepoFlag = true;
         return JSON.stringify({
           jobs: [
             {
@@ -415,13 +163,13 @@ describe('ci_failed_jobs handler', () => {
     let sawExplicitPath = false;
     let sawColonId = false;
     execMockFn = (cmd: string) => {
+      const flat = unquote(cmd);
       if (cmd.startsWith('git remote'))
         return 'https://gitlab.com/cwd-org/cwd-repo.git\n';
-      if (cmd.startsWith('glab api')) {
-        if (cmd.includes('projects/other-org%2Fother-repo/pipelines/101/jobs'))
+      if (flat.includes('glab api')) {
+        if (flat.includes('projects/other-org%2Fother-repo/pipelines/101/jobs'))
           sawExplicitPath = true;
-        if (cmd.includes('projects/:id/pipelines/101/jobs'))
-          sawColonId = true;
+        if (flat.includes('projects/:id/pipelines/101/jobs')) sawColonId = true;
         return JSON.stringify([
           {
             id: 501,
@@ -450,11 +198,11 @@ describe('ci_failed_jobs handler', () => {
   test('regression_no_repo — preserves :id shorthand when repo not provided', async () => {
     let sawColonId = false;
     execMockFn = (cmd: string) => {
+      const flat = unquote(cmd);
       if (cmd.startsWith('git remote'))
         return 'https://gitlab.com/org/repo.git\n';
-      if (cmd.startsWith('glab api')) {
-        if (cmd.includes('projects/:id/pipelines/202/jobs'))
-          sawColonId = true;
+      if (flat.includes('glab api')) {
+        if (flat.includes('projects/:id/pipelines/202/jobs')) sawColonId = true;
         return JSON.stringify([]);
       }
       throw new Error(`Unexpected exec: ${cmd}`);
@@ -470,7 +218,7 @@ describe('ci_failed_jobs handler', () => {
   test('exec_error — surfaces platform command failure as ok:false', async () => {
     execMockFn = (cmd: string) => {
       if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
-      if (cmd.startsWith('gh run view')) {
+      if (cmd.includes('gh') && cmd.includes('run') && cmd.includes('view')) {
         throw new Error('gh: run not found');
       }
       throw new Error(`Unexpected exec: ${cmd}`);


### PR DESCRIPTION
## Summary

Migrates `ci_failed_jobs` from a platform-branching handler to the platform adapter pattern. The handler becomes a thin dispatcher (52 lines, was 161); GitHub and GitLab paths move to colocated adapters with typed `CiFailedJobsArgs` / `CiFailedJobsResponse` contracts.

## Changes

- `handlers/ci_failed_jobs.ts` — reduced to validate -> dispatch -> envelope; no `platform === ...`, no `execSync`.
- `lib/adapters/ci-failed-jobs-github.ts` — NEW. `gh run view <id> --json jobs [--repo <slug>]`, filter completed + non-success, normalize to `FailedJob[]` with `stage: null`.
- `lib/adapters/ci-failed-jobs-gitlab.ts` — NEW. `glab api projects/.../pipelines/<id>/jobs`, filter `status=failed`, normalize to `FailedJob[]` with `stage` from job record.
- `lib/adapters/github.ts` / `gitlab.ts` — wired `ciFailedJobsGithub` / `ciFailedJobsGitlab`.
- `lib/adapters/types.ts` — tightened `PlatformAdapter.ciFailedJobs` signature; exported `FailedJob`.
- `lib/adapters/types.test.ts` — added `'ciFailedJobs'` to `MIGRATED_METHODS`.
- `scripts/ci/migration-allowlist.txt` — removed `ci_failed_jobs.ts`.
- Colocated adapter tests added; integration tests in `tests/ci_failed_jobs.test.ts` trimmed (485 -> 231 lines), with `unquote` shim for shell-escaped argv.

## Linked Issues

Closes #305

## Test Plan

- `./scripts/ci/validate.sh` -> PASS (codegen, lint, gate-greps, shellcheck, tests, smoke; 73/73 tools assertions).
- `bun test` -> 1690 pass / 0 fail across full suite.
- Targeted: `bun test lib/adapters/ci-failed-jobs-*.test.ts tests/ci_failed_jobs.test.ts` -> 25 pass / 0 fail / 56 expect() calls.
- Gate-greps clean on `handlers/ci_failed_jobs.ts`: no platform-branch, no subprocess.