### PR TITLE
refactor(work_item): migrate to platform adapter + typed platform_unsupported (#311)

### DIFF
--- a/handlers/work_item.ts
+++ b/handlers/work_item.ts
@@ -1,123 +1,58 @@
-import { execSync } from 'child_process';
-import { writeFileSync } from 'fs';
+// Origin Operations family handler — adapter-dispatching shell.
+// Subprocess + platform branching live in lib/adapters/work-item-{github,gitlab}.ts
+// per Story 2.17 (#311); see docs/handlers/origin-operations-guide.md for the
+// canonical pattern and docs/platform-adapter-retrofit-devspec.md §5 for the
+// contract.
+//
+// Closes #281: the pre-migration dispatch ran the wrong platform's create fn
+// when `type:'pr'` hit a GitLab repo (or `type:'mr'` hit GitHub). The adapter
+// boundary now returns `{platform_unsupported: true, hint: ...}` for those
+// combinations, which the handler surfaces as a typed error envelope rather
+// than silently running the wrong sub-command.
+
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { getAdapter } from '../lib/adapters/index.js';
 
 const inputSchema = z.object({
-  type: z.enum(['epic', 'story', 'bug', 'chore', 'docs', 'pr', 'mr']),
-  title: z.string(),
+  type: z.enum(['epic', 'story', 'feature', 'bug', 'chore', 'docs', 'fix', 'pr', 'mr']),
+  title: z.string().min(1, 'title must be a non-empty string'),
   body: z.string().optional(),
   labels: z.array(z.string()).optional(),
   head_branch: z.string().optional(),
   base_branch: z.string().optional(),
   draft: z.boolean().optional(),
+  repo: z
+    .string()
+    .regex(/^[a-zA-Z0-9._/-]+\/[a-zA-Z0-9._-]+$/, 'repo must be owner/repo format')
+    .optional(),
 });
 
-type Input = z.infer<typeof inputSchema>;
-
-const TYPE_LABELS: Record<string, string | null> = {
-  epic: 'type::epic',
-  story: 'type::story',
-  bug: 'type::bug',
-  chore: 'type::chore',
-  docs: 'type::docs',
-  pr: null,
-  mr: null,
-};
-
-function buildLabels(type: string, extra: string[] = []): string[] {
-  const auto = TYPE_LABELS[type];
-  return auto ? [auto, ...extra] : [...extra];
-}
-
-function writeTempBody(body: string): string {
-  const path = `/tmp/wi-body-${Date.now()}.md`;
-  writeFileSync(path, body);
-  return path;
-}
-
-function parseOutput(output: string): { url: string; number: number } {
-  // gh / glab outputs the URL on its own line
-  const lines = output.trim().split('\n');
-  const url = lines[lines.length - 1].trim();
-  const match = url.match(/\/(\d+)$/);
-  const number = match ? parseInt(match[1], 10) : 0;
-  return { url, number };
-}
-
-function createGithubIssue(args: Input, bodyFile: string): string {
-  const labels = buildLabels(args.type, args.labels);
-  const parts = ['gh', 'issue', 'create', '--title', `"${args.title}"`, '--body-file', bodyFile];
-  for (const label of labels) {
-    parts.push('--label', `"${label}"`);
-  }
-  return execSync(parts.join(' '), { encoding: 'utf8' });
-}
-
-function createGitlabIssue(args: Input, bodyFile: string): string {
-  const labels = buildLabels(args.type, args.labels);
-  const parts = ['glab', 'issue', 'create', '--title', `"${args.title}"`, '--description', `"$(cat ${bodyFile})"`];
-  if (labels.length > 0) {
-    parts.push('--label', `"${labels.join(',')}"`);
-  }
-  return execSync(parts.join(' '), { encoding: 'utf8' });
-}
-
-function createGithubPR(args: Input, bodyFile: string): string {
-  const parts = ['gh', 'pr', 'create', '--title', `"${args.title}"`, '--body-file', bodyFile];
-  if (args.head_branch) parts.push('--head', args.head_branch);
-  if (args.base_branch) parts.push('--base', args.base_branch);
-  if (args.draft) parts.push('--draft');
-  const labels = args.labels ?? [];
-  for (const label of labels) {
-    parts.push('--label', `"${label}"`);
-  }
-  return execSync(parts.join(' '), { encoding: 'utf8' });
-}
-
-function createGitlabMR(args: Input, bodyFile: string): string {
-  const parts = ['glab', 'mr', 'create', '--title', `"${args.title}"`, '--description', `"$(cat ${bodyFile})"`];
-  if (args.head_branch) parts.push('--source-branch', args.head_branch);
-  if (args.base_branch) parts.push('--target-branch', args.base_branch);
-  if (args.draft) parts.push('--draft');
-  return execSync(parts.join(' '), { encoding: 'utf8' });
+function envelope(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] };
 }
 
 const workItemHandler: HandlerDef = {
   name: 'work_item',
-  description: 'Create a GitHub issue, PR, or GitLab issue/MR via the appropriate CLI.',
+  description:
+    'Create a GitHub issue/PR or GitLab issue/MR via the appropriate CLI. `type` drives dispatch; cross-platform types (pr on GitLab, mr on GitHub) return a typed platform_unsupported error.',
   inputSchema,
   async execute(rawArgs: unknown) {
-    const args = inputSchema.parse(rawArgs);
-    const bodyContent = args.body ?? '';
-    const bodyFile = writeTempBody(bodyContent);
-    const platform = detectPlatform();
-
+    let args;
     try {
-      let output: string;
-      const isIssueType = !['pr', 'mr'].includes(args.type);
-
-      if (isIssueType) {
-        output = platform === 'github'
-          ? createGithubIssue(args, bodyFile)
-          : createGitlabIssue(args, bodyFile);
-      } else if (args.type === 'pr') {
-        output = createGithubPR(args, bodyFile);
-      } else {
-        output = createGitlabMR(args, bodyFile);
-      }
-
-      const { url, number } = parseOutput(output);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: true, url, number }) }],
-      };
+      args = inputSchema.parse(rawArgs);
     } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
+
+    const adapter = getAdapter({ repo: args.repo });
+    const result = await adapter.workItem(args);
+
+    if ('platform_unsupported' in result) {
+      return envelope({ ok: false, platform_unsupported: true, error: result.hint });
+    }
+    if (!result.ok) return envelope({ ok: false, error: result.error });
+    return envelope({ ok: true, ...result.data });
   },
 };
 

--- a/lib/adapters/github.ts
+++ b/lib/adapters/github.ts
@@ -31,6 +31,7 @@ import { prMergeGithub } from './pr-merge-github.js';
 import { prMergeWaitGithub } from './pr-merge-wait-github.js';
 import { prStatusGithub } from './pr-status-github.js';
 import { prWaitCiGithub } from './pr-wait-ci-github.js';
