### PR TITLE
refactor(epic_sub_issues): migrate to platform adapter (#300)

### DIFF
--- a/handlers/epic_sub_issues.ts
+++ b/handlers/epic_sub_issues.ts
@@ -1,123 +1,25 @@
-import { execSync } from 'child_process';
+// Epic-family handler — adapter-dispatching shell. Subprocess + platform
+// branching live in lib/adapters/fetch-issue-{github,gitlab}.ts (Story 2.1,
+// #295); markdown parsers live in lib/epic-sub-issues-parser.ts (Story 2.6,
+// #300). This handler is dispatch + envelope only.
+
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
 import { SUB_ISSUE_SECTION_KEYS, findSubIssueSection, parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
-import { detectPlatform } from '../lib/shared/detect-platform.js';
 import { parseRepoSlug } from '../lib/shared/parse-repo-slug.js';
-import { gitlabApiIssue } from '../lib/glab.js';
+import { getAdapter } from '../lib/adapters/index.js';
+import { parseChecklistOrBullets, parseTableRows } from '../lib/epic-sub-issues-parser.js';
 
 const inputSchema = z.object({
   epic_ref: z.string().min(1, 'epic_ref must be a non-empty string'),
 });
 
-interface SubIssue {
-  ref: string;
-  title?: string;
-  order?: number;
+function envelope(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] };
 }
 
-function fetchBody(ref: IssueRef): string {
-  const platform = detectPlatform();
-  if (platform === 'github') {
-    const repoArg = ref.owner && ref.repo ? `--repo ${ref.owner}/${ref.repo}` : '';
-    const cmd = `gh issue view ${ref.number} ${repoArg} --json body`.trim();
-    const raw = execSync(cmd, { encoding: 'utf8' });
-    return (JSON.parse(raw) as { body: string }).body ?? '';
-  }
-  const result = gitlabApiIssue(ref.number, ref.owner && ref.repo ? { owner: ref.owner, repo: ref.repo } : undefined);
-  return result.description ?? '';
-}
-
-function normalizeRef(ref: string, currentSlug: string | null): string {
-  // URL
-  const urlM =
-    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/.exec(
-      ref,
-    );
-  if (urlM) return `${urlM[1]}/${urlM[2]}#${urlM[3]}`;
-
-  const crossM = /^([^/\s#]+)\/([^/\s#]+)#(\d+)$/.exec(ref);
-  if (crossM) return ref;
-
-  const shortM = /^#?(\d+)$/.exec(ref);
-  if (shortM) {
-    return currentSlug ? `${currentSlug}#${shortM[1]}` : `#${shortM[1]}`;
-  }
-  return ref;
-}
-
-// Section-name aliases live in lib/spec_parser so wave_compute and
-// epic_sub_issues stay in lock-step. See SUB_ISSUE_SECTION_KEYS for the
-// canonical list and rationale.
-
-function parseTableRows(section: string, currentSlug: string | null): SubIssue[] {
-  const lines = section.split('\n').map(l => l.trim());
-  const subs: SubIssue[] = [];
-  let headerIdx = -1;
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].startsWith('|') && lines[i].includes('|', 1)) {
-      headerIdx = i;
-      break;
-    }
-  }
-  if (headerIdx === -1) return [];
-  const headerCells = lines[headerIdx]
-    .split('|')
-    .slice(1, -1)
-    .map(c => c.trim().toLowerCase());
-  const colIdx = (name: string) => headerCells.findIndex(c => c.includes(name));
-  const orderCol = colIdx('order');
-  const issueCol = colIdx('issue');
-  const titleCol = colIdx('title');
-
-  let startRow = headerIdx + 1;
-  if (startRow < lines.length && /^\|[\s\-:|]+\|$/.test(lines[startRow])) startRow += 1;
-
-  for (let i = startRow; i < lines.length; i++) {
-    const line = lines[i];
-    if (!line.startsWith('|')) break;
-    const cells = line.split('|').slice(1, -1).map(c => c.trim());
-    const getCell = (idx: number) => (idx >= 0 && idx < cells.length ? cells[idx] : '');
-    const issueRaw = getCell(issueCol);
-    const refM = /#?(\d+)|([^/\s#]+)\/([^/\s#]+)#(\d+)/.exec(issueRaw);
-    if (!refM) continue;
-    const ref = normalizeRef(issueRaw, currentSlug);
-    const order = orderCol >= 0 ? parseInt(getCell(orderCol), 10) : undefined;
-    const title = titleCol >= 0 ? getCell(titleCol) : undefined;
-    subs.push({
-      ref,
-      title: title && title.length > 0 ? title : undefined,
-      order: Number.isFinite(order) ? (order as number) : undefined,
-    });
-  }
-  return subs;
-}
-
-function parseChecklistOrBullets(section: string, currentSlug: string | null): SubIssue[] {
-  const subs: SubIssue[] = [];
-  const checklistRe = /^\s*[-*]\s*(?:\[[ xX]\]\s*)?([^\n]*)$/gm;
-  let m: RegExpExecArray | null;
-  let position = 1;
-  while ((m = checklistRe.exec(section)) !== null) {
-    const text = m[1].trim();
-    if (!text) continue;
-    const refM =
-      /(?:^|\s)([^/\s#]+\/[^/\s#]+#\d+|https?:\/\/\S+\/issues\/\d+|#\d+)/.exec(text);
-    if (!refM) continue;
-    const raw = refM[1];
-    const ref = normalizeRef(raw, currentSlug);
-    // Title = text with the ref token stripped out. Also strip leading
-    // list/separator punctuation including em/en dashes commonly used in
-    // `- #NN — Title` style bullets.
-    const title = text.replace(refM[0], '').trim().replace(/^[-:*\s—–]+/, '').trim();
-    subs.push({
-      ref,
-      title: title.length > 0 ? title : undefined,
-      order: position,
-    });
-    position += 1;
-  }
-  return subs;
+function repoSlug(ref: IssueRef): string | undefined {
+  return ref.owner && ref.repo ? `${ref.owner}/${ref.repo}` : undefined;
 }
 
 const epicSubIssuesHandler: HandlerDef = {
@@ -130,79 +32,46 @@ const epicSubIssuesHandler: HandlerDef = {
     try {
       args = inputSchema.parse(rawArgs);
     } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
 
     const ref = parseIssueRef(args.epic_ref);
     if (!ref) {
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({
-              ok: false,
-              error: `could not parse epic_ref: '${args.epic_ref}'`,
-            }),
-          },
-        ],
-      };
+      return envelope({ ok: false, error: `could not parse epic_ref: '${args.epic_ref}'` });
     }
 
-    try {
-      const body = fetchBody(ref);
-      const { sections } = parseSections(body);
-      const section = findSubIssueSection(sections);
-      if (!section) {
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                ok: true,
-                epic_ref: args.epic_ref,
-                sub_issues: [],
-                count: 0,
-                reason: 'no matching sub-issue section found in epic body',
-                accepted_sections: [...SUB_ISSUE_SECTION_KEYS],
-              }),
-            },
-          ],
-        };
-      }
+    const repo = repoSlug(ref);
+    const result = await getAdapter({ repo }).fetchIssue({ number: ref.number, repo });
+    if ('platform_unsupported' in result) return envelope({ ok: false, error: result.hint });
+    if (!result.ok) return envelope({ ok: false, error: result.error });
 
