### PR TITLE
refactor(spec_dependencies): migrate to platform adapter (#299)

### DIFF
--- a/handlers/spec_dependencies.ts
+++ b/handlers/spec_dependencies.ts
@@ -1,89 +1,31 @@
-import { execSync } from 'child_process';
+// Spec-family handler — adapter-dispatching shell. Subprocess + platform
+// branching live in lib/adapters/fetch-issue-{github,gitlab}.ts (Story 2.1,
+// #295). Section + bold-label parsing stays handler-side via lib/spec_parser
+// (platform-agnostic).
+
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { findBoldLabelDependencies, parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
-import { detectPlatformForRef } from '../lib/shared/detect-platform.js';
+import {
+  findBoldLabelDependencies,
+  parseDependenciesSection,
+  parseIssueRef,
+  parseSections,
+  type IssueRef,
+} from '../lib/spec_parser';
 import { parseRepoSlug } from '../lib/shared/parse-repo-slug.js';
-import { gitlabApiIssue } from '../lib/glab.js';
+import { getAdapter } from '../lib/adapters/index.js';
 
 const inputSchema = z.object({
   issue_ref: z.string().min(1, 'issue_ref must be a non-empty string'),
 });
 
-interface Dependency {
-  ref: string;
-  kind: 'blocks' | 'none';
+function envelope(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] };
 }
 
-function fetchBody(ref: IssueRef): string {
-  const platform = detectPlatformForRef(ref);
-  if (platform === 'github') {
-    const repoArg = ref.owner && ref.repo ? `--repo ${ref.owner}/${ref.repo}` : '';
-    const cmd = `gh issue view ${ref.number} ${repoArg} --json body`.trim();
-    const raw = execSync(cmd, { encoding: 'utf8' });
-    return (JSON.parse(raw) as { body: string }).body ?? '';
-  }
-  const result = gitlabApiIssue(ref.number, ref.owner && ref.repo ? { owner: ref.owner, repo: ref.repo } : undefined);
-  return result.description ?? '';
+function repoSlug(ref: IssueRef): string | undefined {
+  return ref.owner && ref.repo ? `${ref.owner}/${ref.repo}` : undefined;
 }
-
-/**
- * Parse a Dependencies section and extract issue references in any
- * of these formats:
- *   #123
- *   org/repo#123
- *   https://github.com/org/repo/issues/123
- *   https://gitlab.com/org/repo/-/issues/123
- *
- * Normalized to `org/repo#N`. If a `#N` ref is seen, use the current
- * repo slug. "None" or empty content returns an empty list.
- */
-function parseDependenciesSection(section: string, currentSlug: string | null): Dependency[] {
-  if (!section) return [];
-  const trimmed = section.trim();
-  if (/^none\b/i.test(trimmed) || trimmed.length === 0) return [];
-
-  const found = new Set<string>();
-  const deps: Dependency[] = [];
-
-  const urlRe =
-    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/g;
-  let m: RegExpExecArray | null;
-  while ((m = urlRe.exec(section)) !== null) {
-    const ref = `${m[1]}/${m[2]}#${m[3]}`;
-    if (!found.has(ref)) {
-      found.add(ref);
-      deps.push({ ref, kind: 'blocks' });
-    }
-  }
-
-  const crossRe = /\b([^\s/#]+)\/([^\s/#]+)#(\d+)\b/g;
-  while ((m = crossRe.exec(section)) !== null) {
-    // Skip if this text is inside a URL we already consumed.
-    const candidate = `${m[1]}/${m[2]}#${m[3]}`;
-    if (m[1].startsWith('http') || m[1].includes('.')) continue;
-    if (!found.has(candidate)) {
-      found.add(candidate);
-      deps.push({ ref: candidate, kind: 'blocks' });
-    }
-  }
-
-  // Short #N — only match at word boundary not preceded by a /.
-  const shortRe = /(?<![/\w])#(\d+)\b/g;
-  while ((m = shortRe.exec(section)) !== null) {
-    const num = m[1];
-    const ref = currentSlug ? `${currentSlug}#${num}` : `#${num}`;
-    if (!found.has(ref)) {
-      found.add(ref);
-      deps.push({ ref, kind: 'blocks' });
-    }
-  }
-
-  return deps;
-}
-
-// findBoldLabelDependencies lives in lib/spec_parser so spec_validate_structure
-// can apply the same fallback rule. See SUB_ISSUE_SECTION_KEYS / lib comment.
 
 const specDependenciesHandler: HandlerDef = {
   name: 'spec_dependencies',
@@ -95,68 +37,41 @@ const specDependenciesHandler: HandlerDef = {
     try {
       args = inputSchema.parse(rawArgs);
     } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
 
     const ref = parseIssueRef(args.issue_ref);
     if (!ref) {
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({
-              ok: false,
-              error: `could not parse issue_ref: '${args.issue_ref}'`,
-            }),
-          },
-        ],
-      };
+      return envelope({ ok: false, error: `could not parse issue_ref: '${args.issue_ref}'` });
     }
 
-    try {
-      const body = fetchBody(ref);
-      const { sections } = parseSections(body);
-      let depsSection = sections.dependencies ?? '';
-      let source: 'dependencies_section' | 'bold_label_fallback' | 'none' =
-        depsSection.trim() ? 'dependencies_section' : 'none';
-      if (!depsSection.trim()) {
-        const fallback = findBoldLabelDependencies(sections);
-        if (fallback) {
-          depsSection = fallback;
-          source = 'bold_label_fallback';
-        }
-      }
-      const deps = parseDependenciesSection(depsSection, parseRepoSlug());
-      // If the fallback yielded text but no refs, the bold label didn't
-      // actually provide dependency data — report source as 'none' rather
-      // than misleading the caller about where (non-existent) refs came from.
-      if (source === 'bold_label_fallback' && deps.length === 0) {
-        source = 'none';
-      }
+    const repo = repoSlug(ref);
+    const result = await getAdapter({ repo }).fetchIssue({ number: ref.number, repo });
+    if ('platform_unsupported' in result) return envelope({ ok: false, error: result.hint });
+    if (!result.ok) return envelope({ ok: false, error: result.error });
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({
-              ok: true,
-              issue_ref: args.issue_ref,
-              dependencies: deps,
-              count: deps.length,
-              source,
-            }),
-          },
-        ],
-      };
-    } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+    const { sections } = parseSections(result.data.body);
+    let depsSection = sections.dependencies ?? '';
+    let source: 'dependencies_section' | 'bold_label_fallback' | 'none' =
+      depsSection.trim() ? 'dependencies_section' : 'none';
+    if (!depsSection.trim()) {
+      const fallback = findBoldLabelDependencies(sections);
+      if (fallback) {
+        depsSection = fallback;
+        source = 'bold_label_fallback';
+      }
     }