+import { workItemGithub } from './work-item-github.js';
 
 const stubMethod = async (_args: unknown) => ({
   platform_unsupported: true as const,
@@ -54,7 +55,7 @@ export const githubAdapter: PlatformAdapter = {
   ciRunsForBranch: ciRunsForBranchGithub,
   labelCreate: labelCreateGithub,
   labelList: labelListGithub,
-  workItem: stubMethod,
+  workItem: workItemGithub,
   ibm: stubMethod,
   epicSubIssues: stubMethod,
   specGet: stubMethod,

--- a/lib/adapters/gitlab.ts
+++ b/lib/adapters/gitlab.ts
@@ -32,6 +32,7 @@ import { prMergeGitlab } from './pr-merge-gitlab.js';
 import { prMergeWaitGitlab } from './pr-merge-wait-gitlab.js';
 import { prStatusGitlab } from './pr-status-gitlab.js';
 import { prWaitCiGitlab } from './pr-wait-ci-gitlab.js';
+import { workItemGitlab } from './work-item-gitlab.js';
 
 const stubMethod = async (_args: unknown) => ({
   platform_unsupported: true as const,
@@ -55,7 +56,7 @@ export const gitlabAdapter: PlatformAdapter = {
   ciRunsForBranch: ciRunsForBranchGitlab,
   labelCreate: labelCreateGitlab,
   labelList: labelListGitlab,
-  workItem: stubMethod,
+  workItem: workItemGitlab,
   ibm: stubMethod,
   epicSubIssues: stubMethod,
   specGet: stubMethod,

--- a/lib/adapters/types.test.ts
+++ b/lib/adapters/types.test.ts
@@ -53,6 +53,7 @@ describe('PlatformAdapter contract', () => {
   // Story 2.14 (#308): ciRunsForBranch
   // Story 2.15 (#309): labelCreate
   // Story 2.16 (#310): labelList
+  // Story 2.17 (#311): workItem (+ closes #281 cross-platform PR/MR asymmetry)
   const MIGRATED_METHODS = new Set<string>([
     'prCreate',
     'prDiff',
@@ -71,6 +72,7 @@ describe('PlatformAdapter contract', () => {
     'ciRunsForBranch',
     'labelCreate',
     'labelList',
+    'workItem',
   ]);
 
   test('still-stubbed methods return platform_unsupported', async () => {

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -490,8 +490,55 @@ export interface LabelListResponse {
   labels: NormalizedLabelListEntry[];
   count: number;
 }
-export type WorkItemArgs = unknown;
-export type WorkItemResponse = unknown;
+/**
+ * `work_item` args/response (Story 2.17, #311). Full-migration of the
+ * multi-shape "create an issue OR PR/MR" handler.
+ *
+ * `type` drives the sub-command an adapter picks:
+ *   - issue types (`epic | story | bug | chore | docs | feature | fix`) →
+ *     `gh issue create` / `glab issue create`
+ *   - `pr` → `gh pr create` (GitHub)    | GitLab returns `platform_unsupported`
+ *   - `mr` → `glab mr create` (GitLab)  | GitHub returns `platform_unsupported`
+ *
+ * The cross-platform asymmetry (PR on GitLab / MR on GitHub) is the typed
+ * `platform_unsupported` signal per R-03 / #281. Before this migration, the
+ * handler dispatched to the wrong platform's create fn on those inputs — e.g.
+ * `createGithubPR` ran on a GitLab repo for `type:'pr'`. The adapter boundary
+ * collapses dispatch into one method so the handler never branches on type
+ * OR platform.
+ *
+ * `head_branch`, `base_branch`, `draft` are PR/MR-only and silently ignored on
+ * issue types (matches pre-migration behavior — those fields are schema-opt).
+ * `labels` apply to both issue and PR/MR creation, with `type::<name>` auto-
+ * merged for issue types only (PRs/MRs do not receive auto type labels — they
+ * carry `size::*` / `priority::*` etc. via the caller's explicit labels list).
+ */
+export type WorkItemType =
+  | 'epic'
+  | 'story'
+  | 'feature'
+  | 'bug'
+  | 'chore'
+  | 'docs'
+  | 'fix'
+  | 'pr'
+  | 'mr';
+
+export interface WorkItemArgs {
+  type: WorkItemType;
+  title: string;
+  body?: string;
+  labels?: string[];
+  head_branch?: string;
+  base_branch?: string;
+  draft?: boolean;
+  repo?: string;
+}
+
+export interface WorkItemResponse {
+  url: string;
+  number: number;
+}
 export type IbmArgs = unknown;
 export type IbmResponse = unknown;
 export type EpicSubIssuesArgs = unknown;

--- a/lib/adapters/work-item-github.test.ts
+++ b/lib/adapters/work-item-github.test.ts
@@ -1,0 +1,231 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { AdapterResult, WorkItemResponse } from './types.ts';
+
+// Subprocess-boundary tests for the GitHub work_item adapter (R-15).
+// Integration-level coverage (schema validation, handler envelope, cross-platform
+// dispatch) stays in tests/work_item.test.ts; this file owns the argv-shape
+// assertions that prove the adapter speaks `gh` correctly.
+//
+// Argv strictness per `lesson_origin_ops_pitfalls.md`: gh takes `--repo` (long
+// flag) and `--body <string>` inline — NOT glab's `-R` or `--description`.
+// Also covers the typed `platform_unsupported` asymmetry required by #281
+// for `type:'mr'` on a GitHub repo.
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  // Argv strictness — glab-style flags on the gh path means we regressed.
+  if (
+    (flat.includes('gh issue create') || flat.includes('gh pr create')) &&
+    (/\s-R\s/.test(flat) || /--description/.test(flat) || /--source-branch/.test(flat) || /--target-branch/.test(flat))
+  ) {
+    const err = new Error(
+      `FAIL: gh ${flat.includes('issue') ? 'issue' : 'pr'} create invoked with glab-style flags`,
+    ) as ThrowableError;
+    err.status = 127;
+    throw err;
+  }
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { workItemGithub } = await import('./work-item-github.ts');
+
+function on(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
+function expectOk(
+  r: AdapterResult<WorkItemResponse>,
+): asserts r is { ok: true; data: WorkItemResponse } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectErr(
+  r: AdapterResult<WorkItemResponse>,
+): asserts r is { ok: false; error: string; code: string } {
+  if (!('ok' in r) || r.ok) {
+    throw new Error(`expected error result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectUnsupported(
+  r: AdapterResult<WorkItemResponse>,
+): asserts r is { platform_unsupported: true; hint: string } {
+  if (!('platform_unsupported' in r)) {
+    throw new Error(`expected platform_unsupported, got ${JSON.stringify(r)}`);
+  }
+}
+
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('workItemGithub — subprocess boundary', () => {
+  // --- #281 regression: type:'mr' on GitHub returns platform_unsupported ---
+
+  test("type:'mr' returns platform_unsupported with hint (regression for #281)", async () => {
+    const result = await workItemGithub({ type: 'mr', title: 'My MR', head_branch: 'x', base_branch: 'main' });
+    expectUnsupported(result);
+    expect(result.hint).toContain('type="pr"');
+    // No `glab` sub-command should have been attempted.
+    expect(execCalls.length).toBe(0);
+  });
+
+  // --- issue types → gh issue create ---
+
+  test("argv: gh issue create for type:'story' auto-merges type::story label", async () => {
+    on('gh issue create', 'https://github.com/org/repo/issues/42\n');
+
+    const result = await workItemGithub({ type: 'story', title: 'My story', body: 'details' });
+    expectOk(result);
+
+    const call = findCall('gh issue create');
+    expect(call).toContain("'gh' 'issue' 'create'");
+    expect(call).toContain("'--title' 'My story'");
+    expect(call).toContain("'--body' 'details'");
+    expect(call).toContain("'--label' 'type::story'");
+    expect(result.data.number).toBe(42);
+    expect(result.data.url).toBe('https://github.com/org/repo/issues/42');
+  });
+
+  test('argv: forwards caller labels alongside auto type::* label', async () => {
+    on('gh issue create', 'https://github.com/org/repo/issues/7\n');
+
+    await workItemGithub({ type: 'epic', title: 'Big epic', labels: ['priority::high', 'size::XL'] });
+
+    const call = findCall('gh issue create');
+    expect(call).toContain("'--label' 'type::epic'");
+    expect(call).toContain("'--label' 'priority::high'");
+    expect(call).toContain("'--label' 'size::XL'");
+  });
+
+  test('argv: --repo forwarded for cross-repo issue create', async () => {
+    on('gh issue create', 'https://github.com/foo/bar/issues/3\n');
+
+    await workItemGithub({ type: 'chore', title: 'Cleanup', repo: 'foo/bar' });
+
+    const call = findCall('gh issue create');
+    expect(call).toContain("'--repo' 'foo/bar'");
+  });
+
+  test('argv: body defaults to empty string when omitted', async () => {
+    on('gh issue create', 'https://github.com/org/repo/issues/1\n');
+
+    await workItemGithub({ type: 'bug', title: 'No body' });
+
+    const call = findCall('gh issue create');
+    expect(call).toContain("'--body' ''");
+  });
+
+  // --- type:'pr' → gh pr create ---
+
+  test("argv: gh pr create for type:'pr' with head/base/draft", async () => {
+    on('gh pr create', 'https://github.com/org/repo/pull/99\n');
+
+    const result = await workItemGithub({
+      type: 'pr',
+      title: 'My PR',
+      body: 'pr body',
+      head_branch: 'feature/1-foo',
+      base_branch: 'main',
+      draft: true,
+    });
+    expectOk(result);
+
+    const call = findCall('gh pr create');
+    expect(call).toContain("'--title' 'My PR'");
+    expect(call).toContain("'--body' 'pr body'");
+    expect(call).toContain("'--head' 'feature/1-foo'");
+    expect(call).toContain("'--base' 'main'");
+    expect(call).toContain('--draft');
+    expect(result.data.number).toBe(99);
+  });
+
+  test("type:'pr' gets no automatic type label; caller labels still forwarded", async () => {
+    on('gh pr create', 'https://github.com/org/repo/pull/5\n');
+
+    await workItemGithub({ type: 'pr', title: 'Patch', labels: ['size::S'] });
+
+    const call = findCall('gh pr create');
+    expect(call).not.toContain('type::pr');
+    expect(call).toContain("'--label' 'size::S'");
+  });
+
+  test('argv: omits --draft when draft not set', async () => {
+    on('gh pr create', 'https://github.com/org/repo/pull/5\n');
+
+    await workItemGithub({ type: 'pr', title: 'Patch', head_branch: 'x', base_branch: 'main' });
+
+    const call = findCall('gh pr create');
+    expect(call).not.toContain('--draft');
+  });
+
+  // --- error surface ---
+
+  test('returns AdapterResult.error on gh issue failure (not thrown)', async () => {
+    on('gh issue create', () => {
+      const err = new Error('gh: not authenticated') as ThrowableError;
+      err.stderr = 'gh: not authenticated';
+      err.status = 1;
+      throw err;
+    });
+
+    const result = await workItemGithub({ type: 'bug', title: 'Boom' });
+    expectErr(result);
+    expect(result.code).toBe('gh_issue_create_failed');
+    expect(result.error).toContain('gh issue create failed');
+  });
+
+  test('returns AdapterResult.error on gh pr failure (not thrown)', async () => {
+    on('gh pr create', () => {
+      const err = new Error('gh: cannot find base branch') as ThrowableError;
+      err.stderr = 'no such ref';
+      err.status = 1;
+      throw err;
+    });
+
+    const result = await workItemGithub({ type: 'pr', title: 'Bad', head_branch: 'nope', base_branch: 'gone' });
+    expectErr(result);
+    expect(result.code).toBe('gh_pr_create_failed');
+  });
+
+  test('shell-escapes titles with embedded quotes', async () => {
+    on('gh issue create', 'https://github.com/org/repo/issues/1\n');
+
+    await workItemGithub({ type: 'story', title: "it's a story" });
+
+    const call = findCall('gh issue create');
+    // shellEscape converts `'` into `'\''`.
+    expect(call).toContain(`'it'\\''s a story'`);
+  });
+});

--- a/lib/adapters/work-item-github.ts
+++ b/lib/adapters/work-item-github.ts
@@ -1,0 +1,142 @@
+/**
+ * GitHub `work_item` adapter implementation.
+ *
+ * Lifted from `handlers/work_item.ts` per Story 2.17 (#311). Unifies what was
+ * two GitHub-specific functions (`createGithubIssue`, `createGithubPR`) into a
+ * single adapter method that picks the right `gh` sub-command internally based
+ * on `args.type`.
+ *
+ * Cross-platform asymmetry (R-03 / #281):
+ *   - `type: 'mr'` is a GitLab concept. This adapter returns
+ *     `{platform_unsupported: true, hint: 'use type="pr" on GitHub'}` rather
+ *     than silently succeeding OR running the wrong sub-command (the
+ *     pre-migration bug that #281 tracked).
+ *
+ * Argv composition:
+ *   Issue types (epic | story | bug | chore | docs | feature | fix):
+ *     gh issue create
+ *       --title <title>
+ *       --body <body>
+ *       [--label <label>]...          // repeated; includes auto `type::<type>`
+ *       [--repo <owner/repo>]
+ *
+ *   `type: 'pr'`:
+ *     gh pr create
+ *       --title <title>
+ *       --body <body>
+ *       [--head <branch>]
+ *       [--base <branch>]
+ *       [--draft]
+ *       [--label <label>]...          // caller-supplied; NO auto type label
+ *       [--repo <owner/repo>]
+ */
+
+import { execSync } from 'child_process';
+import { runArgv } from '../shared/error-norm.js';
+import type {
+  AdapterResult,
+  WorkItemArgs,
+  WorkItemResponse,
+} from './types.js';
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+const ISSUE_TYPE_LABELS: Record<string, string | null> = {
+  epic: 'type::epic',
+  story: 'type::story',
+  feature: 'type::feature',
+  bug: 'type::bug',
+  chore: 'type::chore',
+  docs: 'type::docs',
+  fix: 'type::fix',
+  pr: null,
+  mr: null,
+};
+
+function isIssueType(type: string): boolean {
+  return type !== 'pr' && type !== 'mr';
+}
+
+/**
+ * Parse `{url, number}` from a `gh issue/pr create` success payload. Both
+ * commands print the created item's URL on their last line of stdout; the
+ * trailing path segment is the numeric id.
+ */
+function parseGhOutput(stdout: string): WorkItemResponse {
+  const lines = stdout.trim().split('\n');
+  const url = lines[lines.length - 1].trim();
+  const match = url.match(/\/(\d+)$/);
+  const number = match ? parseInt(match[1], 10) : 0;
+  return { url, number };
+}
+
+export async function workItemGithub(
+  args: WorkItemArgs,
+): Promise<AdapterResult<WorkItemResponse>> {
+  // Cross-platform asymmetry — `mr` is GitLab-only. Per #281, we surface this
+  // as a typed signal rather than running the wrong sub-command.
+  if (args.type === 'mr') {
+    return {
+      platform_unsupported: true,
+      hint: 'use type="pr" on GitHub',
+    };
+  }
+
+  try {
+    const cwd = projectDir();
+    const body = args.body ?? '';
+
+    if (isIssueType(args.type)) {
+      const cmd = ['gh', 'issue', 'create', '--title', args.title, '--body', body];
+      const autoLabel = ISSUE_TYPE_LABELS[args.type];
+      const labels = autoLabel ? [autoLabel, ...(args.labels ?? [])] : [...(args.labels ?? [])];
+      for (const label of labels) {
+        cmd.push('--label', label);
+      }
+      if (args.repo !== undefined) cmd.push('--repo', args.repo);
+
+      const result = runArgv(cmd, cwd);
+      if (result.exitCode !== 0) {
+        return {
+          ok: false,
+          code: 'gh_issue_create_failed',
+          error: `gh issue create failed: ${result.stderr.trim() || result.stdout.trim()}`,
+        };
+      }
+      return { ok: true, data: parseGhOutput(result.stdout) };
+    }
+
+    // args.type === 'pr'
+    const cmd = ['gh', 'pr', 'create', '--title', args.title, '--body', body];
+    if (args.head_branch !== undefined) cmd.push('--head', args.head_branch);
+    if (args.base_branch !== undefined) cmd.push('--base', args.base_branch);
+    if (args.draft) cmd.push('--draft');
+    for (const label of args.labels ?? []) {
+      cmd.push('--label', label);
+    }
+    if (args.repo !== undefined) cmd.push('--repo', args.repo);
+
+    const result = runArgv(cmd, cwd);
+    if (result.exitCode !== 0) {
+      return {
+        ok: false,
+        code: 'gh_pr_create_failed',
+        error: `gh pr create failed: ${result.stderr.trim() || result.stdout.trim()}`,
+      };
+    }
+    return { ok: true, data: parseGhOutput(result.stdout) };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'unexpected_error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// `execSync` is intentionally re-imported above so that adapter-level test
+// files can `mock.module('child_process', ...)` and intercept this module's
+// subprocess calls without needing access to the handler's mock setup.
+void execSync;

--- a/lib/adapters/work-item-gitlab.test.ts
+++ b/lib/adapters/work-item-gitlab.test.ts
@@ -1,0 +1,211 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { AdapterResult, WorkItemResponse } from './types.ts';
+
+// Subprocess-boundary tests for the GitLab work_item adapter (R-15).
+// Integration-level coverage (schema validation, handler envelope, cross-platform
+// dispatch) stays in tests/work_item.test.ts; this file owns the argv-shape
+// assertions that prove the adapter speaks `glab` correctly.
+//
+// Argv strictness per `lesson_origin_ops_pitfalls.md`: glab takes `-R` (short
+// flag) and `--description <string>` — NOT gh's `--repo` or `--body`. Also
+// covers the typed `platform_unsupported` asymmetry required by #281 for
+// `type:'pr'` on a GitLab repo.
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  // Argv strictness — gh-style flags on the glab path means we regressed.
+  if (
+    (flat.includes('glab issue create') || flat.includes('glab mr create')) &&
+    (/--repo\s/.test(flat) || /--body\s/.test(flat) || /--head\s/.test(flat) || /--base\s/.test(flat))
+  ) {
+    const err = new Error(
+      `FAIL: glab ${flat.includes('issue') ? 'issue' : 'mr'} create invoked with gh-style flags`,
+    ) as ThrowableError;
+    err.status = 127;
+    throw err;
+  }
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { workItemGitlab } = await import('./work-item-gitlab.ts');
+
+function on(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
+function expectOk(
+  r: AdapterResult<WorkItemResponse>,
+): asserts r is { ok: true; data: WorkItemResponse } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectErr(
+  r: AdapterResult<WorkItemResponse>,
+): asserts r is { ok: false; error: string; code: string } {
+  if (!('ok' in r) || r.ok) {
+    throw new Error(`expected error result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectUnsupported(
+  r: AdapterResult<WorkItemResponse>,
+): asserts r is { platform_unsupported: true; hint: string } {
+  if (!('platform_unsupported' in r)) {
+    throw new Error(`expected platform_unsupported, got ${JSON.stringify(r)}`);
+  }
+}
+
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('workItemGitlab — subprocess boundary', () => {
+  // --- #281 regression: type:'pr' on GitLab returns platform_unsupported ---
+
+  test("type:'pr' returns platform_unsupported with hint (regression for #281)", async () => {
+    const result = await workItemGitlab({ type: 'pr', title: 'My PR', head_branch: 'x', base_branch: 'main' });
+    expectUnsupported(result);
+    expect(result.hint).toContain('type="mr"');
+    // No `gh` sub-command should have been attempted.
+    expect(execCalls.length).toBe(0);
+  });
+
+  // --- issue types → glab issue create ---
+
+  test("argv: glab issue create for type:'story' auto-merges type::story label", async () => {
+    on('glab issue create', 'https://gitlab.com/org/repo/-/issues/7\n');
+
+    const result = await workItemGitlab({ type: 'story', title: 'GL story', body: 'details' });
+    expectOk(result);
+
+    const call = findCall('glab issue create');
+    expect(call).toContain("'glab' 'issue' 'create'");
+    expect(call).toContain("'--title' 'GL story'");
+    expect(call).toContain("'--description' 'details'");
+    expect(call).toContain("'--label' 'type::story'");
+    expect(result.data.number).toBe(7);
+  });
+
+  test('argv: forwards caller labels as CSV alongside auto type::* label', async () => {
+    on('glab issue create', 'https://gitlab.com/org/repo/-/issues/12\n');
+
+    await workItemGitlab({ type: 'bug', title: 'A bug', labels: ['priority::high', 'team::alpha'] });
+
+    const call = findCall('glab issue create');
+    // glab wants a single comma-separated --label value.
+    expect(call).toContain("'--label' 'type::bug,priority::high,team::alpha'");
+  });
+
+  test('argv: -R (not --repo) forwarded for cross-repo issue create', async () => {
+    on('glab issue create', 'https://gitlab.com/foo/bar/-/issues/3\n');
+
+    await workItemGitlab({ type: 'chore', title: 'Cleanup', repo: 'foo/bar' });
+
+    const call = findCall('glab issue create');
+    expect(call).toContain("'-R' 'foo/bar'");
+    expect(call).not.toContain('--repo');
+  });
+
+  // --- type:'mr' → glab mr create ---
+
+  test("argv: glab mr create for type:'mr' with source/target/draft", async () => {
+    on('glab mr create', 'https://gitlab.com/org/repo/-/merge_requests/99\n');
+
+    const result = await workItemGitlab({
+      type: 'mr',
+      title: 'My MR',
+      body: 'mr body',
+      head_branch: 'feature/2-bar',
+      base_branch: 'main',
+      draft: true,
+    });
+    expectOk(result);
+
+    const call = findCall('glab mr create');
+    expect(call).toContain("'--title' 'My MR'");
+    expect(call).toContain("'--description' 'mr body'");
+    expect(call).toContain("'--source-branch' 'feature/2-bar'");
+    expect(call).toContain("'--target-branch' 'main'");
+    expect(call).toContain('--draft');
+    expect(result.data.number).toBe(99);
+  });
+
+  test("type:'mr' gets no automatic type label; caller labels still forwarded as CSV", async () => {
+    on('glab mr create', 'https://gitlab.com/org/repo/-/merge_requests/5\n');
+
+    await workItemGitlab({ type: 'mr', title: 'Patch', labels: ['size::S', 'team::beta'] });
+
+    const call = findCall('glab mr create');
+    expect(call).not.toContain('type::mr');
+    expect(call).toContain("'--label' 'size::S,team::beta'");
+  });
+
+  test('argv: omits --label when no labels supplied for MR', async () => {
+    on('glab mr create', 'https://gitlab.com/org/repo/-/merge_requests/5\n');
+
+    await workItemGitlab({ type: 'mr', title: 'Patch', head_branch: 'x', base_branch: 'main' });
+
+    const call = findCall('glab mr create');
+    expect(call).not.toContain('--label');
+  });
+
+  // --- error surface ---
+
+  test('returns AdapterResult.error on glab issue failure (not thrown)', async () => {
+    on('glab issue create', () => {
+      const err = new Error('glab: not authenticated') as ThrowableError;
+      err.stderr = 'glab: not authenticated';
+      err.status = 1;
+      throw err;
+    });
+
+    const result = await workItemGitlab({ type: 'bug', title: 'Boom' });
+    expectErr(result);
+    expect(result.code).toBe('glab_issue_create_failed');
+    expect(result.error).toContain('glab issue create failed');
+  });
+
+  test('returns AdapterResult.error on glab mr failure (not thrown)', async () => {
+    on('glab mr create', () => {
+      const err = new Error('glab: cannot find target branch') as ThrowableError;
+      err.stderr = 'no such ref';
+      err.status = 1;
+      throw err;
+    });
+
+    const result = await workItemGitlab({ type: 'mr', title: 'Bad', head_branch: 'x', base_branch: 'gone' });
+    expectErr(result);
+    expect(result.code).toBe('glab_mr_create_failed');
+  });
+});

--- a/lib/adapters/work-item-gitlab.ts
+++ b/lib/adapters/work-item-gitlab.ts
@@ -1,0 +1,144 @@
+/**
+ * GitLab `work_item` adapter implementation.
+ *
+ * Lifted from `handlers/work_item.ts` per Story 2.17 (#311). Unifies what was
+ * two GitLab-specific functions (`createGitlabIssue`, `createGitlabMR`) into a
+ * single adapter method that picks the right `glab` sub-command internally
+ * based on `args.type`.
+ *
+ * Cross-platform asymmetry (R-03 / #281):
+ *   - `type: 'pr'` is a GitHub concept. This adapter returns
+ *     `{platform_unsupported: true, hint: 'use type="mr" on GitLab'}` rather
+ *     than silently succeeding OR running the wrong sub-command (the
+ *     pre-migration bug — `createGithubPR` ran against a GitLab origin).
+ *
+ * Argv composition:
+ *   Issue types (epic | story | bug | chore | docs | feature | fix):
+ *     glab issue create
+ *       --title <title>
+ *       --description <body>
+ *       [--label <csv>]               // glab takes a comma-separated list
+ *       [-R <owner/repo>]             // glab uses short `-R`, NOT `--repo`
+ *
+ *   `type: 'mr'`:
+ *     glab mr create
+ *       --title <title>
+ *       --description <body>
+ *       [--source-branch <branch>]
+ *       [--target-branch <branch>]
+ *       [--draft]
+ *       [--label <csv>]
+ *       [-R <owner/repo>]
+ *
+ * Argv strictness per `lesson_origin_ops_pitfalls.md`: glab rejects GitHub-style
+ * `--repo` and `--body-file`; this adapter uses `-R` and `--description <body>`.
+ */
+
+import { execSync } from 'child_process';
+import { runArgv } from '../shared/error-norm.js';
+import type {
+  AdapterResult,
+  WorkItemArgs,
+  WorkItemResponse,
+} from './types.js';
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+const ISSUE_TYPE_LABELS: Record<string, string | null> = {
+  epic: 'type::epic',
+  story: 'type::story',
+  feature: 'type::feature',
+  bug: 'type::bug',
+  chore: 'type::chore',
+  docs: 'type::docs',
+  fix: 'type::fix',
+  pr: null,
+  mr: null,
+};
+
+function isIssueType(type: string): boolean {
+  return type !== 'pr' && type !== 'mr';
+}
+
+/**
+ * Parse `{url, number}` from a `glab issue/mr create` success payload. Both
+ * commands print the created item's URL on their last line of stdout; the
+ * trailing path segment is the numeric id.
+ */
+function parseGlabOutput(stdout: string): WorkItemResponse {
+  const lines = stdout.trim().split('\n');
+  const url = lines[lines.length - 1].trim();
+  const match = url.match(/\/(\d+)$/);
+  const number = match ? parseInt(match[1], 10) : 0;
+  return { url, number };
+}
+
+export async function workItemGitlab(
+  args: WorkItemArgs,
+): Promise<AdapterResult<WorkItemResponse>> {
+  // Cross-platform asymmetry — `pr` is GitHub-only. Per #281, we surface this
+  // as a typed signal rather than running the wrong sub-command.
+  if (args.type === 'pr') {
+    return {
+      platform_unsupported: true,
+      hint: 'use type="mr" on GitLab',
+    };
+  }
+
+  try {
+    const cwd = projectDir();
+    const body = args.body ?? '';
+
+    if (isIssueType(args.type)) {
+      const cmd = ['glab', 'issue', 'create', '--title', args.title, '--description', body];
+      const autoLabel = ISSUE_TYPE_LABELS[args.type];
+      const labels = autoLabel ? [autoLabel, ...(args.labels ?? [])] : [...(args.labels ?? [])];
+      if (labels.length > 0) {
+        cmd.push('--label', labels.join(','));
+      }
+      if (args.repo !== undefined) cmd.push('-R', args.repo);
+
+      const result = runArgv(cmd, cwd);
+      if (result.exitCode !== 0) {
+        return {
+          ok: false,
+          code: 'glab_issue_create_failed',
+          error: `glab issue create failed: ${result.stderr.trim() || result.stdout.trim()}`,
+        };
+      }
+      return { ok: true, data: parseGlabOutput(result.stdout) };
+    }
+
+    // args.type === 'mr'
+    const cmd = ['glab', 'mr', 'create', '--title', args.title, '--description', body];
+    if (args.head_branch !== undefined) cmd.push('--source-branch', args.head_branch);
+    if (args.base_branch !== undefined) cmd.push('--target-branch', args.base_branch);
+    if (args.draft) cmd.push('--draft');
+    const labels = args.labels ?? [];
+    if (labels.length > 0) {
+      cmd.push('--label', labels.join(','));
+    }
+    if (args.repo !== undefined) cmd.push('-R', args.repo);
+
+    const result = runArgv(cmd, cwd);
+    if (result.exitCode !== 0) {
+      return {
+        ok: false,
+        code: 'glab_mr_create_failed',
+        error: `glab mr create failed: ${result.stderr.trim() || result.stdout.trim()}`,
+      };
+    }
+    return { ok: true, data: parseGlabOutput(result.stdout) };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'unexpected_error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// See work-item-github.ts for the rationale.
+void execSync;

--- a/scripts/ci/migration-allowlist.txt
+++ b/scripts/ci/migration-allowlist.txt
@@ -25,4 +25,3 @@ wave_init.ts
 wave_previous_merged.ts
 wave_reconcile_mrs.ts
 wave_topology.ts
-work_item.ts

--- a/tests/work_item.test.ts
+++ b/tests/work_item.test.ts
@@ -1,79 +1,117 @@
-import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
 
-// ---- Mocks ----------------------------------------------------------------
-// We intercept child_process.execSync and fs.writeFileSync so no OS calls happen.
+// Integration coverage for the work_item handler post-Story-2.17 (#311).
+//
+// work_item now dispatches through the platform adapter; per-platform adapters
+// call subprocess via `runArgv`, which shell-escapes its argv (e.g.
+// `'gh' 'issue' 'create' '--title' 'X'`). The `unquote` shim strips that
+// quoting so test match-keys can stay as plain `gh issue create` strings —
+// same pattern adopted by tests/label_list.test.ts / tests/label_create.test.ts.
+//
+// Argv-shape assertions live in the colocated adapter tests
+// (lib/adapters/work-item-{github,gitlab}.test.ts). This file owns:
+//   - schema validation
+//   - handler envelope shape
+//   - cross-platform dispatch via detect-platform
+//   - #281 regression (cross-platform asymmetry)
 
-let lastExecCall = '';
-let execMockFn: (cmd: string) => string = () => 'https://github.com/org/repo/issues/42\n';
+interface MockExecError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
 
 const mockExecSync = mock((cmd: string, _opts?: unknown) => {
-  lastExecCall = cmd;
-  return execMockFn(cmd);
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  throw new Error(`Unexpected exec: ${cmd}`);
 });
 
-const mockWriteFileSync = mock((_path: unknown, _data: unknown) => undefined);
-
-// Patch modules before importing the handler
 mock.module('child_process', () => ({ execSync: mockExecSync }));
-mock.module('fs', () => ({ writeFileSync: mockWriteFileSync }));
 
-// Now import handler (after mocks are in place)
 const { default: handler } = await import('../handlers/work_item.ts');
 
-// ---- Helpers ----------------------------------------------------------------
-function resetMocks() {
-  lastExecCall = '';
-  mockExecSync.mockClear();
-  mockWriteFileSync.mockClear();
+function parseResult(content: Array<{ type: string; text: string }>) {
+  return JSON.parse(content[0].text) as Record<string, unknown>;
 }
 
-function setOriginUrl(url: string) {
-  execMockFn = (cmd: string) => {
-    if (cmd.startsWith('git remote get-url')) return url + '\n';
-    return 'https://github.com/org/repo/issues/42\n';
-  };
+function onExec(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
 }
 
-function setGitlabOrigin() {
-  execMockFn = (cmd: string) => {
-    if (cmd.startsWith('git remote get-url')) return 'git@gitlab.com:org/repo.git\n';
-    return 'https://gitlab.com/org/repo/-/issues/7\n';
-  };
-}
-
-// ---- Tests -----------------------------------------------------------------
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
 
 describe('work_item handler', () => {
-  beforeEach(resetMocks);
-  afterEach(resetMocks);
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('work_item');
+    expect(typeof handler.execute).toBe('function');
+  });
 
-  // ---- routes_issue_to_gh_issue_create ------------------------------------
-  test('routes_issue_to_gh_issue_create — GitHub issue types use gh issue create', async () => {
-    setOriginUrl('https://github.com/org/repo.git');
+  // ---- schema validation ----
+
+  test('schema rejects unknown type', async () => {
+    const result = await handler.execute({ type: 'not-a-type', title: 'X' });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+    expect(String(data.error)).toMatch(/type/);
+  });
+
+  test('schema rejects empty title', async () => {
+    const result = await handler.execute({ type: 'story', title: '' });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+    expect(String(data.error)).toMatch(/title/);
+  });
+
+  // ---- github: issue types ----
+
+  test('github — type:story dispatches to gh issue create', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
+    onExec('gh issue create', 'https://github.com/org/repo/issues/42\n');
+
     const result = await handler.execute({ type: 'story', title: 'My story', body: 'details' });
-    const calls = mockExecSync.mock.calls.map(c => c[0] as string);
-    const createCall = calls.find(c => c.includes('gh issue create'));
-    expect(createCall).toBeDefined();
-    expect(createCall).toContain('gh issue create');
-    expect(createCall).toContain('My story');
-    const parsed = JSON.parse((result.content[0] as { type: string; text: string }).text);
-    expect(parsed.ok).toBe(true);
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    expect(data.number).toBe(42);
+    expect(data.url).toBe('https://github.com/org/repo/issues/42');
+
+    const call = execCalls.find((c) => unquote(c).includes('gh issue create')) ?? '';
+    expect(call).toContain("'--title' 'My story'");
+    expect(call).toContain("'--label' 'type::story'");
   });
 
-  test('routes_issue_to_gh_issue_create — bug type also uses gh issue create', async () => {
-    setOriginUrl('https://github.com/org/repo.git');
-    await handler.execute({ type: 'bug', title: 'A bug' });
-    const calls = mockExecSync.mock.calls.map(c => c[0] as string);
-    expect(calls.some(c => c.includes('gh issue create'))).toBe(true);
+  test('github — type:bug auto-merges type::bug label', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
+    onExec('gh issue create', 'https://github.com/org/repo/issues/7\n');
+
+    await handler.execute({ type: 'bug', title: 'A bug', labels: ['priority::high'] });
+
+    const call = execCalls.find((c) => unquote(c).includes('gh issue create')) ?? '';
+    expect(call).toContain("'--label' 'type::bug'");
+    expect(call).toContain("'--label' 'priority::high'");
   });
 
-  // ---- routes_pr_to_gh_pr_create ------------------------------------------
-  test('routes_pr_to_gh_pr_create — GitHub PR uses gh pr create', async () => {
-    setOriginUrl('https://github.com/org/repo.git');
-    execMockFn = (cmd: string) => {
-      if (cmd.startsWith('git remote get-url')) return 'https://github.com/org/repo.git\n';
-      return 'https://github.com/org/repo/pull/99\n';
-    };
+  // ---- github: PR ----
+
+  test('github — type:pr dispatches to gh pr create with head/base/draft', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
+    onExec('gh pr create', 'https://github.com/org/repo/pull/99\n');
+
     const result = await handler.execute({
       type: 'pr',
       title: 'My PR',
@@ -81,104 +119,104 @@ describe('work_item handler', () => {
       base_branch: 'main',
       draft: true,
     });
-    const calls = mockExecSync.mock.calls.map(c => c[0] as string);
-    const prCall = calls.find(c => c.includes('gh pr create'));
-    expect(prCall).toBeDefined();
-    expect(prCall).toContain('--head feature/1-foo');
-    expect(prCall).toContain('--base main');
-    expect(prCall).toContain('--draft');
-    const parsed = JSON.parse((result.content[0] as { type: string; text: string }).text);
-    expect(parsed.ok).toBe(true);
-    expect(parsed.number).toBe(99);
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    expect(data.number).toBe(99);
+
+    const call = execCalls.find((c) => unquote(c).includes('gh pr create')) ?? '';
+    expect(call).toContain("'--head' 'feature/1-foo'");
+    expect(call).toContain("'--base' 'main'");
+    expect(call).toContain('--draft');
   });
 
-  // ---- routes_mr_to_glab_mr_create ----------------------------------------
-  test('routes_mr_to_glab_mr_create — GitLab MR uses glab mr create', async () => {
-    setGitlabOrigin();
+  // ---- #281 regression: cross-platform asymmetry ----
+
+  test("github — type:'mr' returns platform_unsupported (regression for #281)", async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
+
+    const result = await handler.execute({ type: 'mr', title: 'Wrong platform' });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+    expect(data.platform_unsupported).toBe(true);
+    expect(String(data.error)).toContain('type="pr"');
+    // Verify NO `glab` sub-command was attempted (only `git remote get-url`).
+    const glabCalls = execCalls.filter((c) => unquote(c).includes('glab'));
+    expect(glabCalls.length).toBe(0);
+  });
+
+  test("gitlab — type:'pr' returns platform_unsupported (regression for #281)", async () => {
+    onExec('git remote get-url origin', 'git@gitlab.com:org/repo.git');
+
+    const result = await handler.execute({ type: 'pr', title: 'Wrong platform' });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+    expect(data.platform_unsupported).toBe(true);
+    expect(String(data.error)).toContain('type="mr"');
+    // Verify NO `gh` sub-command was attempted.
+    const ghCalls = execCalls.filter((c) => {
+      const flat = unquote(c);
+      return flat.startsWith('gh ') || flat.includes(' gh ');
+    });
+    expect(ghCalls.length).toBe(0);
+  });
+
+  // ---- gitlab: issue types ----
+
+  test('gitlab — type:story dispatches to glab issue create with -R and CSV labels', async () => {
+    onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git');
+    onExec('glab issue create', 'https://gitlab.com/org/repo/-/issues/5\n');
+
+    const result = await handler.execute({
+      type: 'story',
+      title: 'GL story',
+      labels: ['team::alpha'],
+      repo: 'foo/bar',
+    });
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    expect(data.number).toBe(5);
+
+    const call = execCalls.find((c) => unquote(c).includes('glab issue create')) ?? '';
+    expect(call).toContain("'--title' 'GL story'");
+    expect(call).toContain("'--label' 'type::story,team::alpha'");
+    expect(call).toContain("'-R' 'foo/bar'");
+  });
+
+  // ---- gitlab: MR ----
+
+  test('gitlab — type:mr dispatches to glab mr create with source/target branches', async () => {
+    onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git');
+    onExec('glab mr create', 'https://gitlab.com/org/repo/-/merge_requests/12\n');
+
     const result = await handler.execute({
       type: 'mr',
       title: 'My MR',
       head_branch: 'feature/2-bar',
       base_branch: 'main',
     });
-    const calls = mockExecSync.mock.calls.map(c => c[0] as string);
-    const mrCall = calls.find(c => c.includes('glab mr create'));
-    expect(mrCall).toBeDefined();
-    expect(mrCall).toContain('--source-branch feature/2-bar');
-    expect(mrCall).toContain('--target-branch main');
-    const parsed = JSON.parse((result.content[0] as { type: string; text: string }).text);
-    expect(parsed.ok).toBe(true);
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(true);
+    expect(data.number).toBe(12);
+
+    const call = execCalls.find((c) => unquote(c).includes('glab mr create')) ?? '';
+    expect(call).toContain("'--source-branch' 'feature/2-bar'");
+    expect(call).toContain("'--target-branch' 'main'");
   });
 
-  // ---- merges_type_label --------------------------------------------------
-  test('merges_type_label — automatic type::* label merged with caller labels', async () => {
-    setOriginUrl('https://github.com/org/repo.git');
-    await handler.execute({ type: 'epic', title: 'Big epic', labels: ['priority::high'] });
-    const calls = mockExecSync.mock.calls.map(c => c[0] as string);
-    const createCall = calls.find(c => c.includes('gh issue create'));
-    expect(createCall).toBeDefined();
-    expect(createCall).toContain('type::epic');
-    expect(createCall).toContain('priority::high');
-  });
+  // ---- error surface ----
 
-  test('merges_type_label — pr type gets no automatic type label', async () => {
-    setOriginUrl('https://github.com/org/repo.git');
-    execMockFn = (cmd: string) => {
-      if (cmd.startsWith('git remote get-url')) return 'https://github.com/org/repo.git\n';
-      return 'https://github.com/org/repo/pull/5\n';
-    };
-    await handler.execute({ type: 'pr', title: 'Patch', labels: ['size::S'] });
-    const calls = mockExecSync.mock.calls.map(c => c[0] as string);
-    const prCall = calls.find(c => c.includes('gh pr create'));
-    expect(prCall).toBeDefined();
-    expect(prCall).not.toContain('type::pr');
-    expect(prCall).toContain('size::S');
-  });
+  test('github — returns ok:false on subprocess failure', async () => {
+    onExec('git remote get-url origin', 'https://github.com/org/repo.git');
+    onExec('gh issue create', () => {
+      const err: MockExecError = new Error('gh not authenticated') as MockExecError;
+      err.stderr = 'gh: not authenticated';
+      err.status = 1;
+      throw err;
+    });
 
-  // ---- pr_fields_ignored_for_issue ----------------------------------------
-  test('pr_fields_ignored_for_issue — head_branch not passed to issue create', async () => {
-    setOriginUrl('https://github.com/org/repo.git');
-    await handler.execute({ type: 'chore', title: 'Cleanup', head_branch: 'feature/9-foo' });
-    const calls = mockExecSync.mock.calls.map(c => c[0] as string);
-    const createCall = calls.find(c => c.includes('gh issue create'));
-    expect(createCall).toBeDefined();
-    expect(createCall).not.toContain('--head');
-    expect(createCall).not.toContain('feature/9-foo');
-  });
-
-  // ---- routes_gitlab_issue ------------------------------------------------
-  test('routes_gitlab_issue — GitLab issue types use glab issue create', async () => {
-    setGitlabOrigin();
-    const result = await handler.execute({ type: 'story', title: 'GL story', labels: ['team::alpha'] });
-    const calls = mockExecSync.mock.calls.map(c => c[0] as string);
-    const createCall = calls.find(c => c.includes('glab issue create'));
-    expect(createCall).toBeDefined();
-    expect(createCall).toContain('GL story');
-    expect(createCall).toContain('type::story');
-    const parsed = JSON.parse((result.content[0] as { type: string; text: string }).text);
-    expect(parsed.ok).toBe(true);
-  });
-
-  // ---- error handling -----------------------------------------------------
-  test('returns ok:false on exec failure', async () => {
-    execMockFn = (cmd: string) => {
-      if (cmd.startsWith('git remote get-url')) return 'https://github.com/org/repo.git\n';
-      throw new Error('gh: command not found');
-    };
     const result = await handler.execute({ type: 'bug', title: 'Boom' });
-    const parsed = JSON.parse((result.content[0] as { type: string; text: string }).text);
-    expect(parsed.ok).toBe(false);
-    expect(parsed.error).toContain('gh: command not found');
-  });
-
-  // ---- body written to temp file ------------------------------------------
-  test('writes body to temp file before exec', async () => {
-    setOriginUrl('https://github.com/org/repo.git');
-    await handler.execute({ type: 'docs', title: 'Update readme', body: 'Some body text' });
-    expect(mockWriteFileSync.mock.calls.length).toBeGreaterThan(0);
-    const writtenPath = mockWriteFileSync.mock.calls[0][0] as string;
-    const writtenBody = mockWriteFileSync.mock.calls[0][1] as string;
-    expect(writtenPath).toMatch(/^\/tmp\/wi-body-\d+\.md$/);
-    expect(writtenBody).toBe('Some body text');
+    const data = parseResult(result.content);
+    expect(data.ok).toBe(false);
+    expect(String(data.error)).toContain('gh issue create failed');
   });
 });


### PR DESCRIPTION
## Summary

Migrate `work_item` handler to the platform adapter pattern. Handler becomes a thin 59-line dispatcher (no `platform ===`, no `execSync`); adapters return a typed `{platform_unsupported:true, hint}` for cross-platform requests (e.g. `type:'mr'` on GitHub).

Also closes #281 — cross-platform asymmetry now blocks at the adapter boundary, and subprocess-stub tests assert NO CLI call to the wrong platform.

## Changes

- Rewrite `handlers/work_item.ts` as thin adapter dispatcher (59 lines)
- Add `workItem` to `PlatformAdapter` interface with typed `WorkItemArgs` / `WorkItemResponse` / `WorkItemType`
- New `lib/adapters/work-item-github.ts` and `work-item-gitlab.ts`
- New subprocess-boundary tests on both adapters (argv-strictness + wrong-platform guard)
- Rewrite `tests/work_item.test.ts` for adapter dispatch; add #281 regressions
- Remove `work_item.ts` from `scripts/ci/migration-allowlist.txt`
- Add `workItem` to `MIGRATED_METHODS`

## Linked Issues

Closes #311
Closes #281

## Test Plan

- ./scripts/ci/validate.sh — clean (tsc, gate-greps across 57 non-allowlisted handlers, shellcheck, 1803 tests pass, 73-tool smoke)
- Focused: bun test lib/adapters/work-item-github.test.ts lib/adapters/work-item-gitlab.test.ts tests/work_item.test.ts lib/adapters/types.test.ts — 82/82 pass
- #281 regression: work_item({type:'pr'}) on GitLab → platform_unsupported:true with hint; zero execCalls. Mirror for type:'mr' on GitHub.