### PR TITLE
refactor(spec_validate_structure): migrate to platform adapter (#297)

### DIFF
--- a/handlers/spec_validate_structure.ts
+++ b/handlers/spec_validate_structure.ts
@@ -1,41 +1,29 @@
-import { execSync } from 'child_process';
+// Adapter-dispatching shell — subprocess + platform branching live in
+// lib/adapters/fetch-issue-{github,gitlab}.ts (Story 2.1, #295). H2-section
+// validation + bold-label dependencies fallback is platform-agnostic and stays
+// here. See docs/issue-body-grammar.md.
+
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
 import { findBoldLabelDependencies, parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
-import { detectPlatform } from '../lib/shared/detect-platform.js';
-import { gitlabApiIssue } from '../lib/glab.js';
+import { getAdapter } from '../lib/adapters/index.js';
 
-const inputSchema = z.object({
-  issue_ref: z.string().min(1, 'issue_ref must be a non-empty string'),
-});
+const inputSchema = z.object({ issue_ref: z.string().min(1, 'issue_ref must be a non-empty string') });
 
-// Canonical section keys → accepted H2 heading aliases (after normalizeHeading).
-// `## Changes` or `## Implementation Steps` both satisfy the `changes` requirement;
-// `## Tests` or `## Test Procedures` both satisfy `tests`. See docs/issue-body-grammar.md.
-const REQUIRED_SECTION_ALIASES: Record<string, readonly string[]> = {
+// Canonical key → accepted H2 heading aliases (after normalizeHeading).
+const REQUIRED: Record<string, readonly string[]> = {
   changes: ['changes', 'implementation_steps'],
   tests: ['tests', 'test_procedures'],
   acceptance_criteria: ['acceptance_criteria'],
 };
-const OPTIONAL_SECTION_ALIASES: Record<string, readonly string[]> = {
-  dependencies: ['dependencies'],
-};
+const OPTIONAL: Record<string, readonly string[]> = { dependencies: ['dependencies'] };
 
-function acceptedHeadings(aliases: readonly string[]): string[] {
-  return aliases.map((a) => `## ${a.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}`);
-}
-
-function fetchBody(ref: IssueRef): string {
-  const platform = detectPlatform();
-  if (platform === 'github') {
-    const repoArg = ref.owner && ref.repo ? `--repo ${ref.owner}/${ref.repo}` : '';
-    const cmd = `gh issue view ${ref.number} ${repoArg} --json body`.trim();
-    const raw = execSync(cmd, { encoding: 'utf8' });
-    return (JSON.parse(raw) as { body: string }).body ?? '';
-  }
-  const result = gitlabApiIssue(ref.number, ref.owner && ref.repo ? { owner: ref.owner, repo: ref.repo } : undefined);
-  return result.description ?? '';
-}
+const acceptedHeadings = (aliases: readonly string[]) =>
+  aliases.map((a) => `## ${a.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}`);
+const envelope = (payload: unknown) => ({ content: [{ type: 'text' as const, text: JSON.stringify(payload) }] });
+const repoSlug = (ref: IssueRef) => (ref.owner && ref.repo ? `${ref.owner}/${ref.repo}` : undefined);
+const hasSection = (sections: Record<string, string>, aliases: readonly string[]) =>
+  aliases.some((a) => sections[a] && sections[a].trim().length > 0);
 
 const specValidateStructureHandler: HandlerDef = {
   name: 'spec_validate_structure',
@@ -47,80 +35,41 @@ const specValidateStructureHandler: HandlerDef = {
     try {
       args = inputSchema.parse(rawArgs);
     } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
-
     const ref = parseIssueRef(args.issue_ref);
-    if (!ref) {
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({
-              ok: false,
-              error: `could not parse issue_ref: '${args.issue_ref}'`,
-            }),
-          },
-        ],
-      };
+    if (!ref) return envelope({ ok: false, error: `could not parse issue_ref: '${args.issue_ref}'` });
+
+    const repo = repoSlug(ref);
+    const result = await getAdapter({ repo }).fetchIssue({ number: ref.number, repo });
+    if ('platform_unsupported' in result) return envelope({ ok: false, error: result.hint });
+    if (!result.ok) return envelope({ ok: false, error: result.error });
+
+    const { sections } = parseSections(result.data.body);
+    const presence: Record<string, boolean> = {};
+    const missing: string[] = [];
+    const acceptedHint: Record<string, string[]> = {};
+    for (const [k, aliases] of Object.entries(REQUIRED)) {
+      const has = hasSection(sections, aliases);
+      presence[`has_${k}`] = has;
+      if (!has) {
+        missing.push(k);
+        acceptedHint[k] = acceptedHeadings(aliases);
+      }
     }
+    for (const [k, aliases] of Object.entries(OPTIONAL)) presence[`has_${k}`] = hasSection(sections, aliases);
+    // Bold-label fallback for has_dependencies only (parity with spec_dependencies).
+    if (!presence.has_dependencies && findBoldLabelDependencies(sections)) presence.has_dependencies = true;
 
-    try {
-      const body = fetchBody(ref);
-      const { sections } = parseSections(body);
-
-      const presence: Record<string, boolean> = {};
-      const missing: string[] = [];
-      const acceptedHeadingsHint: Record<string, string[]> = {};
-      for (const [canonical, aliases] of Object.entries(REQUIRED_SECTION_ALIASES)) {
-        const has = aliases.some(
-          (alias) => sections[alias] && sections[alias].trim().length > 0,
-        );
-        presence[`has_${canonical}`] = has;
-        if (!has) {
-          missing.push(canonical);
-          acceptedHeadingsHint[canonical] = acceptedHeadings(aliases);
-        }
-      }
-      for (const [canonical, aliases] of Object.entries(OPTIONAL_SECTION_ALIASES)) {
-        presence[`has_${canonical}`] = aliases.some(
-          (alias) => sections[alias] && sections[alias].trim().length > 0,
-        );
-      }
-      // Bold-label fallback for `has_dependencies` only (mirrors
-      // spec_dependencies' fallback). Stories that embed deps as
-      // `**Dependencies:** #5, #6` inside ## Metadata count as declared.
-      // The narrow scope is deliberate — implementation/test sections must
-      // remain strict because they carry semantic content, not metadata.
-      // Truthiness check matches the idiom in spec_dependencies (the helper
-      // returns `''` when no label is present or its content is empty).
-      if (!presence.has_dependencies && findBoldLabelDependencies(sections)) {
-        presence.has_dependencies = true;
-      }
-
-      const response: Record<string, unknown> = {
-        ok: true,
-        issue_ref: args.issue_ref,
-        ...presence,
-        missing_sections: missing,
-        valid: missing.length === 0,
-      };
-      if (missing.length > 0) {
-        response.accepted_headings = acceptedHeadingsHint;
-      }
-
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify(response) }],
-      };
-    } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
-    }
+    const response: Record<string, unknown> = {
+      ok: true,
+      issue_ref: args.issue_ref,
+      ...presence,
+      missing_sections: missing,
+      valid: missing.length === 0,
+    };
+    if (missing.length > 0) response.accepted_headings = acceptedHint;
+    return envelope(response);
   },
 };
 