-      // Resolve bare `#N` refs in the epic body against the EPIC's repo, not
-      // the MCP process's cwd. Fall back to cwd's slug only when the epic_ref
-      // itself was bare (back-compat for same-repo invocations).
-      const epicSlug =
-        ref.owner && ref.repo ? `${ref.owner}/${ref.repo}` : parseRepoSlug();
-      // Try table format first; if it yields nothing, fall back to checklist/bullets.
-      let subs = parseTableRows(section, epicSlug);
-      if (subs.length === 0) {
-        subs = parseChecklistOrBullets(section, epicSlug);
-      }
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({
-              ok: true,
-              epic_ref: args.epic_ref,
-              sub_issues: subs,
-              count: subs.length,
-            }),
-          },
-        ],
-      };
-    } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+    const { sections } = parseSections(result.data.body);
+    const section = findSubIssueSection(sections);
+    if (!section) {
+      return envelope({
+        ok: true,
+        epic_ref: args.epic_ref,
+        sub_issues: [],
+        count: 0,
+        reason: 'no matching sub-issue section found in epic body',
+        accepted_sections: [...SUB_ISSUE_SECTION_KEYS],
+      });
     }
+
+    // Resolve bare `#N` refs in the epic body against the EPIC's repo, not
+    // the MCP process's cwd. Fall back to cwd's slug only when the epic_ref
+    // itself was bare (back-compat for same-repo invocations).
+    const epicSlug = repo ?? parseRepoSlug();
+    // Try table format first; fall back to checklist/bullets if table yields nothing.
+    let subs = parseTableRows(section, epicSlug);
+    if (subs.length === 0) subs = parseChecklistOrBullets(section, epicSlug);
+
+    return envelope({
+      ok: true,
+      epic_ref: args.epic_ref,
+      sub_issues: subs,
+      count: subs.length,
+    });
   },
 };
 

