### PR TITLE
refactor(label_create): migrate to platform adapter (#309)

### DIFF
--- a/handlers/label_create.ts
+++ b/handlers/label_create.ts
@@ -1,13 +1,19 @@
-// Origin Operations family handler.
-// See docs/handlers/origin-operations-guide.md for the canonical pattern,
-// gh ↔ glab field mappings, and normalized response schemas.
+// Origin Operations family handler — adapter-dispatching shell.
+// Subprocess + platform branching live in lib/adapters/label-create-{github,gitlab}.ts
+// per Story 2.15 (#309); see docs/handlers/origin-operations-guide.md for the
+// canonical pattern and docs/platform-adapter-retrofit-devspec.md §5 for the
+// contract.
+//
+// Color contract: schema accepts BARE 6-char hex (no leading `#`). Adapters
+// own the platform-specific hand-off — gh takes bare hex, glab prepends `#`.
+// See `lesson_origin_ops_pitfalls.md`.
 
-import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { getAdapter } from '../lib/adapters/index.js';
 
-// 6-char hex (no leading #). Both gh and glab accept color in this form.
+// 6-char hex (no leading #). Both gh and glab accept color in this form at
+// the adapter boundary; glab's `#` prefix is applied inside the adapter.
 const HEX_COLOR_RE = /^[0-9a-fA-F]{6}$/;
 
 const inputSchema = z.object({
@@ -23,160 +29,8 @@ const inputSchema = z.object({
     .optional(),
 });
 
-type Input = z.infer<typeof inputSchema>;
-
-interface NormalizedLabel {
-  name: string;
-  description: string;
-  color: string;
-  created: boolean; // true if newly created, false if already existed
-}
-
-interface ExecError extends Error {
-  stderr?: Buffer | string;
-  stdout?: Buffer | string;
-}
-
-function bufToString(b: unknown): string {
-  if (b === undefined || b === null) return '';
-  if (typeof b === 'string') return b;
-  if (typeof (b as Buffer).toString === 'function') return (b as Buffer).toString();
-  return String(b);
-}
-
-function exec(cmd: string): { ok: boolean; stdout: string; stderr: string } {
-  try {
-    const out = execSync(cmd, { encoding: 'utf8' });
-    return { ok: true, stdout: out.trim(), stderr: '' };
-  } catch (err) {
-    const e = err as ExecError;
-    return {
-      ok: false,
-      stdout: bufToString(e.stdout).trim(),
-      stderr: bufToString(e.stderr).trim() || e.message || '',
-    };
-  }
-}
-
-function quoteArg(s: string): string {
-  return `'${s.replace(/'/g, `'\\''`)}'`;
-}
-
-/**
- * gh and glab both report "label already exists" on the duplicate path.
- * Heuristic match — phrasing varies across CLI versions but consistently
- * includes the substring "already exists".
- */
-function stderrIndicatesDuplicate(text: string): boolean {
-  return /already exists/i.test(text);
-}
-
-function lookupGithubLabel(name: string, repo: string | undefined): NormalizedLabel | null {
-  const parts = ['gh', 'label', 'list', '--search', quoteArg(name), '--json', 'name,description,color', '--limit', '20'];
-  if (repo !== undefined) {
-    parts.push('--repo', quoteArg(repo));
-  }
-  const result = exec(parts.join(' '));
-  if (!result.ok) return null;
-  try {
-    const labels = JSON.parse(result.stdout) as Array<{ name: string; description?: string; color?: string }>;
-    // gh label list --search is a fuzzy match; pick the exact case-insensitive name.
-    const match = labels.find((l) => l.name.toLowerCase() === name.toLowerCase());
-    if (match === undefined) return null;
-    return {
-      name: match.name,
-      description: match.description ?? '',
-      color: match.color ?? '',
-      created: false,
-    };
-  } catch {
-    return null;
-  }
-}
-
-function createGithubLabel(args: Input): NormalizedLabel {
-  const parts = ['gh', 'label', 'create', quoteArg(args.name)];
-  if (args.description.length > 0) {
-    parts.push('--description', quoteArg(args.description));
-  }
-  if (args.color !== undefined) {
-    parts.push('--color', quoteArg(args.color));
-  }
-  if (args.repo !== undefined) {
-    parts.push('--repo', quoteArg(args.repo));
-  }
-  const result = exec(parts.join(' '));
-  if (!result.ok) {
-    if (stderrIndicatesDuplicate(result.stderr) || stderrIndicatesDuplicate(result.stdout)) {
-      const existing = lookupGithubLabel(args.name, args.repo);
-      if (existing !== null) return existing;
-      throw new Error(
-        `gh label create: label '${args.name}' already exists but could not be found via lookup`,
-      );
-    }
-    throw new Error(`gh label create failed: ${result.stderr || result.stdout}`);
-  }
-  return {
-    name: args.name,
-    description: args.description,
-    color: args.color ?? '',
-    created: true,
-  };
-}
-
-function lookupGitlabLabel(name: string, repo: string | undefined): NormalizedLabel | null {
-  const parts = ['glab', 'label', 'list', '-F', 'json', '--per-page', '100'];
-  if (repo !== undefined) {
-    parts.push('-R', quoteArg(repo));
-  }
-  const result = exec(parts.join(' '));
-  if (!result.ok) return null;
-  try {
-    const labels = JSON.parse(result.stdout) as Array<{ name: string; description?: string; color?: string }>;
-    const match = labels.find((l) => l.name.toLowerCase() === name.toLowerCase());
-    if (match === undefined) return null;
-    return {
-      name: match.name,
-      description: match.description ?? '',
-      color: (match.color ?? '').replace(/^#/, ''),
-      created: false,
-    };
-  } catch {
-    return null;
-  }
-}
-
-function createGitlabLabel(args: Input): NormalizedLabel {
-  const parts = ['glab', 'label', 'create', '--name', quoteArg(args.name)];
-  if (args.description.length > 0) {
-    parts.push('--description', quoteArg(args.description));
-  }
-  if (args.color !== undefined) {
-    // GitLab's REST API requires `#RRGGBB`; bare hex is rejected. Schema
-    // takes bare hex (consumer-friendly, symmetric with the gh path);
-    // prepend the `#` here when handing off to glab.
-    parts.push('--color', quoteArg(`#${args.color}`));
-  }
-  if (args.repo !== undefined) {
-    parts.push('-R', quoteArg(args.repo));
-  }
-  const result = exec(parts.join(' '));
-  if (!result.ok) {
-    if (stderrIndicatesDuplicate(result.stderr) || stderrIndicatesDuplicate(result.stdout)) {
-      const existing = lookupGitlabLabel(args.name, args.repo);
-      if (existing !== null) return existing;
-      throw new Error(
-        `glab label create: label '${args.name}' already exists but could not be found via lookup`,
-      );
-    }
-    throw new Error(`glab label create failed: ${result.stderr || result.stdout}`);
-  }
-  return {
-    name: args.name,
-    description: args.description,
-    color: args.color ?? '',
-    created: true,
-  };
+function envelope(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] };
 }
 
 const labelCreateHandler: HandlerDef = {
@@ -185,28 +39,21 @@ const labelCreateHandler: HandlerDef = {
     'Create a label on the current repo. Idempotent: returns the existing label with `created: false` if it already exists. Color is a 6-char hex (no leading #). Cross-platform (gh + glab).',
   inputSchema,
   async execute(rawArgs: unknown) {
-    let args: Input;
+    let args;
     try {
       args = inputSchema.parse(rawArgs);
     } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
 
-    try {
-      const platform = detectPlatform();
-      const label = platform === 'github' ? createGithubLabel(args) : createGitlabLabel(args);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: true, ...label }) }],
-      };
-    } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+    const adapter = getAdapter({ repo: args.repo });
+    const result = await adapter.labelCreate(args);
+
+    if ('platform_unsupported' in result) {
+      return envelope({ ok: false, error: result.hint });
     }
