### PR TITLE
refactor(spec_get): migrate to platform adapter (#296)

### DIFF
--- a/handlers/spec_get.ts
+++ b/handlers/spec_get.ts
@@ -1,52 +1,25 @@
-import { execSync } from 'child_process';
+// Spec-family handler — adapter-dispatching shell.
+// Subprocess + platform branching live in lib/adapters/fetch-issue-{github,gitlab}.ts
+// (Story 2.1, #295); this handler consumes the normalized `AdapterIssue` shape
+// via `getAdapter().fetchIssue(...)`. Markdown section-parsing (`parseSections`)
+// stays here — it's platform-agnostic.
+
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
 import { parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
-import { detectPlatformForRef } from '../lib/shared/detect-platform.js';
-import { gitlabApiIssue } from '../lib/glab.js';
+import { getAdapter } from '../lib/adapters/index.js';
 
 const inputSchema = z.object({
   issue_ref: z.string().min(1, 'issue_ref must be a non-empty string'),
 });
 
-interface IssueInfo {
-  number: number;
-  title: string;
-  body: string;
-  state: string;
-  labels: string[];
+function envelope(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] };
 }
 
-function fetchGithub(ref: IssueRef): IssueInfo {
-  const repoArg = ref.owner && ref.repo ? `--repo ${ref.owner}/${ref.repo}` : '';
-  const cmd = `gh issue view ${ref.number} ${repoArg} --json number,title,body,state,labels`.trim();
-  const raw = execSync(cmd, { encoding: 'utf8' });
-  const parsed = JSON.parse(raw) as {
-    number: number;
-    title: string;
-    body: string;
-    state: string;
-    labels: Array<{ name: string }>;
-  };
-  return {
-    number: parsed.number,
-    title: parsed.title,
-    body: parsed.body ?? '',
-    state: parsed.state.toUpperCase(),
-    labels: (parsed.labels ?? []).map(l => l.name),
-  };
-}
-
-function fetchGitlab(ref: IssueRef): IssueInfo {
-  const parsed = gitlabApiIssue(ref.number, ref.owner && ref.repo ? { owner: ref.owner, repo: ref.repo } : undefined);
-  const state = parsed.state === 'opened' ? 'OPEN' : parsed.state.toUpperCase();
-  return {
-    number: parsed.iid,
-    title: parsed.title,
-    body: parsed.description ?? '',
-    state,
-    labels: parsed.labels,
-  };
+function repoSlug(ref: IssueRef): string | undefined {
+  if (ref.owner && ref.repo) return `${ref.owner}/${ref.repo}`;
+  return undefined;
 }
 
 const specGetHandler: HandlerDef = {
@@ -58,55 +31,35 @@ const specGetHandler: HandlerDef = {
     try {
       args = inputSchema.parse(rawArgs);
     } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
 
     const ref = parseIssueRef(args.issue_ref);
     if (!ref) {
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({
-              ok: false,
-              error: `could not parse issue_ref: '${args.issue_ref}' (expected #N or org/repo#N)`,
-            }),
-          },
-        ],
-      };
+      return envelope({
+        ok: false,
+        error: `could not parse issue_ref: '${args.issue_ref}' (expected #N or org/repo#N)`,
+      });
     }
 
-    try {
-      const platform = detectPlatformForRef(ref);
-      const info = platform === 'github' ? fetchGithub(ref) : fetchGitlab(ref);
-      const { sections, order } = parseSections(info.body);
+    const repo = repoSlug(ref);
+    const result = await getAdapter({ repo }).fetchIssue({ number: ref.number, repo });
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({
-              ok: true,
-              number: info.number,
-              title: info.title,
-              state: info.state,
-              labels: info.labels,
-              body: info.body,
-              sections,
-              section_order: order,
-            }),
-          },
-        ],
-      };
-    } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
-    }
+    if ('platform_unsupported' in result) return envelope({ ok: false, error: result.hint });
+    if (!result.ok) return envelope({ ok: false, error: result.error });
+
+    const info = result.data;
+    const { sections, order } = parseSections(info.body);
+    return envelope({
+      ok: true,
+      number: info.number,
+      title: info.title,
+      state: info.state,
+      labels: info.labels,
+      body: info.body,
+      sections,
+      section_order: order,
+    });
   },
 };
 

--- a/scripts/ci/migration-allowlist.txt
+++ b/scripts/ci/migration-allowlist.txt
@@ -15,7 +15,6 @@ epic_sub_issues.ts
 ibm.ts
 spec_acceptance_criteria.ts
 spec_dependencies.ts
-spec_get.ts
 spec_validate_structure.ts
 wave_ci_trust_level.ts
 wave_compute.ts


### PR DESCRIPTION
## Summary
Migrates `spec_get` handler to use the platform adapter `fetchIssue` sub-call, removing local platform-dispatch helpers and direct subprocess calls.

## Changes
- `handlers/spec_get.ts`: 113 → 66 lines. Removed local `fetchGithub`/`fetchGitlab` helpers (spec called this `fetchBody`; actual naming was split). Replaced inline dispatch with `getAdapter({ repo }).fetchIssue({ number, repo })`. Now consumes normalized `AdapterIssue` shape directly.
- `scripts/ci/migration-allowlist.txt`: removed `spec_get.ts` — gate-greps now enforce R-09/R-10 against it.
- `tests/spec_get.test.ts`: unchanged; existing `mock.module('child_process', ...)` continues to intercept the adapter's `execSync`.

## Linked Issues
Closes #296

## Test Plan
- `./scripts/ci/validate.sh`: exit 0 (codegen, lint, gate-greps, shellcheck, tests, smoke all green)
- `bun test tests/spec_get.test.ts`: 9/9 pass
- Full suite: 1803 pass, 0 fail