+    const deps = parseDependenciesSection(depsSection, parseRepoSlug());
+    // Fallback yielded text but no refs → revert source to 'none'.
+    if (source === 'bold_label_fallback' && deps.length === 0) source = 'none';
+
+    return envelope({
+      ok: true,
+      issue_ref: args.issue_ref,
+      dependencies: deps,
+      count: deps.length,
+      source,
+    });
   },
 };
 

--- a/lib/spec_parser.ts
+++ b/lib/spec_parser.ts
@@ -166,3 +166,74 @@ export function findBoldLabelDependencies(sections: Record<string, string>): str
   }
   return '';
 }
+
+/**
+ * A single parsed dependency ref extracted from a `## Dependencies` section
+ * or `**Dependencies:**` bold-label body. `kind` currently only carries the
+ * `blocks` relation — placeholder for future expansion.
+ */
+export interface Dependency {
+  ref: string;
+  kind: 'blocks' | 'none';
+}
+
+/**
+ * Parse a Dependencies section and extract issue references in any of these
+ * formats:
+ *
+ *   #123
+ *   org/repo#123
+ *   https://github.com/org/repo/issues/123
+ *   https://gitlab.com/org/repo/-/issues/123
+ *
+ * Normalized to `org/repo#N`. If a `#N` ref is seen, use `currentSlug` as the
+ * owning repo. "None" or empty content returns an empty list.
+ *
+ * Lives in `lib/` (not the handler) because `spec_dependencies` is
+ * platform-agnostic after the Story 2.5 adapter migration — the parser is
+ * shared-module material, same as `findBoldLabelDependencies`.
+ */
+export function parseDependenciesSection(
+  section: string,
+  currentSlug: string | null,
+): Dependency[] {
+  if (!section) return [];
+  const trimmed = section.trim();
+  if (/^none\b/i.test(trimmed) || trimmed.length === 0) return [];
+
+  const found = new Set<string>();
+  const deps: Dependency[] = [];
+
+  const urlRe =
+    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = urlRe.exec(section)) !== null) {
+    const ref = `${m[1]}/${m[2]}#${m[3]}`;
+    if (!found.has(ref)) {
+      found.add(ref);
+      deps.push({ ref, kind: 'blocks' });
+    }
+  }
+
+  const crossRe = /\b([^\s/#]+)\/([^\s/#]+)#(\d+)\b/g;
+  while ((m = crossRe.exec(section)) !== null) {
+    const candidate = `${m[1]}/${m[2]}#${m[3]}`;
+    if (m[1].startsWith('http') || m[1].includes('.')) continue;
+    if (!found.has(candidate)) {
+      found.add(candidate);
+      deps.push({ ref: candidate, kind: 'blocks' });
+    }
+  }
+
+  const shortRe = /(?<![/\w])#(\d+)\b/g;
+  while ((m = shortRe.exec(section)) !== null) {
+    const num = m[1];
+    const ref = currentSlug ? `${currentSlug}#${num}` : `#${num}`;
+    if (!found.has(ref)) {
+      found.add(ref);
+      deps.push({ ref, kind: 'blocks' });
+    }
+  }
+
+  return deps;
+}

--- a/scripts/ci/migration-allowlist.txt
+++ b/scripts/ci/migration-allowlist.txt
@@ -13,7 +13,6 @@ ci_wait_run.ts
 dod_load_manifest.ts
 epic_sub_issues.ts
 ibm.ts
-spec_dependencies.ts
 wave_ci_trust_level.ts
 wave_compute.ts
 wave_dependency_graph.ts


### PR DESCRIPTION
## Summary
Migrate `handlers/spec_dependencies.ts` from direct `execSync('gh issue view ...')` + `gitlabApiIssue(...)` platform branching to `getAdapter({repo}).fetchIssue(...)`. Handler now platform-agnostic and ≤80 lines.

## Changes
- `handlers/spec_dependencies.ts` — 163 → 78 lines; adapter dispatch; no subprocess, no platform branching.
- `lib/spec_parser.ts` — added `parseDependenciesSection(section, currentSlug)` + `Dependency` interface (previously handler-local).
- `scripts/ci/migration-allowlist.txt` — removed `spec_dependencies.ts`.

## Linked Issues
Closes #299

## Test Plan
- `./scripts/ci/validate.sh` → exit 0, `gate-greps: OK` over 61 non-allowlisted handlers; 73/73 per-tool assertions pass.
- `bun test tests/spec_dependencies.test.ts` → 17 pass / 0 fail.
- `bun test` → 1803 pass / 0 fail across 122 files.