--- a/lib/epic-sub-issues-parser.test.ts
+++ b/lib/epic-sub-issues-parser.test.ts
@@ -1,0 +1,165 @@
+import { describe, test, expect } from 'bun:test';
+
+// Pure-function tests for the parsers lifted from handlers/epic_sub_issues.ts
+// during Story 2.6 (#300). No mock.module needed — these parsers operate on
+// already-extracted section strings and never touch platform/subprocess code.
+
+import {
+  normalizeRef,
+  parseTableRows,
+  parseChecklistOrBullets,
+} from './epic-sub-issues-parser.ts';
+
+describe('epic-sub-issues-parser — ref normalization', () => {
+  test('github URL collapses to org/repo#N', () => {
+    expect(
+      normalizeRef('https://github.com/Wave-Engineering/mcp-server-sdlc/issues/42', null),
+    ).toBe('Wave-Engineering/mcp-server-sdlc#42');
+  });
+
+  test('gitlab URL (with /-/issues/) collapses to group/project#N', () => {
+    expect(
+      normalizeRef('https://gitlab.com/mygroup/myproject/-/issues/12', null),
+    ).toBe('mygroup/myproject#12');
+  });
+
+  test('already-qualified cross-repo ref passes through unchanged', () => {
+    expect(normalizeRef('acme/widgets#7', 'myorg/myrepo')).toBe('acme/widgets#7');
+  });
+
+  test('bare #N is qualified against currentSlug when provided', () => {
+    expect(normalizeRef('#5', 'myorg/myrepo')).toBe('myorg/myrepo#5');
+  });
+
+  test('bare N (no hash) is also qualified against currentSlug', () => {
+    expect(normalizeRef('5', 'myorg/myrepo')).toBe('myorg/myrepo#5');
+  });
+
+  test('bare #N stays bare when currentSlug is null', () => {
+    expect(normalizeRef('#5', null)).toBe('#5');
+  });
+
+  test('unparseable input is returned verbatim', () => {
+    expect(normalizeRef('not a ref', 'myorg/myrepo')).toBe('not a ref');
+  });
+});
+
+describe('epic-sub-issues-parser — table row extraction', () => {
+  test('extracts order/issue/title from a standard 3-column table', () => {
+    const section = `| Order | Issue | Title |
+|-------|-------|-------|
+| 1 | #5 | wave_init |
+| 2 | #6 | wave_preflight |
+`;
+    const rows = parseTableRows(section, 'myorg/myrepo');
+    expect(rows).toEqual([
+      { ref: 'myorg/myrepo#5', title: 'wave_init', order: 1 },
+      { ref: 'myorg/myrepo#6', title: 'wave_preflight', order: 2 },
+    ]);
+  });
+
+  test('preserves order values from the Order column (not row position)', () => {
+    const section = `| Order | Issue |
+|-------|-------|
+| 3 | #5 |
+| 1 | #6 |
+| 2 | #7 |
+`;
+    const rows = parseTableRows(section, 'myorg/myrepo');
+    expect(rows.map(r => r.order)).toEqual([3, 1, 2]);
+  });
+
+  test('cross-repo refs in table cells pass through verbatim', () => {
+    const section = `| Order | Issue | Title |
+|-------|-------|-------|
+| 1 | Wave-Engineering/other#42 | cross repo |
+`;
+    const rows = parseTableRows(section, 'myorg/myrepo');
+    expect(rows[0].ref).toBe('Wave-Engineering/other#42');
+  });
+
+  test('rows without a parseable ref are skipped', () => {
+    const section = `| Order | Issue | Title |
+|-------|-------|-------|
+| 1 | TBD | pending |
+| 2 | #7 | real |
+`;
+    const rows = parseTableRows(section, 'myorg/myrepo');
+    expect(rows).toEqual([
+      { ref: 'myorg/myrepo#7', title: 'real', order: 2 },
+    ]);
+  });
+
+  test('returns [] when the section has no pipe-delimited header', () => {
+    expect(parseTableRows('just prose, no table here', null)).toEqual([]);
+  });
+
+  test('title/order cells are optional — only issue column required', () => {
+    const section = `| Issue |
+|-------|
+| #9 |
+`;
+    const rows = parseTableRows(section, 'myorg/myrepo');
+    expect(rows).toEqual([{ ref: 'myorg/myrepo#9', title: undefined, order: undefined }]);
+  });
+});
+
+describe('epic-sub-issues-parser — checklist/bullet extraction', () => {
+  test('parses checklist items `- [ ] #N Title` and `- [x] #N Title`', () => {
+    const section = `- [ ] #5 wave_init
+- [x] #6 wave_preflight
+`;
+    const rows = parseChecklistOrBullets(section, 'myorg/myrepo');
+    expect(rows).toEqual([
+      { ref: 'myorg/myrepo#5', title: 'wave_init', order: 1 },
+      { ref: 'myorg/myrepo#6', title: 'wave_preflight', order: 2 },
+    ]);
+  });
+
+  test('parses plain bullet items `- #N Title`', () => {
+    const section = `- #5 wave_init
+- #6 wave_preflight
+`;
+    const rows = parseChecklistOrBullets(section, 'myorg/myrepo');
+    expect(rows[0]).toEqual({ ref: 'myorg/myrepo#5', title: 'wave_init', order: 1 });
+    expect(rows[1].order).toBe(2);
+  });
+
+  test('strips em/en dashes + other separators from the title', () => {
+    const section = `- #86 — Story 1.1: Pipeline config schema
+- #87 – Story 1.2: Pipeline config loader
+`;
+    const rows = parseChecklistOrBullets(section, 'myorg/myrepo');
+    expect(rows[0].title).toBe('Story 1.1: Pipeline config schema');
+    expect(rows[1].title).toBe('Story 1.2: Pipeline config loader');
+  });
+
+  test('cross-repo refs in bullets pass through verbatim', () => {
+    const section = `- Wave-Engineering/other#42 cross-repo task
+`;
+    const rows = parseChecklistOrBullets(section, 'myorg/myrepo');
+    expect(rows[0].ref).toBe('Wave-Engineering/other#42');
+  });
+
+  test('full issue URL in a bullet is normalized', () => {
+    const section = `- https://github.com/acme/widgets/issues/7 widget work
+`;
+    const rows = parseChecklistOrBullets(section, 'myorg/myrepo');
+    expect(rows[0].ref).toBe('acme/widgets#7');
+  });
+
+  test('bullets without any ref are skipped (position counter does not advance)', () => {
+    const section = `- just prose, no ref
+- #5 first real
+- another prose line
+- #6 second real
+`;
+    const rows = parseChecklistOrBullets(section, 'myorg/myrepo');
+    expect(rows.map(r => r.order)).toEqual([1, 2]);
+    expect(rows.map(r => r.ref)).toEqual(['myorg/myrepo#5', 'myorg/myrepo#6']);
+  });
+
+  test('returns [] on a section with no bullets', () => {
+    expect(parseChecklistOrBullets('just a paragraph of prose.', null)).toEqual([]);
+  });
+});