+    if (!result.ok) return envelope({ ok: false, error: result.error });
+    return envelope({ ok: true, ...result.data });
   },
 };
 

--- a/lib/adapters/github.ts
+++ b/lib/adapters/github.ts
@@ -20,6 +20,7 @@ import { ciRunStatusGithub } from './ci-run-status-github.js';
 import { ciRunsForBranchGithub } from './ci-runs-for-branch-github.js';
 import { fetchIssueGithub } from './fetch-issue-github.js';
 import { fetchPrStateGithub } from './fetch-pr-state-github.js';
+import { labelCreateGithub } from './label-create-github.js';
 import { prCommentGithub } from './pr-comment-github.js';
 import { prCreateGithub } from './pr-create-github.js';
 import { prDiffGithub } from './pr-diff-github.js';
@@ -50,7 +51,7 @@ export const githubAdapter: PlatformAdapter = {
   ciRunLogs: ciRunLogsGithub,
   ciFailedJobs: ciFailedJobsGithub,
   ciRunsForBranch: ciRunsForBranchGithub,
-  labelCreate: stubMethod,
+  labelCreate: labelCreateGithub,
   labelList: stubMethod,
   workItem: stubMethod,
   ibm: stubMethod,

--- a/lib/adapters/gitlab.ts
+++ b/lib/adapters/gitlab.ts
@@ -21,6 +21,7 @@ import { ciRunStatusGitlab } from './ci-run-status-gitlab.js';
 import { ciRunsForBranchGitlab } from './ci-runs-for-branch-gitlab.js';
 import { fetchIssueGitlab } from './fetch-issue-gitlab.js';
 import { fetchPrStateGitlab } from './fetch-pr-state-gitlab.js';
+import { labelCreateGitlab } from './label-create-gitlab.js';
 import { prCommentGitlab } from './pr-comment-gitlab.js';
 import { prCreateGitlab } from './pr-create-gitlab.js';
 import { prDiffGitlab } from './pr-diff-gitlab.js';
@@ -51,7 +52,7 @@ export const gitlabAdapter: PlatformAdapter = {
   ciRunLogs: ciRunLogsGitlab,
   ciFailedJobs: ciFailedJobsGitlab,
   ciRunsForBranch: ciRunsForBranchGitlab,
-  labelCreate: stubMethod,
+  labelCreate: labelCreateGitlab,
   labelList: stubMethod,
   workItem: stubMethod,
   ibm: stubMethod,

--- a/lib/adapters/label-create-github.test.ts
+++ b/lib/adapters/label-create-github.test.ts
@@ -1,0 +1,279 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { AdapterResult, NormalizedLabel } from './types.ts';
+
+// Subprocess-boundary tests for the GitHub label_create adapter (R-15).
+// Integration-level coverage (schema validation, handler envelope, cross-platform
+// dispatch) stays in tests/label_create.test.ts; this file owns the argv-shape
+// assertions that prove the adapter speaks `gh` correctly.
+//
+// Color format strictness — gh accepts BARE 6-char hex (no leading `#`).
+// The stub fails loudly if we forget and emit `--color '#d73a4a'` on the
+// GitHub side (per `lesson_origin_ops_pitfalls.md`).
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  // Argv strictness — leading-# color on the gh path means we regressed.
+  // Fail LOUDLY rather than let the test silently pass.
+  if (flat.includes("gh label create") && flat.includes("--color #")) {
+    const err = new Error(
+      `FAIL: gh label create invoked with leading-# color — gh requires BARE hex`,
+    ) as ThrowableError;
+    err.status = 127;
+    throw err;
+  }
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { labelCreateGithub } = await import('./label-create-github.ts');
+
+function on(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
+function expectOk(
+  r: AdapterResult<NormalizedLabel>,
+): asserts r is { ok: true; data: NormalizedLabel } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectErr(
+  r: AdapterResult<NormalizedLabel>,
+): asserts r is { ok: false; error: string; code: string } {
+  if (!('ok' in r) || r.ok) {
+    throw new Error(`expected error result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('labelCreateGithub — subprocess boundary', () => {
+  // --- argv: gh label create (bare-hex color) ---
+
+  test('argv: gh label create (bare-hex color)', async () => {
+    on('gh label create', '');
+
+    const result = await labelCreateGithub({
+      name: 'priority::high',
+      color: 'd73a4a',
+      description: 'Top priority',
+    });
+    expectOk(result);
+
+    const call = findCall('gh label create');
+    expect(call).toContain('priority::high');
+    // Bare hex — no leading `#` on the gh path.
+    expect(call).toContain("'--color' 'd73a4a'");
+    expect(call).not.toContain("'#d73a4a'");
+    expect(call).toContain("'--description' 'Top priority'");
+  });
+
+  test('argv: omits --color when color not provided', async () => {
+    on('gh label create', '');
+
+    const result = await labelCreateGithub({ name: 'bug' });
+    expectOk(result);
+
+    const call = findCall('gh label create');
+    expect(call).not.toContain('--color');
+  });
+
+  test('argv: omits --description when description empty', async () => {
+    on('gh label create', '');
+
+    await labelCreateGithub({ name: 'bug', color: 'd73a4a' });
+
+    const call = findCall('gh label create');
+    expect(call).not.toContain('--description');
+  });
+
+  test('argv: --repo flag forwarded for cross-repo create', async () => {
+    on('gh label create', '');
+
+    await labelCreateGithub({ name: 'bug', color: 'd73a4a', repo: 'other-org/other-repo' });
+
+    const call = findCall('gh label create');
+    expect(call).toContain("'--repo' 'other-org/other-repo'");
+  });
+
+  test('argv: quotes name with shell-escape', async () => {
+    on('gh label create', '');
+
+    await labelCreateGithub({ name: "needs-review's-input", color: 'd73a4a' });
+
+    const call = findCall('gh label create');
+    expect(call).toContain(`'needs-review'\\''s-input'`);
+  });
+
+  // --- happy path: creates new label ---
+
+  test('creates new label — returns created:true with caller-requested fields', async () => {
+    on('gh label create', '');
+
+    const result = await labelCreateGithub({
+      name: 'priority::high',
+      color: 'd73a4a',
+      description: 'Top priority',
+    });
+    expectOk(result);
+
+    expect(result.data).toEqual({
+      name: 'priority::high',
+      description: 'Top priority',
+      color: 'd73a4a',
+      created: true,
+    });
+  });
+
+  // --- duplicate-lookup fallback ---
+
+  test('duplicate-lookup fallback on "already exists"', async () => {
+    on('gh label create', () => {
+      const err = new Error('label already exists') as ThrowableError;
+      err.stderr = '! Label "bug" already exists\n';
+      err.status = 1;
+      throw err;
+    });
+    on(
+      'gh label list',
+      JSON.stringify([{ name: 'bug', description: 'pre-existing', color: 'aabbcc' }]),
+    );
+
+    const result = await labelCreateGithub({
+      name: 'bug',
+      description: 'requested (ignored)',
+      color: 'd73a4a',
+    });
+    expectOk(result);
+
+    // Returned values reflect what's on the platform, not what we asked for.
+    expect(result.data).toEqual({
+      name: 'bug',
+      description: 'pre-existing',
+      color: 'aabbcc',
+      created: false,
+    });
+
+    // Lookup argv: --search <name>, --json, --limit 20.
+    const lookupCall = findCall('gh label list');
+    expect(lookupCall).toContain("'--search' 'bug'");
+    expect(lookupCall).toContain('--json');
+    expect(lookupCall).toContain('name,description,color');
+    expect(lookupCall).toContain("'--limit' '20'");
+  });
+
+  test('duplicate-lookup forwards --repo on the lookup call too', async () => {
+    on('gh label create', () => {
+      const err = new Error('already exists') as ThrowableError;
+      err.stderr = 'Label already exists\n';
+      err.status = 1;
+      throw err;
+    });
+    on(
+      'gh label list',
+      JSON.stringify([{ name: 'bug', description: '', color: 'aabbcc' }]),
+    );
+
+    await labelCreateGithub({ name: 'bug', color: 'd73a4a', repo: 'foo/bar' });
+
+    const lookupCall = findCall('gh label list');
+    expect(lookupCall).toContain("'--repo' 'foo/bar'");
+  });
+
+  test('duplicate detection is case-insensitive (Already Exists)', async () => {
+    on('gh label create', () => {
+      const err = new Error('') as ThrowableError;
+      err.stderr = 'Label Already Exists in repo\n';
+      err.status = 1;
+      throw err;
+    });
+    on(
+      'gh label list',
+      JSON.stringify([{ name: 'bug', description: '', color: '' }]),
+    );
+
+    const result = await labelCreateGithub({ name: 'bug', color: 'd73a4a' });
+    expectOk(result);
+    expect(result.data.created).toBe(false);
+  });
+
+  test('duplicate detection also matches against stdout', async () => {
+    on('gh label create', () => {
+      const err = new Error('') as ThrowableError;
+      err.stdout = 'label already exists\n';
+      err.stderr = '';
+      err.status = 1;
+      throw err;
+    });
+    on(
+      'gh label list',
+      JSON.stringify([{ name: 'bug', description: '', color: '' }]),
+    );
+
+    const result = await labelCreateGithub({ name: 'bug', color: 'd73a4a' });
+    expectOk(result);
+    expect(result.data.created).toBe(false);
+  });
+
+  test('duplicate lookup misses → ok:false with gh_label_lookup_failed code', async () => {
+    on('gh label create', () => {
+      const err = new Error('already exists') as ThrowableError;
+      err.stderr = 'Label already exists\n';
+      err.status = 1;
+      throw err;
+    });
+    on('gh label list', JSON.stringify([])); // lookup returns no matches
+
+    const result = await labelCreateGithub({ name: 'bug', color: 'd73a4a' });
+    expectErr(result);
+    expect(result.code).toBe('gh_label_lookup_failed');
+  });
+
+  // --- error surface ---
+
+  test('returns AdapterResult.error on non-duplicate gh failure (not thrown)', async () => {
+    on('gh label create', () => {
+      const err = new Error('gh: not authenticated') as ThrowableError;
+      err.stderr = 'gh: not authenticated';
+      err.status = 1;
+      throw err;
+    });
+
+    const result = await labelCreateGithub({ name: 'bug', color: 'd73a4a' });
+    expectErr(result);
+    expect(result.code).toBe('gh_label_create_failed');
+    expect(result.error).toContain('gh label create failed');
+  });
+});

--- a/lib/adapters/label-create-github.ts
+++ b/lib/adapters/label-create-github.ts
@@ -1,0 +1,125 @@
+/**
+ * GitHub `label_create` adapter implementation.
+ *
+ * Lifted from `handlers/label_create.ts` per Story 2.15 (#309). The handler
+ * is now a thin dispatcher; this module owns the GitHub-specific subprocess
+ * work (argv composition + `gh label create` invocation) AND the
+ * idempotent-duplicate-lookup retry that swallows "already exists" into a
+ * `created: false` success.
+ *
+ * Argv composition (create):
+ *   gh label create <name>
+ *     [--description <description>]
+ *     [--color <bare-hex>]      // gh accepts bare 6-char hex (no leading `#`)
+ *     [--repo <owner/repo>]
+ *
+ * Argv composition (duplicate-lookup fallback):
+ *   gh label list --search <name> --json name,description,color --limit 20
+ *     [--repo <owner/repo>]
+ *
+ * Color asymmetry (per `lesson_origin_ops_pitfalls.md`):
+ *   - GitHub: bare hex `RRGGBB` — no leading `#`. gh REJECTS `#RRGGBB`.
+ *   - GitLab: leading `#RRGGBB` — GitLab REST API REJECTS bare hex.
+ *   The handler's schema accepts bare hex (consumer-symmetric); the GitLab
+ *   adapter prepends the `#` before handing off to `glab`.
+ */
+
+import { execSync } from 'child_process';
+import { runArgv } from '../shared/error-norm.js';
+import type {
+  AdapterResult,
+  LabelCreateArgs,
+  NormalizedLabel,
+} from './types.js';
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+/**
+ * gh reports "label already exists" on the duplicate path. Heuristic match —
+ * phrasing varies across CLI versions but consistently includes the substring
+ * "already exists". Case-insensitive — "Already Exists" seen in the wild too.
+ */
+function stderrIndicatesDuplicate(text: string): boolean {
+  return /already exists/i.test(text);
+}
+
+function lookupGithubLabel(
+  name: string,
+  repo: string | undefined,
+  cwd: string,
+): NormalizedLabel | null {
+  const cmd = ['gh', 'label', 'list', '--search', name, '--json', 'name,description,color', '--limit', '20'];
+  if (repo !== undefined) cmd.push('--repo', repo);
+  const result = runArgv(cmd, cwd);
+  if (result.exitCode !== 0) return null;
+  try {
+    const labels = JSON.parse(result.stdout) as Array<{ name: string; description?: string; color?: string }>;
+    // gh label list --search is a fuzzy match; pick the exact case-insensitive name.
+    const match = labels.find((l) => l.name.toLowerCase() === name.toLowerCase());
+    if (match === undefined) return null;
+    return {
+      name: match.name,
+      description: match.description ?? '',
+      color: match.color ?? '',
+      created: false,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function labelCreateGithub(
+  args: LabelCreateArgs,
+): Promise<AdapterResult<NormalizedLabel>> {
+  try {
+    const cwd = projectDir();
+    const description = args.description ?? '';
+
+    const cmd = ['gh', 'label', 'create', args.name];
+    if (description.length > 0) cmd.push('--description', description);
+    if (args.color !== undefined) cmd.push('--color', args.color);
+    if (args.repo !== undefined) cmd.push('--repo', args.repo);
+
+    const result = runArgv(cmd, cwd);
+    if (result.exitCode !== 0) {
+      const combined = `${result.stderr}\n${result.stdout}`;
+      if (stderrIndicatesDuplicate(combined)) {
+        const existing = lookupGithubLabel(args.name, args.repo, cwd);
+        if (existing !== null) return { ok: true, data: existing };
+        return {
+          ok: false,
+          code: 'gh_label_lookup_failed',
+          error: `gh label create: label '${args.name}' already exists but could not be found via lookup`,
+        };
+      }
+      return {
+        ok: false,
+        code: 'gh_label_create_failed',
+        error: `gh label create failed: ${result.stderr.trim() || result.stdout.trim()}`,
+      };
+    }
+
+    return {
+      ok: true,
+      data: {
+        name: args.name,
+        description,
+        color: args.color ?? '',
+        created: true,
+      },
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'unexpected_error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// `execSync` is intentionally re-imported above so that adapter-level test
+// files can `mock.module('child_process', ...)` and intercept this module's
+// subprocess calls without needing access to the handler's mock setup.
+void execSync;

--- a/lib/adapters/label-create-gitlab.test.ts
+++ b/lib/adapters/label-create-gitlab.test.ts
@@ -1,0 +1,246 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { AdapterResult, NormalizedLabel } from './types.ts';
+
+// Subprocess-boundary tests for the GitLab label_create adapter (R-15).
+// Integration-level coverage (schema validation, handler envelope, cross-platform
+// dispatch) stays in tests/label_create.test.ts; this file owns the argv-shape
+// assertions that prove the adapter speaks `glab` correctly.
+//
+// Color format strictness — GitLab REST API REQUIRES leading `#RRGGBB`; bare
+// hex is rejected. The stub fails loudly if we forget and emit `--color 'd73a4a'`
+// on the GitLab side (per `lesson_origin_ops_pitfalls.md`).
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  // Argv strictness — bare-hex color on the glab path means we regressed.
+  // Fail LOUDLY rather than let the test silently pass.
+  if (flat.includes('glab label create') && /--color [0-9a-fA-F]{6}/.test(flat)) {
+    const err = new Error(
+      `FAIL: glab label create invoked with bare-hex color — GitLab requires leading '#'`,
+    ) as ThrowableError;
+    err.status = 127;
+    throw err;
+  }
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { labelCreateGitlab } = await import('./label-create-gitlab.ts');
+
+function on(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
+function expectOk(
+  r: AdapterResult<NormalizedLabel>,
+): asserts r is { ok: true; data: NormalizedLabel } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectErr(
+  r: AdapterResult<NormalizedLabel>,
+): asserts r is { ok: false; error: string; code: string } {
+  if (!('ok' in r) || r.ok) {
+    throw new Error(`expected error result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('labelCreateGitlab — subprocess boundary', () => {
+  // --- argv: glab label create (leading-# color) ---
+
+  test('argv: glab api ... (leading-# color)', async () => {
+    on('glab label create', '');
+
+    const result = await labelCreateGitlab({
+      name: 'priority::high',
+      color: 'd73a4a',
+      description: 'Top priority',
+    });
+    expectOk(result);
+
+    const call = findCall('glab label create');
+    // --name is a flag, not positional, on the glab path.
+    expect(call).toContain("'--name' 'priority::high'");
+    // Leading `#` prepended — GitLab REST API rejects bare hex.
+    expect(call).toContain("'--color' '#d73a4a'");
+    expect(call).not.toContain("'--color' 'd73a4a'");
+    expect(call).toContain("'--description' 'Top priority'");
+  });
+
+  test('argv: omits --color when color not provided', async () => {
+    on('glab label create', '');
+
+    const result = await labelCreateGitlab({ name: 'bug' });
+    expectOk(result);
+
+    const call = findCall('glab label create');
+    expect(call).not.toContain('--color');
+  });
+
+  test('argv: omits --description when description empty', async () => {
+    on('glab label create', '');
+
+    await labelCreateGitlab({ name: 'bug', color: 'd73a4a' });
+
+    const call = findCall('glab label create');
+    expect(call).not.toContain('--description');
+  });
+
+  test('argv: -R flag (not --repo) forwarded for cross-repo create', async () => {
+    on('glab label create', '');
+
+    await labelCreateGitlab({ name: 'bug', color: 'd73a4a', repo: 'foo/bar' });
+
+    const call = findCall('glab label create');
+    // glab uses short `-R`, NOT `--repo`.
+    expect(call).toContain("'-R' 'foo/bar'");
+    expect(call).not.toContain('--repo');
+  });
+
+  test('argv: quotes name with shell-escape', async () => {
+    on('glab label create', '');
+
+    await labelCreateGitlab({ name: "needs-review's-input", color: 'd73a4a' });
+
+    const call = findCall('glab label create');
+    expect(call).toContain(`'needs-review'\\''s-input'`);
+  });
+
+  // --- happy path: creates new label ---
+
+  test('creates new label — returns created:true with caller-requested fields', async () => {
+    on('glab label create', '');
+
+    const result = await labelCreateGitlab({
+      name: 'priority::high',
+      color: 'd73a4a',
+      description: 'Top priority',
+    });
+    expectOk(result);
+
+    // Response mirrors caller input (bare hex) — the `#` only exists on-wire.
+    expect(result.data).toEqual({
+      name: 'priority::high',
+      description: 'Top priority',
+      color: 'd73a4a',
+      created: true,
+    });
+  });
+
+  // --- duplicate-lookup fallback ---
+
+  test('duplicate-lookup fallback', async () => {
+    on('glab label create', () => {
+      const err = new Error('label already exists') as ThrowableError;
+      err.stderr = 'Label already exists\n';
+      err.status = 1;
+      throw err;
+    });
+    on(
+      'glab label list',
+      JSON.stringify([{ name: 'bug', description: 'pre-existing', color: '#aabbcc' }]),
+    );
+
+    const result = await labelCreateGitlab({
+      name: 'bug',
+      description: 'ignored',
+      color: 'd73a4a',
+    });
+    expectOk(result);
+
+    // `#` stripped — consumers always see bare hex.
+    expect(result.data).toEqual({
+      name: 'bug',
+      description: 'pre-existing',
+      color: 'aabbcc',
+      created: false,
+    });
+
+    // Lookup argv: -F json --per-page 100
+    const lookupCall = findCall('glab label list');
+    expect(lookupCall).toContain("'-F' 'json'");
+    expect(lookupCall).toContain("'--per-page' '100'");
+  });
+
+  test('duplicate-lookup forwards -R on the lookup call too', async () => {
+    on('glab label create', () => {
+      const err = new Error('already exists') as ThrowableError;
+      err.stderr = 'Label already exists\n';
+      err.status = 1;
+      throw err;
+    });
+    on(
+      'glab label list',
+      JSON.stringify([{ name: 'bug', description: '', color: '#aabbcc' }]),
+    );
+
+    await labelCreateGitlab({ name: 'bug', color: 'd73a4a', repo: 'foo/bar' });
+
+    const lookupCall = findCall('glab label list');
+    expect(lookupCall).toContain("'-R' 'foo/bar'");
+  });
+
+  test('duplicate lookup misses → ok:false with glab_label_lookup_failed code', async () => {
+    on('glab label create', () => {
+      const err = new Error('already exists') as ThrowableError;
+      err.stderr = 'Label already exists\n';
+      err.status = 1;
+      throw err;
+    });
+    on('glab label list', JSON.stringify([])); // lookup returns no matches
+
+    const result = await labelCreateGitlab({ name: 'bug', color: 'd73a4a' });
+    expectErr(result);
+    expect(result.code).toBe('glab_label_lookup_failed');
+  });
+
+  // --- error surface ---
+
+  test('returns AdapterResult.error on non-duplicate glab failure (not thrown)', async () => {
+    on('glab label create', () => {
+      const err = new Error('glab: 401 unauthorized') as ThrowableError;
+      err.stderr = 'glab: 401 unauthorized';
+      err.status = 1;
+      throw err;
+    });
+
+    const result = await labelCreateGitlab({ name: 'bug', color: 'd73a4a' });
+    expectErr(result);
+    expect(result.code).toBe('glab_label_create_failed');
+    expect(result.error).toContain('glab label create failed');
+  });
+});

--- a/lib/adapters/label-create-gitlab.ts
+++ b/lib/adapters/label-create-gitlab.ts
@@ -1,0 +1,124 @@
+/**
+ * GitLab `label_create` adapter implementation.
+ *
+ * Lifted from `handlers/label_create.ts` per Story 2.15 (#309). Mirrors
+ * `label-create-github.ts` — the handler dispatches to either depending on
+ * cwd platform.
+ *
+ * Argv composition (create):
+ *   glab label create --name <name>
+ *     [--description <description>]
+ *     [--color '#<hex>']       // GitLab REST API requires leading `#`
+ *     [-R <owner/repo>]        // glab uses short `-R`, NOT `--repo`
+ *
+ * Argv composition (duplicate-lookup fallback):
+ *   glab label list -F json --per-page 100 [-R <owner/repo>]
+ *
+ * Color asymmetry (per `lesson_origin_ops_pitfalls.md`):
+ *   - GitHub: bare hex `RRGGBB` — no leading `#`.
+ *   - GitLab: leading `#RRGGBB` — GitLab REST API REJECTS bare hex.
+ *   The handler's schema accepts bare hex (consumer-symmetric); we prepend
+ *   the `#` here on hand-off to `glab`. The response strips `#` from the
+ *   lookup payload so consumers always see bare hex.
+ */
+
+import { execSync } from 'child_process';
+import { runArgv } from '../shared/error-norm.js';
+import type {
+  AdapterResult,
+  LabelCreateArgs,
+  NormalizedLabel,
+} from './types.js';
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+/**
+ * glab reports "label already exists" on the duplicate path — same heuristic
+ * as the GitHub adapter. Phrasing varies across CLI versions but consistently
+ * includes the substring "already exists". Case-insensitive.
+ */
+function stderrIndicatesDuplicate(text: string): boolean {
+  return /already exists/i.test(text);
+}
+
+function lookupGitlabLabel(
+  name: string,
+  repo: string | undefined,
+  cwd: string,
+): NormalizedLabel | null {
+  const cmd = ['glab', 'label', 'list', '-F', 'json', '--per-page', '100'];
+  if (repo !== undefined) cmd.push('-R', repo);
+  const result = runArgv(cmd, cwd);
+  if (result.exitCode !== 0) return null;
+  try {
+    const labels = JSON.parse(result.stdout) as Array<{ name: string; description?: string; color?: string }>;
+    const match = labels.find((l) => l.name.toLowerCase() === name.toLowerCase());
+    if (match === undefined) return null;
+    return {
+      name: match.name,
+      description: match.description ?? '',
+      // Strip leading `#` — consumers always see bare hex (symmetric with gh path).
+      color: (match.color ?? '').replace(/^#/, ''),
+      created: false,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function labelCreateGitlab(
+  args: LabelCreateArgs,
+): Promise<AdapterResult<NormalizedLabel>> {
+  try {
+    const cwd = projectDir();
+    const description = args.description ?? '';
+
+    const cmd = ['glab', 'label', 'create', '--name', args.name];
+    if (description.length > 0) cmd.push('--description', description);
+    if (args.color !== undefined) {
+      // GitLab REST API requires `#RRGGBB`; bare hex is rejected.
+      cmd.push('--color', `#${args.color}`);
+    }
+    if (args.repo !== undefined) cmd.push('-R', args.repo);
+
+    const result = runArgv(cmd, cwd);
+    if (result.exitCode !== 0) {
+      const combined = `${result.stderr}\n${result.stdout}`;
+      if (stderrIndicatesDuplicate(combined)) {
+        const existing = lookupGitlabLabel(args.name, args.repo, cwd);
+        if (existing !== null) return { ok: true, data: existing };
+        return {
+          ok: false,
+          code: 'glab_label_lookup_failed',
+          error: `glab label create: label '${args.name}' already exists but could not be found via lookup`,
+        };
+      }
+      return {
+        ok: false,
+        code: 'glab_label_create_failed',
+        error: `glab label create failed: ${result.stderr.trim() || result.stdout.trim()}`,
+      };
+    }
+
+    return {
+      ok: true,
+      data: {
+        name: args.name,
+        description,
+        color: args.color ?? '',
+        created: true,
+      },
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'unexpected_error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// See label-create-github.ts for the rationale.
+void execSync;

--- a/lib/adapters/types.test.ts
+++ b/lib/adapters/types.test.ts
@@ -51,6 +51,7 @@ describe('PlatformAdapter contract', () => {
   // Story 2.12 (#306): ciRunLogs
   // Story 2.13 (#307): ciRunStatus
   // Story 2.14 (#308): ciRunsForBranch
+  // Story 2.15 (#309): labelCreate
   const MIGRATED_METHODS = new Set<string>([
     'prCreate',
     'prDiff',
@@ -67,6 +68,7 @@ describe('PlatformAdapter contract', () => {
     'ciRunLogs',
     'ciRunStatus',
     'ciRunsForBranch',
+    'labelCreate',
   ]);
 
   test('still-stubbed methods return platform_unsupported', async () => {

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -428,8 +428,36 @@ export interface CiRunsForBranchResponse {
   runs: CiRunsForBranchRun[];
 }
 
-export type LabelCreateArgs = unknown;
-export type LabelCreateResponse = unknown;
+/**
+ * `label_create` args/response (Story 2.15, #309). Full-migration of the
+ * idempotent create-with-duplicate-lookup-fallback.
+ *
+ * Color asymmetry (per `lesson_origin_ops_pitfalls.md`):
+ * - `args.color` is bare 6-char hex (no leading `#`) — validated at the
+ *   handler schema level. Symmetric with the `gh label create --color` flag.
+ * - GitLab's REST API requires `#RRGGBB`; the `label-create-gitlab.ts` adapter
+ *   prepends the `#` on hand-off and strips it from the lookup payload so
+ *   consumers always see bare hex.
+ *
+ * `NormalizedLabel.created` discriminates the new-create path (`true`) from
+ * the idempotent-duplicate path (`false`, values reflect the pre-existing
+ * label on disk rather than what the caller asked for).
+ */
+export interface LabelCreateArgs {
+  name: string;
+  color?: string;
+  description?: string;
+  repo?: string;
+}
+
+export interface NormalizedLabel {
+  name: string;
+  description: string;
+  color: string;
+  created: boolean;
+}
+
+export type LabelCreateResponse = NormalizedLabel;
 export type LabelListArgs = unknown;
 export type LabelListResponse = unknown;
 export type WorkItemArgs = unknown;
@@ -509,7 +537,7 @@ export interface PlatformAdapter {
   ciRunsForBranch(args: CiRunsForBranchArgs): Promise<AdapterResult<CiRunsForBranchResponse>>;
 
   // Label & issue CRUD
-  labelCreate(args: LabelCreateArgs): Promise<AdapterResult<LabelCreateResponse>>;
+  labelCreate(args: LabelCreateArgs): Promise<AdapterResult<NormalizedLabel>>;
   labelList(args: LabelListArgs): Promise<AdapterResult<LabelListResponse>>;
   workItem(args: WorkItemArgs): Promise<AdapterResult<WorkItemResponse>>;
   ibm(args: IbmArgs): Promise<AdapterResult<IbmResponse>>;

--- a/scripts/ci/migration-allowlist.txt
+++ b/scripts/ci/migration-allowlist.txt
@@ -13,7 +13,6 @@ ci_wait_run.ts
 dod_load_manifest.ts
 epic_sub_issues.ts
 ibm.ts
-label_create.ts
 label_list.ts
 spec_acceptance_criteria.ts
 spec_dependencies.ts

--- a/tests/label_create.test.ts
+++ b/tests/label_create.test.ts
@@ -1,26 +1,45 @@
 import { describe, test, expect, mock, beforeEach } from 'bun:test';
 
-let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
-let execCalls: string[] = [];
+// --- Mock child_process.execSync at module level ---
+//
+// label_create now dispatches through the platform adapter (Story 2.15 /
+// #309). The per-platform adapters call subprocess via `runArgv`, which
+// shell-escapes its argv (e.g. `'gh' 'label' 'create' 'bug' '--color' 'd73a4a'`).
+// The `unquote` shim strips that quoting so test match-keys can stay as plain
+// `gh label create ...` strings — same pattern adopted by tests/ci_failed_jobs.test.ts.
+//
+// Integration coverage: schema validation, handler envelope shape, cross-platform
+// dispatch (github → bare hex; gitlab → leading `#`), idempotent fallback
+// (duplicate → lookup → created:false).
+//
+// Subprocess-boundary argv assertions live in the colocated adapter tests
+// (lib/adapters/label-create-{github,gitlab}.test.ts).
 
 interface MockExecError extends Error {
   stderr?: string;
   stdout?: string;
+  status?: number;
 }
 
-function mockExec(cmd: string): string {
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
   execCalls.push(cmd);
+  const flat = unquote(cmd);
   for (const { match, respond } of execRegistry) {
-    if (cmd.includes(match)) {
+    if (cmd.includes(match) || flat.includes(match)) {
       return typeof respond === 'function' ? respond() : respond;
     }
   }
-  throw new Error(`Unexpected exec call: ${cmd}`);
-}
+  throw new Error(`Unexpected exec: ${cmd}`);
+});
 
-mock.module('child_process', () => ({
-  execSync: (cmd: string, _opts?: unknown) => mockExec(cmd),
-}));
+mock.module('child_process', () => ({ execSync: mockExecSync }));
 
 const { default: handler } = await import('../handlers/label_create.ts');
 
@@ -72,9 +91,9 @@ describe('label_create handler', () => {
     expect(data.ok).toBe(false);
   });
 
-  // ---- github happy path ----
+  // ---- github end-to-end ----
 
-  test('github — creates new label, returns created:true', async () => {
+  test('github_end_to_end — creates new label, returns created:true', async () => {
     onExec('git remote get-url origin', 'https://github.com/org/repo.git');
     onExec('gh label create', '');
     const result = await handler.execute({
@@ -90,26 +109,12 @@ describe('label_create handler', () => {
     expect(data.description).toBe('Top priority');
   });
 
-  test('github — quotes name and description with shell-escape', async () => {
-    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
-    onExec('gh label create', '');
-    await handler.execute({
-      name: "needs-review's-input",
-      description: "It's important",
-      color: 'd73a4a',
-    });
-    const createCall = execCalls.find((c) => c.includes('gh label create')) ?? '';
-    expect(createCall).toContain(`'needs-review'\\''s-input'`);
-    expect(createCall).toContain(`'It'\\''s important'`);
-  });
-
-  // ---- github idempotent path ----
-
   test('github — idempotent: duplicate triggers lookup, returns created:false', async () => {
     onExec('git remote get-url origin', 'https://github.com/org/repo.git');
     onExec('gh label create', () => {
       const err: MockExecError = new Error('label already exists') as MockExecError;
       err.stderr = '! Label "bug" already exists\n';
+      err.status = 1;
       throw err;
     });
     onExec('gh label list', JSON.stringify([
@@ -134,6 +139,7 @@ describe('label_create handler', () => {
     onExec('gh label create', () => {
       const err: MockExecError = new Error('auth required') as MockExecError;
       err.stderr = 'gh: not authenticated\n';
+      err.status = 1;
       throw err;
     });
     const result = await handler.execute({ name: 'bug', color: 'd73a4a' });
@@ -142,17 +148,9 @@ describe('label_create handler', () => {
     expect(String(data.error)).toContain('gh label create failed');
   });
 
-  test('github — repo flag passed through to both create and lookup', async () => {
-    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
-    onExec('gh label create', '');
-    await handler.execute({ name: 'bug', color: 'd73a4a', repo: 'foo/bar' });
-    const createCall = execCalls.find((c) => c.includes('gh label create')) ?? '';
-    expect(createCall).toContain("--repo 'foo/bar'");
-  });
+  // ---- gitlab end-to-end ----
 
-  // ---- gitlab happy path ----
-
-  test('gitlab — creates new label, returns created:true', async () => {
+  test('gitlab_end_to_end — creates new label, returns created:true', async () => {
     onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git');
     onExec('glab label create', '');
     const result = await handler.execute({
@@ -166,41 +164,12 @@ describe('label_create handler', () => {
     expect(data.name).toBe('priority::high');
   });
 
-  test('gitlab — uses --name (not positional) for label name', async () => {
-    onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git');
-    onExec('glab label create', '');
-    await handler.execute({ name: 'bug', color: 'd73a4a' });
-    const createCall = execCalls.find((c) => c.includes('glab label create')) ?? '';
-    expect(createCall).toContain("--name 'bug'");
-  });
-
-  test('gitlab — prepends `#` to color (GitLab REST API rejects bare hex)', async () => {
-    onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git');
-    onExec('glab label create', '');
-    await handler.execute({ name: 'bug', color: 'd73a4a' });
-    const createCall = execCalls.find((c) => c.includes('glab label create')) ?? '';
-    expect(createCall).toContain("--color '#d73a4a'");
-    // Sanity: bare hex must NOT appear as a standalone color value (would
-    // mean we forgot the # prepend).
-    expect(createCall).not.toContain("--color 'd73a4a'");
-  });
-
-  test('github — passes color bare (gh accepts bare hex, no # prepend)', async () => {
-    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
-    onExec('gh label create', '');
-    await handler.execute({ name: 'bug', color: 'd73a4a' });
-    const createCall = execCalls.find((c) => c.includes('gh label create')) ?? '';
-    expect(createCall).toContain("--color 'd73a4a'");
-    expect(createCall).not.toContain("--color '#d73a4a'");
-  });
-
-  // ---- gitlab idempotent path ----
-
   test('gitlab — idempotent: duplicate triggers lookup, returns created:false', async () => {
     onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git');
     onExec('glab label create', () => {
       const err: MockExecError = new Error('label already exists') as MockExecError;
       err.stderr = 'Label already exists\n';
+      err.status = 1;
       throw err;
     });
     onExec('glab label list', JSON.stringify([
@@ -217,14 +186,6 @@ describe('label_create handler', () => {
     expect(data.color).toBe('aabbcc'); // # stripped
   });
 
-  test('gitlab — repo flag uses -R (glab convention, not --repo)', async () => {
-    onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git');
-    onExec('glab label create', '');
-    await handler.execute({ name: 'bug', color: 'd73a4a', repo: 'foo/bar' });
-    const createCall = execCalls.find((c) => c.includes('glab label create')) ?? '';
-    expect(createCall).toContain("-R 'foo/bar'");
-  });
-
   // ---- color is optional ----
 
   test('color may be omitted', async () => {
@@ -233,38 +194,5 @@ describe('label_create handler', () => {
     const result = await handler.execute({ name: 'bug' });
     const data = parseResult(result.content);
     expect(data.ok).toBe(true);
-    const createCall = execCalls.find((c) => c.includes('gh label create')) ?? '';
-    expect(createCall).not.toContain('--color');
-  });
-
-  // ---- duplicate detection regex ----
-
-  test('"already exists" detection is case-insensitive', async () => {
-    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
-    onExec('gh label create', () => {
-      const err: MockExecError = new Error('') as MockExecError;
-      err.stderr = 'Label Already Exists in repo\n'; // mixed case
-      throw err;
-    });
-    onExec('gh label list', JSON.stringify([{ name: 'bug', description: '', color: '' }]));
-    const result = await handler.execute({ name: 'bug', color: 'd73a4a' });
-    const data = parseResult(result.content);
-    expect(data.ok).toBe(true);
-    expect(data.created).toBe(false);
-  });
-
-  test('"already exists" detection also matches against stdout (some CLI versions)', async () => {
-    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
-    onExec('gh label create', () => {
-      const err: MockExecError = new Error('') as MockExecError;
-      err.stdout = 'label already exists\n'; // on stdout, not stderr
-      err.stderr = '';
-      throw err;
-    });
-    onExec('gh label list', JSON.stringify([{ name: 'bug', description: '', color: '' }]));
-    const result = await handler.execute({ name: 'bug', color: 'd73a4a' });
-    const data = parseResult(result.content);
-    expect(data.ok).toBe(true);
-    expect(data.created).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Migrates `label_create` from direct subprocess logic to the platform adapter pattern (GitHub + GitLab). Handler shrinks to ≤80 lines (now 60) and delegates to `getAdapter().labelCreate(args)`. Color-format asymmetry (bare-hex for `gh`, leading-`#` for `glab`) is isolated inside the adapters per `lesson_origin_ops_pitfalls.md`.

## Changes

- Add `lib/adapters/label-create-github.ts` and `lib/adapters/label-create-gitlab.ts` with colocated subprocess-boundary tests that FAIL LOUDLY on wrong color format.
- Tighten `PlatformAdapter.labelCreate` signature in `lib/adapters/types.ts` (concrete `LabelCreateArgs` + `NormalizedLabel`).
- Wire adapters through `lib/adapters/github.ts` and `lib/adapters/gitlab.ts`.
- Refactor `handlers/label_create.ts` from 213 → 60 lines (thin dispatcher, no platform branching, no direct subprocess).
- Add `'labelCreate'` to `MIGRATED_METHODS` in `lib/adapters/types.test.ts`.
- Remove `label_create.ts` from `scripts/ci/migration-allowlist.txt`.
- Retarget `tests/label_create.test.ts` as integration coverage through the adapter.

## Linked Issues

Closes #309

## Test Plan

- [x] `./scripts/ci/validate.sh` — exit 0 (shellcheck + gate-greps + 73/73 per-tool assertions)
- [x] `bun test` — 1764 pass / 0 fail across 118 files
- [x] New adapter tests: `label-create-github.test.ts` (12 tests) + `label-create-gitlab.test.ts` (10 tests) all passing
- [x] Handler line count ≤80 (now 60); gate-greps clean after removal from allowlist
- [x] Contract test (`types.test.ts`) confirms both adapters return real results (not `platform_unsupported`)