### PR TITLE
refactor(label_list): migrate to platform adapter (#310)

### DIFF
--- a/handlers/label_list.ts
+++ b/handlers/label_list.ts
@@ -1,11 +1,16 @@
-// Origin Operations family handler.
-// See docs/handlers/origin-operations-guide.md for the canonical pattern,
-// gh ↔ glab field mappings, and normalized response schemas.
+// Origin Operations family handler — adapter-dispatching shell.
+// Subprocess + platform branching live in lib/adapters/label-list-{github,gitlab}.ts
+// per Story 2.16 (#310); see docs/handlers/origin-operations-guide.md for the
+// canonical pattern and docs/platform-adapter-retrofit-devspec.md §5 for the
+// contract.
+//
+// Color contract (symmetric across platforms): response always carries bare
+// 6-char hex (no leading `#`). The GitLab adapter strips the `#` that glab
+// emits; gh already returns bare hex. See `lesson_origin_ops_pitfalls.md`.
 
-import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { getAdapter } from '../lib/adapters/index.js';
 
 const inputSchema = z.object({
   limit: z.number().int().positive().optional().default(100),
@@ -15,61 +20,8 @@ const inputSchema = z.object({
     .optional(),
 });
 
-type Input = z.infer<typeof inputSchema>;
-
-interface NormalizedLabel {
-  name: string;
-  description: string;
-  color: string;
-}
-
-function exec(cmd: string): string {
-  return execSync(cmd, { encoding: 'utf8' }).trim();
-}
-
-function quoteArg(s: string): string {
-  return `'${s.replace(/'/g, `'\\''`)}'`;
-}
-
-interface GithubLabel {
-  name: string;
-  description?: string;
-  color?: string;
-}
-
-function listGithubLabels(args: Input): NormalizedLabel[] {
-  const parts = ['gh', 'label', 'list', '--json', 'name,description,color', '--limit', String(args.limit)];
-  if (args.repo !== undefined) {
-    parts.push('--repo', quoteArg(args.repo));
-  }
-  const raw = exec(parts.join(' '));
-  const parsed = JSON.parse(raw) as GithubLabel[];
-  return parsed.map((l) => ({
-    name: l.name,
-    description: l.description ?? '',
-    color: l.color ?? '',
-  }));
-}
-
-interface GitlabLabel {
-  name: string;
-  description?: string;
-  // glab label list returns `color` as `#RRGGBB` (with leading #); normalize to bare hex.
-  color?: string;
-}
-
-function listGitlabLabels(args: Input): NormalizedLabel[] {
-  const parts = ['glab', 'label', 'list', '-F', 'json', '--per-page', String(args.limit)];
-  if (args.repo !== undefined) {
-    parts.push('-R', quoteArg(args.repo));
-  }
-  const raw = exec(parts.join(' '));
-  const parsed = JSON.parse(raw) as GitlabLabel[];
-  return parsed.map((l) => ({
-    name: l.name,
-    description: l.description ?? '',
-    color: (l.color ?? '').replace(/^#/, ''),
-  }));
+function envelope(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] };
 }
 
 const labelListHandler: HandlerDef = {
@@ -78,30 +30,21 @@ const labelListHandler: HandlerDef = {
     'List labels for the current repo. Returns name, description, and color (bare 6-char hex, no leading #) for each. Cross-platform (gh + glab).',
   inputSchema,
   async execute(rawArgs: unknown) {
-    let args: Input;
+    let args;
     try {
       args = inputSchema.parse(rawArgs);
     } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
 
-    try {
-      const platform = detectPlatform();
-      const labels = platform === 'github' ? listGithubLabels(args) : listGitlabLabels(args);
-      return {
-        content: [
-          { type: 'text' as const, text: JSON.stringify({ ok: true, labels, count: labels.length }) },
-        ],
-      };
-    } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+    const adapter = getAdapter({ repo: args.repo });
+    const result = await adapter.labelList(args);
+
+    if ('platform_unsupported' in result) {
+      return envelope({ ok: false, error: result.hint });
     }
+    if (!result.ok) return envelope({ ok: false, error: result.error });
+    return envelope({ ok: true, ...result.data });
   },
 };
 

--- a/lib/adapters/github.ts
+++ b/lib/adapters/github.ts
@@ -21,6 +21,7 @@ import { ciRunsForBranchGithub } from './ci-runs-for-branch-github.js';
 import { fetchIssueGithub } from './fetch-issue-github.js';
 import { fetchPrStateGithub } from './fetch-pr-state-github.js';
 import { labelCreateGithub } from './label-create-github.js';
+import { labelListGithub } from './label-list-github.js';
 import { prCommentGithub } from './pr-comment-github.js';
 import { prCreateGithub } from './pr-create-github.js';
 import { prDiffGithub } from './pr-diff-github.js';
@@ -52,7 +53,7 @@ export const githubAdapter: PlatformAdapter = {
   ciFailedJobs: ciFailedJobsGithub,
   ciRunsForBranch: ciRunsForBranchGithub,
   labelCreate: labelCreateGithub,
-  labelList: stubMethod,
+  labelList: labelListGithub,
   workItem: stubMethod,
   ibm: stubMethod,
   epicSubIssues: stubMethod,

--- a/lib/adapters/gitlab.ts
+++ b/lib/adapters/gitlab.ts
@@ -22,6 +22,7 @@ import { ciRunsForBranchGitlab } from './ci-runs-for-branch-gitlab.js';
 import { fetchIssueGitlab } from './fetch-issue-gitlab.js';
 import { fetchPrStateGitlab } from './fetch-pr-state-gitlab.js';
 import { labelCreateGitlab } from './label-create-gitlab.js';
+import { labelListGitlab } from './label-list-gitlab.js';
 import { prCommentGitlab } from './pr-comment-gitlab.js';
 import { prCreateGitlab } from './pr-create-gitlab.js';
 import { prDiffGitlab } from './pr-diff-gitlab.js';
@@ -53,7 +54,7 @@ export const gitlabAdapter: PlatformAdapter = {
   ciFailedJobs: ciFailedJobsGitlab,
   ciRunsForBranch: ciRunsForBranchGitlab,
   labelCreate: labelCreateGitlab,
-  labelList: stubMethod,
+  labelList: labelListGitlab,
   workItem: stubMethod,
   ibm: stubMethod,
   epicSubIssues: stubMethod,

--- a/lib/adapters/label-list-github.test.ts
+++ b/lib/adapters/label-list-github.test.ts
@@ -1,0 +1,211 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { AdapterResult, LabelListResponse } from './types.ts';
+
+// Subprocess-boundary tests for the GitHub label_list adapter (R-15).
+// Integration-level coverage (schema validation, handler envelope, cross-platform
+// dispatch) stays in tests/label_list.test.ts; this file owns the argv-shape
+// assertions that prove the adapter speaks `gh` correctly.
+//
+// Argv strictness per `lesson_origin_ops_pitfalls.md`: gh takes `--limit` and
+// `--repo` (long flags). The stub fails loudly if we regress.
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  // Argv strictness — glab-style flags on the gh path means we regressed.
+  if (flat.includes('gh label list') && (/--per-page/.test(flat) || /\s-R\s/.test(flat))) {
+    const err = new Error(
+      `FAIL: gh label list invoked with glab-style flags — gh uses --limit/--repo`,
+    ) as ThrowableError;
+    err.status = 127;
+    throw err;
+  }
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { labelListGithub } = await import('./label-list-github.ts');
+
+function on(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
+function expectOk(
+  r: AdapterResult<LabelListResponse>,
+): asserts r is { ok: true; data: LabelListResponse } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectErr(
+  r: AdapterResult<LabelListResponse>,
+): asserts r is { ok: false; error: string; code: string } {
+  if (!('ok' in r) || r.ok) {
+    throw new Error(`expected error result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('labelListGithub — subprocess boundary', () => {
+  // --- argv: gh label list ---
+
+  test('argv: gh label list default flags', async () => {
+    on('gh label list', '[]');
+
+    const result = await labelListGithub({ limit: 100 });
+    expectOk(result);
+
+    const call = findCall('gh label list');
+    expect(call).toContain("'--json' 'name,description,color'");
+    expect(call).toContain("'--limit' '100'");
+    expect(call).not.toContain('--repo');
+    // glab-style flags must NOT leak onto the gh path.
+    expect(call).not.toContain('--per-page');
+    expect(call).not.toContain(' -R ');
+    expect(call).not.toContain("'-R'");
+  });
+
+  test('argv: forwards --limit with caller-supplied value', async () => {
+    on('gh label list', '[]');
+
+    await labelListGithub({ limit: 50 });
+
+    const call = findCall('gh label list');
+    expect(call).toContain("'--limit' '50'");
+  });
+
+  test('argv: --repo flag forwarded for cross-repo list', async () => {
+    on('gh label list', '[]');
+
+    await labelListGithub({ limit: 100, repo: 'other-org/other-repo' });
+
+    const call = findCall('gh label list');
+    expect(call).toContain("'--repo' 'other-org/other-repo'");
+  });
+
+  test('argv: quotes repo with shell-escape', async () => {
+    on('gh label list', '[]');
+
+    await labelListGithub({ limit: 100, repo: "tricky/repo-name" });
+
+    const call = findCall('gh label list');
+    // shellEscape wraps in single quotes.
+    expect(call).toContain("'tricky/repo-name'");
+  });
+
+  // --- happy path: normalization ---
+
+  test('normalizes labels — passes bare-hex color through unchanged', async () => {
+    on(
+      'gh label list',
+      JSON.stringify([
+        { name: 'bug', description: 'Something broken', color: 'd73a4a' },
+        { name: 'enhancement', description: 'New feature', color: 'a2eeef' },
+      ]),
+    );
+
+    const result = await labelListGithub({ limit: 100 });
+    expectOk(result);
+
+    expect(result.data.count).toBe(2);
+    expect(result.data.labels[0]).toEqual({
+      name: 'bug',
+      description: 'Something broken',
+      color: 'd73a4a',
+    });
+    expect(result.data.labels[1]).toEqual({
+      name: 'enhancement',
+      description: 'New feature',
+      color: 'a2eeef',
+    });
+  });
+
+  test('fills missing description with empty string', async () => {
+    on(
+      'gh label list',
+      JSON.stringify([{ name: 'bug', color: 'd73a4a' }]),
+    );
+
+    const result = await labelListGithub({ limit: 100 });
+    expectOk(result);
+
+    expect(result.data.labels[0].description).toBe('');
+  });
+
+  test('fills missing color with empty string', async () => {
+    on(
+      'gh label list',
+      JSON.stringify([{ name: 'bug', description: 'x' }]),
+    );
+
+    const result = await labelListGithub({ limit: 100 });
+    expectOk(result);
+
+    expect(result.data.labels[0].color).toBe('');
+  });
+
+  test('empty list → count 0, labels []', async () => {
+    on('gh label list', '[]');
+
+    const result = await labelListGithub({ limit: 100 });
+    expectOk(result);
+
+    expect(result.data.count).toBe(0);
+    expect(result.data.labels).toEqual([]);
+  });
+
+  // --- error surface ---
+
+  test('returns AdapterResult.error on gh failure (not thrown)', async () => {
+    on('gh label list', () => {
+      const err = new Error('gh: not authenticated') as ThrowableError;
+      err.stderr = 'gh: not authenticated';
+      err.status = 1;
+      throw err;
+    });
+
+    const result = await labelListGithub({ limit: 100 });
+    expectErr(result);
+    expect(result.code).toBe('gh_label_list_failed');
+    expect(result.error).toContain('gh label list failed');
+  });
+
+  test('returns parse error when gh emits non-JSON', async () => {
+    on('gh label list', 'not valid json');
+
+    const result = await labelListGithub({ limit: 100 });
+    expectErr(result);
+    expect(result.code).toBe('gh_label_list_parse_failed');
+  });
+});

--- a/lib/adapters/label-list-github.ts
+++ b/lib/adapters/label-list-github.ts
@@ -1,0 +1,90 @@
+/**
+ * GitHub `label_list` adapter implementation.
+ *
+ * Lifted from `handlers/label_list.ts` per Story 2.16 (#310). The handler is
+ * now a thin dispatcher; this module owns the GitHub-specific subprocess work
+ * (argv composition + `gh label list` invocation) and the bare-hex
+ * color-normalization (gh already emits bare hex, so the transform is an
+ * identity pass — kept explicit for symmetry with the GitLab adapter).
+ *
+ * Argv composition:
+ *   gh label list
+ *     --json name,description,color
+ *     --limit <N>
+ *     [--repo <owner/repo>]
+ *
+ * Color asymmetry (per `lesson_origin_ops_pitfalls.md`):
+ *   - GitHub: bare hex `RRGGBB` — gh returns color without a leading `#`.
+ *   - GitLab: leading `#RRGGBB` — glab returns color with a leading `#`;
+ *     `label-list-gitlab.ts` strips it so consumers always see bare hex.
+ */
+
+import { execSync } from 'child_process';
+import { runArgv } from '../shared/error-norm.js';
+import type {
+  AdapterResult,
+  LabelListArgs,
+  LabelListResponse,
+  NormalizedLabelListEntry,
+} from './types.js';
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+interface GithubLabel {
+  name: string;
+  description?: string;
+  color?: string;
+}
+
+export async function labelListGithub(
+  args: LabelListArgs,
+): Promise<AdapterResult<LabelListResponse>> {
+  try {
+    const cwd = projectDir();
+
+    const cmd = ['gh', 'label', 'list', '--json', 'name,description,color', '--limit', String(args.limit)];
+    if (args.repo !== undefined) cmd.push('--repo', args.repo);
+
+    const result = runArgv(cmd, cwd);
+    if (result.exitCode !== 0) {
+      return {
+        ok: false,
+        code: 'gh_label_list_failed',
+        error: `gh label list failed: ${result.stderr.trim() || result.stdout.trim()}`,
+      };
+    }
+
+    let parsed: GithubLabel[];
+    try {
+      parsed = JSON.parse(result.stdout) as GithubLabel[];
+    } catch (err) {
+      return {
+        ok: false,
+        code: 'gh_label_list_parse_failed',
+        error: `gh label list: failed to parse JSON — ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    const labels: NormalizedLabelListEntry[] = parsed.map((l) => ({
+      name: l.name,
+      description: l.description ?? '',
+      // gh emits bare hex already; identity pass kept for symmetry with glab path.
+      color: l.color ?? '',
+    }));
+
+    return { ok: true, data: { labels, count: labels.length } };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'unexpected_error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// `execSync` is intentionally re-imported above so that adapter-level test
+// files can `mock.module('child_process', ...)` and intercept this module's
+// subprocess calls without needing access to the handler's mock setup.
+void execSync;

--- a/lib/adapters/label-list-gitlab.test.ts
+++ b/lib/adapters/label-list-gitlab.test.ts
@@ -1,0 +1,195 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { AdapterResult, LabelListResponse } from './types.ts';
+
+// Subprocess-boundary tests for the GitLab label_list adapter (R-15).
+// Integration-level coverage (schema validation, handler envelope, cross-platform
+// dispatch) stays in tests/label_list.test.ts; this file owns the argv-shape
+// assertions that prove the adapter speaks `glab` correctly.
+//
+// Argv strictness per `lesson_origin_ops_pitfalls.md`: glab takes `--per-page`
+// and short `-R` (NOT `--repo`). The stub fails loudly if we regress to the
+// gh-style flags.
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  // Argv strictness — gh-style flags on the glab path means we regressed.
+  if (flat.includes('glab label list') && (/--limit/.test(flat) || /--repo\s/.test(flat))) {
+    const err = new Error(
+      `FAIL: glab label list invoked with gh-style flags — glab uses --per-page/-R`,
+    ) as ThrowableError;
+    err.status = 127;
+    throw err;
+  }
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { labelListGitlab } = await import('./label-list-gitlab.ts');
+
+function on(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
+function expectOk(
+  r: AdapterResult<LabelListResponse>,
+): asserts r is { ok: true; data: LabelListResponse } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectErr(
+  r: AdapterResult<LabelListResponse>,
+): asserts r is { ok: false; error: string; code: string } {
+  if (!('ok' in r) || r.ok) {
+    throw new Error(`expected error result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('labelListGitlab — subprocess boundary', () => {
+  // --- argv: glab label list ---
+
+  test('argv: glab label list default flags', async () => {
+    on('glab label list', '[]');
+
+    const result = await labelListGitlab({ limit: 100 });
+    expectOk(result);
+
+    const call = findCall('glab label list');
+    expect(call).toContain("'-F' 'json'");
+    expect(call).toContain("'--per-page' '100'");
+    expect(call).not.toContain('-R ');
+    // gh-style flags must NOT leak onto the glab path.
+    expect(call).not.toContain('--limit');
+    expect(call).not.toContain("'--repo'");
+  });
+
+  test('argv: forwards --per-page with caller-supplied value', async () => {
+    on('glab label list', '[]');
+
+    await labelListGitlab({ limit: 25 });
+
+    const call = findCall('glab label list');
+    expect(call).toContain("'--per-page' '25'");
+  });
+
+  test('argv: -R flag (not --repo) forwarded for cross-repo list', async () => {
+    on('glab label list', '[]');
+
+    await labelListGitlab({ limit: 100, repo: 'foo/bar' });
+
+    const call = findCall('glab label list');
+    // glab uses short `-R`, NOT `--repo`.
+    expect(call).toContain("'-R' 'foo/bar'");
+    expect(call).not.toContain("'--repo'");
+  });
+
+  // --- happy path: normalization ---
+
+  test('strips leading # from color — consumers see bare hex', async () => {
+    on(
+      'glab label list',
+      JSON.stringify([
+        { name: 'bug', description: 'Bug', color: '#d73a4a' },
+        { name: 'enhancement', description: '', color: '#a2eeef' },
+      ]),
+    );
+
+    const result = await labelListGitlab({ limit: 100 });
+    expectOk(result);
+
+    expect(result.data.count).toBe(2);
+    expect(result.data.labels[0].color).toBe('d73a4a');
+    expect(result.data.labels[1].color).toBe('a2eeef');
+  });
+
+  test('fills missing description with empty string', async () => {
+    on(
+      'glab label list',
+      JSON.stringify([{ name: 'bug', color: '#d73a4a' }]),
+    );
+
+    const result = await labelListGitlab({ limit: 100 });
+    expectOk(result);
+
+    expect(result.data.labels[0].description).toBe('');
+  });
+
+  test('tolerates missing color field', async () => {
+    on(
+      'glab label list',
+      JSON.stringify([{ name: 'bug', description: 'x' }]),
+    );
+
+    const result = await labelListGitlab({ limit: 100 });
+    expectOk(result);
+
+    expect(result.data.labels[0].color).toBe('');
+  });
+
+  test('empty list → count 0, labels []', async () => {
+    on('glab label list', '[]');
+
+    const result = await labelListGitlab({ limit: 100 });
+    expectOk(result);
+
+    expect(result.data.count).toBe(0);
+    expect(result.data.labels).toEqual([]);
+  });
+
+  // --- error surface ---
+
+  test('returns AdapterResult.error on glab failure (not thrown)', async () => {
+    on('glab label list', () => {
+      const err = new Error('glab: 401 unauthorized') as ThrowableError;
+      err.stderr = 'glab: 401 unauthorized';
+      err.status = 1;
+      throw err;
+    });
+
+    const result = await labelListGitlab({ limit: 100 });
+    expectErr(result);
+    expect(result.code).toBe('glab_label_list_failed');
+    expect(result.error).toContain('glab label list failed');
+  });
+
+  test('returns parse error when glab emits non-JSON', async () => {
+    on('glab label list', 'not valid json');
+
+    const result = await labelListGitlab({ limit: 100 });
+    expectErr(result);
+    expect(result.code).toBe('glab_label_list_parse_failed');
+  });
+});

--- a/lib/adapters/label-list-gitlab.ts
+++ b/lib/adapters/label-list-gitlab.ts
@@ -1,0 +1,87 @@
+/**
+ * GitLab `label_list` adapter implementation.
+ *
+ * Lifted from `handlers/label_list.ts` per Story 2.16 (#310). Mirrors
+ * `label-list-github.ts` — the handler dispatches to either depending on cwd
+ * platform.
+ *
+ * Argv composition:
+ *   glab label list
+ *     -F json
+ *     --per-page <N>
+ *     [-R <owner/repo>]        // glab uses short `-R`, NOT `--repo`
+ *
+ * Color asymmetry (per `lesson_origin_ops_pitfalls.md`):
+ *   - GitHub: bare hex `RRGGBB` — gh returns without a leading `#`.
+ *   - GitLab: leading `#RRGGBB` — glab returns with a leading `#`; we strip it
+ *     so consumers always see bare hex (symmetric with gh path).
+ */
+
+import { execSync } from 'child_process';
+import { runArgv } from '../shared/error-norm.js';
+import type {
+  AdapterResult,
+  LabelListArgs,
+  LabelListResponse,
+  NormalizedLabelListEntry,
+} from './types.js';
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+interface GitlabLabel {
+  name: string;
+  description?: string;
+  // `glab label list -F json` returns `color` as `#RRGGBB` (with leading `#`).
+  color?: string;
+}
+
+export async function labelListGitlab(
+  args: LabelListArgs,
+): Promise<AdapterResult<LabelListResponse>> {
+  try {
+    const cwd = projectDir();
+
+    const cmd = ['glab', 'label', 'list', '-F', 'json', '--per-page', String(args.limit)];
+    if (args.repo !== undefined) cmd.push('-R', args.repo);
+
+    const result = runArgv(cmd, cwd);
+    if (result.exitCode !== 0) {
+      return {
+        ok: false,
+        code: 'glab_label_list_failed',
+        error: `glab label list failed: ${result.stderr.trim() || result.stdout.trim()}`,
+      };
+    }
+
+    let parsed: GitlabLabel[];
+    try {
+      parsed = JSON.parse(result.stdout) as GitlabLabel[];
+    } catch (err) {
+      return {
+        ok: false,
+        code: 'glab_label_list_parse_failed',
+        error: `glab label list: failed to parse JSON — ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    const labels: NormalizedLabelListEntry[] = parsed.map((l) => ({
+      name: l.name,
+      description: l.description ?? '',
+      // Strip leading `#` — consumers always see bare hex (symmetric with gh path).
+      color: (l.color ?? '').replace(/^#/, ''),
+    }));
+
+    return { ok: true, data: { labels, count: labels.length } };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'unexpected_error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// See label-list-github.ts for the rationale.
+void execSync;

--- a/lib/adapters/types.test.ts
+++ b/lib/adapters/types.test.ts
@@ -52,6 +52,7 @@ describe('PlatformAdapter contract', () => {
   // Story 2.13 (#307): ciRunStatus
   // Story 2.14 (#308): ciRunsForBranch
   // Story 2.15 (#309): labelCreate
+  // Story 2.16 (#310): labelList
   const MIGRATED_METHODS = new Set<string>([
     'prCreate',
     'prDiff',
@@ -69,6 +70,7 @@ describe('PlatformAdapter contract', () => {
     'ciRunStatus',
     'ciRunsForBranch',
     'labelCreate',
+    'labelList',
   ]);
 
   test('still-stubbed methods return platform_unsupported', async () => {

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -458,8 +458,38 @@ export interface NormalizedLabel {
 }
 
 export type LabelCreateResponse = NormalizedLabel;
-export type LabelListArgs = unknown;
-export type LabelListResponse = unknown;
+
+/**
+ * `label_list` args/response (Story 2.16, #310). Full-migration of the simplest
+ * Origin Operations handler — list labels with limit and optional cross-repo
+ * slug.
+ *
+ * Color contract is symmetric across platforms at the adapter boundary:
+ * consumers always see bare 6-char hex (no leading `#`). The GitLab adapter
+ * strips the leading `#` that `glab label list` returns; the GitHub adapter
+ * passes gh's bare-hex output through unchanged. See
+ * `lesson_origin_ops_pitfalls.md` for the argv-level asymmetry
+ * (`--limit`/`--repo` on gh vs. `--per-page`/`-R` on glab).
+ *
+ * The `NormalizedLabelListEntry` shape deliberately omits `created` — that
+ * field is the discriminator used by `label_create`'s idempotent path. A
+ * simple `list` call has no such signal.
+ */
+export interface LabelListArgs {
+  limit: number;
+  repo?: string;
+}
+
+export interface NormalizedLabelListEntry {
+  name: string;
+  description: string;
+  color: string;
+}
+
+export interface LabelListResponse {
+  labels: NormalizedLabelListEntry[];
+  count: number;
+}
 export type WorkItemArgs = unknown;
 export type WorkItemResponse = unknown;
 export type IbmArgs = unknown;

--- a/scripts/ci/migration-allowlist.txt
+++ b/scripts/ci/migration-allowlist.txt
@@ -13,7 +13,6 @@ ci_wait_run.ts
 dod_load_manifest.ts
 epic_sub_issues.ts
 ibm.ts
-label_list.ts
 spec_acceptance_criteria.ts
 spec_dependencies.ts
 spec_get.ts

--- a/tests/label_list.test.ts
+++ b/tests/label_list.test.ts
@@ -1,21 +1,44 @@
 import { describe, test, expect, mock, beforeEach } from 'bun:test';
 
-let execRegistry: Record<string, string> = {};
-let execCalls: string[] = [];
-let execError: Error | null = null;
+// --- Mock child_process.execSync at module level ---
+//
+// label_list now dispatches through the platform adapter (Story 2.16 /
+// #310). The per-platform adapters call subprocess via `runArgv`, which
+// shell-escapes its argv (e.g. `'gh' 'label' 'list' '--limit' '100'`).
+// The `unquote` shim strips that quoting so test match-keys can stay as plain
+// `gh label list` strings — same pattern adopted by tests/label_create.test.ts.
+//
+// Integration coverage: schema validation, handler envelope shape, cross-platform
+// dispatch (github → bare hex passthrough; gitlab → strip leading `#`).
+//
+// Subprocess-boundary argv assertions live in the colocated adapter tests
+// (lib/adapters/label-list-{github,gitlab}.test.ts).
 
-function mockExec(cmd: string): string {
-  execCalls.push(cmd);
-  if (execError) throw execError;
-  for (const [key, value] of Object.entries(execRegistry)) {
-    if (cmd.includes(key)) return value;
-  }
-  throw new Error(`Unexpected exec call: ${cmd}`);
+interface MockExecError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
 }
 
-mock.module('child_process', () => ({
-  execSync: (cmd: string, _opts?: unknown) => mockExec(cmd),
-}));
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  throw new Error(`Unexpected exec: ${cmd}`);
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
 
 const { default: handler } = await import('../handlers/label_list.ts');
 
@@ -23,10 +46,13 @@ function parseResult(content: Array<{ type: string; text: string }>) {
   return JSON.parse(content[0].text) as Record<string, unknown>;
 }
 
+function onExec(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
 beforeEach(() => {
-  execRegistry = {};
+  execRegistry = [];
   execCalls = [];
-  execError = null;
 });
 
 describe('label_list handler', () => {
@@ -35,12 +61,23 @@ describe('label_list handler', () => {
     expect(typeof handler.execute).toBe('function');
   });
 
+  // ---- schema validation ----
+
+  test('schema rejects malformed repo', async () => {
+    const result = await handler.execute({ repo: 'not-a-slug' });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+    expect(String(data.error)).toContain('owner/repo');
+  });
+
+  // ---- github end-to-end ----
+
   test('github — returns normalized labels from gh label list', async () => {
-    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
-    execRegistry['gh label list'] = JSON.stringify([
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
+    onExec('gh label list', JSON.stringify([
       { name: 'bug', description: 'Something broken', color: 'd73a4a' },
       { name: 'enhancement', description: 'New feature', color: 'a2eeef' },
-    ]);
+    ]));
     const result = await handler.execute({});
     const data = parseResult(result.content);
     expect(data.ok).toBe(true);
@@ -50,22 +87,37 @@ describe('label_list handler', () => {
     expect(labels[0].color).toBe('d73a4a');
   });
 
-  test('github — passes --limit and --repo flags', async () => {
-    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
-    execRegistry['gh label list'] = '[]';
-    await handler.execute({ limit: 50, repo: 'foo/bar' });
-    const ghCall = execCalls.find((c) => c.includes('gh label list')) ?? '';
-    expect(ghCall).toContain('--limit 50');
-    expect(ghCall).toContain("--repo 'foo/bar'");
-    expect(ghCall).toContain('--json name,description,color');
+  test('github — default limit is 100 when not specified', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
+    onExec('gh label list', '[]');
+    await handler.execute({});
+    // runArgv shell-escapes argv, so match against the unquoted form.
+    const call = execCalls.find((c) => unquote(c).includes('gh label list')) ?? '';
+    expect(call).toContain("'--limit' '100'");
   });
 
-  test('gitlab — returns normalized labels from glab label list, strips leading # from color', async () => {
-    execRegistry['git remote get-url origin'] = 'https://gitlab.com/org/repo.git';
-    execRegistry['glab label list'] = JSON.stringify([
+  test('github — returns ok:false on subprocess failure', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
+    onExec('gh label list', () => {
+      const err: MockExecError = new Error('gh not authenticated') as MockExecError;
+      err.stderr = 'gh: not authenticated';
+      err.status = 1;
+      throw err;
+    });
+    const result = await handler.execute({});
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+    expect(String(data.error)).toContain('gh label list failed');
+  });
+
+  // ---- gitlab end-to-end ----
+
+  test('gitlab — returns normalized labels and strips leading # from color', async () => {
+    onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git');
+    onExec('glab label list', JSON.stringify([
       { name: 'bug', description: 'Bug', color: '#d73a4a' },
       { name: 'enhancement', color: '#a2eeef' }, // no description
-    ]);
+    ]));
     const result = await handler.execute({});
     const data = parseResult(result.content);
     expect(data.ok).toBe(true);
@@ -75,37 +127,13 @@ describe('label_list handler', () => {
     expect(labels[1].description).toBe(''); // missing → empty string
   });
 
-  test('gitlab — passes --per-page and -R flags', async () => {
-    execRegistry['git remote get-url origin'] = 'https://gitlab.com/org/repo.git';
-    execRegistry['glab label list'] = '[]';
+  test('gitlab — forwards --per-page and -R (not --limit/--repo)', async () => {
+    onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git');
+    onExec('glab label list', '[]');
     await handler.execute({ limit: 25, repo: 'foo/bar' });
-    const glabCall = execCalls.find((c) => c.includes('glab label list')) ?? '';
-    expect(glabCall).toContain('--per-page 25');
-    expect(glabCall).toContain("-R 'foo/bar'");
-    expect(glabCall).toContain('-F json');
-  });
-
-  test('returns ok:false on subprocess failure', async () => {
-    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
-    execError = new Error('gh not authenticated');
-    const result = await handler.execute({});
-    const data = parseResult(result.content);
-    expect(data.ok).toBe(false);
-    expect(String(data.error)).toContain('gh not authenticated');
-  });
-
-  test('default limit is 100 when not specified', async () => {
-    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
-    execRegistry['gh label list'] = '[]';
-    await handler.execute({});
-    const ghCall = execCalls.find((c) => c.includes('gh label list')) ?? '';
-    expect(ghCall).toContain('--limit 100');
-  });
-
-  test('schema rejects malformed repo', async () => {
-    const result = await handler.execute({ repo: 'not-a-slug' });
-    const data = parseResult(result.content);
-    expect(data.ok).toBe(false);
-    expect(String(data.error)).toContain('owner/repo');
+    const call = execCalls.find((c) => unquote(c).includes('glab label list')) ?? '';
+    expect(call).toContain("'--per-page' '25'");
+    expect(call).toContain("'-R' 'foo/bar'");
+    expect(call).toContain("'-F' 'json'");
   });
 });


### PR DESCRIPTION
## Summary

Migrates the `label_list` handler to the platform adapter pattern, lifting subprocess and argv logic into colocated `labelListGithub` / `labelListGitlab` adapters. Matches the `label_create` migration structure end-to-end.

## Changes

- Added concrete `LabelListArgs` / `NormalizedLabelListEntry` / `LabelListResponse` shapes to `lib/adapters/types.ts` (replaced `unknown` placeholders)
- Created `lib/adapters/label-list-github.ts` and `lib/adapters/label-list-gitlab.ts` with colocated argv tests
- Refactored `handlers/label_list.ts` from 108 lines to 51 — pure `getAdapter().labelList(args)` dispatcher, no platform branching, no subprocess
- Wired `labelListGithub` / `labelListGitlab` into the GitHub and GitLab adapter assemblers
- Added `'labelList'` to `MIGRATED_METHODS` in `lib/adapters/types.test.ts`
- Removed `label_list.ts` from `scripts/ci/migration-allowlist.txt`
- Rewrote `tests/label_list.test.ts` to match post-migration integration pattern
- Color contract: GitHub adapter passes bare hex through; GitLab adapter strips leading `#` from `glab label list -F json` output
- Argv asymmetry preserved (gh `--limit`/`--repo`, glab `--per-page`/`-R`); argv-strictness guards in colocated tests

## Linked Issues

Closes #310

## Test Plan

- `./scripts/ci/validate.sh` exit 0: codegen + TypeScript lint + adapter-retrofit gate-greps (56 non-allowlisted handlers) + shellcheck + `bun test` (1782 pass / 0 fail / 4407 expect() / 120 files) + runtime smoke + per-tool assertions (73/73)
- `bun test lib/adapters/label-list-github.test.ts lib/adapters/label-list-gitlab.test.ts` → 19/0
- `bun test tests/label_list.test.ts` → 7/0