--- a/lib/epic-sub-issues-parser.ts
+++ b/lib/epic-sub-issues-parser.ts
@@ -1,0 +1,130 @@
+/**
+ * Pure parsers for the `epic_sub_issues` handler. Promoted out of
+ * `handlers/epic_sub_issues.ts` during Story 2.6 (#300) so the handler can
+ * shrink to a thin adapter-dispatch shell while the ~200 LoC of markdown
+ * table / checklist-or-bullet / ref-normalization logic continues to live
+ * behind its own colocated tests.
+ *
+ * Nothing here touches the platform, a subprocess, or the filesystem — these
+ * functions are called with an already-extracted section string plus the
+ * caller's repo slug. See `docs/issue-body-grammar.md` for the accepted
+ * surface forms.
+ */
+
+export interface SubIssue {
+  ref: string;
+  title?: string;
+  order?: number;
+}
+
+/**
+ * Normalize a raw issue reference token into the canonical `org/repo#N`
+ * shape (or bare `#N` when no repo slug context is available).
+ *
+ * Accepted input forms:
+ *   - `https://github.com/<owner>/<repo>/issues/<N>` → `<owner>/<repo>#N`
+ *   - `https://gitlab.com/<owner>/<repo>/-/issues/<N>` → `<owner>/<repo>#N`
+ *   - `<owner>/<repo>#N` (already cross-repo qualified) → passthrough
+ *   - `#N` or `N` (bare) → `<currentSlug>#N` when `currentSlug` is non-null,
+ *     otherwise `#N`
+ */
+export function normalizeRef(ref: string, currentSlug: string | null): string {
+  // URL
+  const urlM =
+    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/.exec(
+      ref,
+    );
+  if (urlM) return `${urlM[1]}/${urlM[2]}#${urlM[3]}`;
+
+  const crossM = /^([^/\s#]+)\/([^/\s#]+)#(\d+)$/.exec(ref);
+  if (crossM) return ref;
+
+  const shortM = /^#?(\d+)$/.exec(ref);
+  if (shortM) {
+    return currentSlug ? `${currentSlug}#${shortM[1]}` : `#${shortM[1]}`;
+  }
+  return ref;
+}
+
+/**
+ * Parse a markdown table with `Order | Issue | Title` columns (columns
+ * matched case-insensitively by substring — `Issue Ref` / `Story Order` also
+ * work). Returns `[]` when no `|`-delimited header row is present.
+ */
+export function parseTableRows(section: string, currentSlug: string | null): SubIssue[] {
+  const lines = section.split('\n').map(l => l.trim());
+  const subs: SubIssue[] = [];
+  let headerIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith('|') && lines[i].includes('|', 1)) {
+      headerIdx = i;
+      break;
+    }
+  }
+  if (headerIdx === -1) return [];
+  const headerCells = lines[headerIdx]
+    .split('|')
+    .slice(1, -1)
+    .map(c => c.trim().toLowerCase());
+  const colIdx = (name: string) => headerCells.findIndex(c => c.includes(name));
+  const orderCol = colIdx('order');
+  const issueCol = colIdx('issue');
+  const titleCol = colIdx('title');
+
+  let startRow = headerIdx + 1;
+  if (startRow < lines.length && /^\|[\s\-:|]+\|$/.test(lines[startRow])) startRow += 1;
+
+  for (let i = startRow; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.startsWith('|')) break;
+    const cells = line.split('|').slice(1, -1).map(c => c.trim());
+    const getCell = (idx: number) => (idx >= 0 && idx < cells.length ? cells[idx] : '');
+    const issueRaw = getCell(issueCol);
+    const refM = /#?(\d+)|([^/\s#]+)\/([^/\s#]+)#(\d+)/.exec(issueRaw);
+    if (!refM) continue;
+    const ref = normalizeRef(issueRaw, currentSlug);
+    const order = orderCol >= 0 ? parseInt(getCell(orderCol), 10) : undefined;
+    const title = titleCol >= 0 ? getCell(titleCol) : undefined;
+    subs.push({
+      ref,
+      title: title && title.length > 0 ? title : undefined,
+      order: Number.isFinite(order) ? (order as number) : undefined,
+    });
+  }
+  return subs;
+}
+
+/**
+ * Parse a checklist (`- [ ] #N Title`) or bullet list (`- #N Title`,
+ * `- #N — Title`). `order` is the 1-based position of each matching bullet
+ * (not a column value — the bullet form has no explicit order).
+ */
+export function parseChecklistOrBullets(
+  section: string,
+  currentSlug: string | null,
+): SubIssue[] {
+  const subs: SubIssue[] = [];
+  const checklistRe = /^\s*[-*]\s*(?:\[[ xX]\]\s*)?([^\n]*)$/gm;
+  let m: RegExpExecArray | null;
+  let position = 1;
+  while ((m = checklistRe.exec(section)) !== null) {
+    const text = m[1].trim();
+    if (!text) continue;
+    const refM =
+      /(?:^|\s)([^/\s#]+\/[^/\s#]+#\d+|https?:\/\/\S+\/issues\/\d+|#\d+)/.exec(text);
+    if (!refM) continue;
+    const raw = refM[1];
+    const ref = normalizeRef(raw, currentSlug);
+    // Title = text with the ref token stripped out. Also strip leading
+    // list/separator punctuation including em/en dashes commonly used in
+    // `- #NN — Title` style bullets.
+    const title = text.replace(refM[0], '').trim().replace(/^[-:*\s—–]+/, '').trim();
+    subs.push({
+      ref,
+      title: title.length > 0 ? title : undefined,
+      order: position,
+    });
+    position += 1;
+  }
+  return subs;
+}

--- a/scripts/ci/migration-allowlist.txt
+++ b/scripts/ci/migration-allowlist.txt
@@ -11,7 +11,6 @@
 # Format: one basename per line. Comments (#) and blank lines ignored.
 ci_wait_run.ts
 dod_load_manifest.ts
-epic_sub_issues.ts
 ibm.ts
 wave_ci_trust_level.ts
 wave_compute.ts


### PR DESCRIPTION
## Summary

Migrates `handlers/epic_sub_issues.ts` to the platform adapter (`getAdapter().fetchIssue(...)`), promoting pure parsers to `lib/epic-sub-issues-parser.ts` with colocated tests. Removes direct subprocess and platform-branching from the handler.

## Changes

- `handlers/epic_sub_issues.ts` slimmed to 78 lines; `getAdapter({repo}).fetchIssue(...)` for body fetch; no `execSync`, no `detectPlatform`, no `gitlabApiIssue` imports
- `lib/epic-sub-issues-parser.ts` (NEW) — pure parsers lifted verbatim (`normalizeRef`, `parseTableRows`, `parseChecklistOrBullets`, `SubIssue` interface)
- `lib/epic-sub-issues-parser.test.ts` (NEW) — 19 pure-function tests across ref normalization, table row extraction, checklist/bullet extraction
- `scripts/ci/migration-allowlist.txt` — `epic_sub_issues.ts` removed; gate-greps now enforce R-09/R-10
- `tests/epic_sub_issues.test.ts` preserved unchanged; continues to pass against adapter path

## Linked Issues

Closes #300

## Test Plan

- `./scripts/ci/validate.sh` — exit 0 (codegen, lint, gate-greps, shellcheck, bun test, smoke)
- `bun test` — 1823 pass / 0 fail across 123 files
- `./scripts/ci/gate-greps.sh` standalone — OK; `checking 62 non-allowlisted handler(s) … OK`
- Smoke: 73/73 passed