--- a/scripts/ci/migration-allowlist.txt
+++ b/scripts/ci/migration-allowlist.txt
@@ -15,7 +15,6 @@ epic_sub_issues.ts
 ibm.ts
 spec_acceptance_criteria.ts
 spec_dependencies.ts
-spec_validate_structure.ts
 wave_ci_trust_level.ts
 wave_compute.ts
 wave_dependency_graph.ts


### PR DESCRIPTION
## Summary
Migrate `spec_validate_structure` handler to the platform adapter pattern (`getAdapter({repo}).fetchIssue(...)`), deleting handler-local `fetchBody`, inline `detectPlatform`, direct `execSync('gh …')` calls, and GitLab API branching. Compacts the handler to 76 lines and removes it from the migration allowlist so gate-greps enforce R-09/R-10.

## Changes
- `handlers/spec_validate_structure.ts`: adapter-based `fetchIssue`; platform branching removed; 76 lines (≤80 AC target); validation logic (alias bookkeeping, `findBoldLabelDependencies` fallback) preserved verbatim
- `scripts/ci/migration-allowlist.txt`: `spec_validate_structure.ts` removed
- `tests/spec_validate_structure.test.ts`: unchanged per [R-11]; existing `child_process` mock still a valid external boundary — adapter shells `gh issue view` via `execSync`

## Linked Issues
Closes #297

## Test Plan
- `./scripts/ci/validate.sh` — exit 0 (73/73 per-tool assertions)
- `./scripts/ci/gate-greps.sh` — OK (59 non-allowlisted handlers; `spec_validate_structure.ts` now in scope)
- `bun test` — 1803 pass / 0 fail across 122 files