### PR TITLE
refactor(dod_load_manifest): migrate to platform adapter + close cross-repo GitLab gap (#301)

### DIFF
--- a/handlers/dod_load_manifest.ts
+++ b/handlers/dod_load_manifest.ts
@@ -1,156 +1,52 @@
-import { execSync } from 'child_process';
+// DoD handler — adapter-dispatching shell (Story 2.7, #301).
+// Platform branching + subprocess live in lib/adapters/fetch-issue-{github,gitlab}.ts.
+// Markdown parsing lives in lib/dod-manifest-parser.ts (R-05 ≤80 lines).
+// Closes #283: cross-repo `org/project#N` resolves on BOTH platforms via
+// fetchIssue, eliminating the prior GitHub-only gap.
+
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform } from '../lib/shared/detect-platform.js';
-import { gitlabApiIssue } from '../lib/glab.js';
+import { getAdapter } from '../lib/adapters/index.js';
+import { extractManifestSection, parseManifestTable } from '../lib/dod-manifest-parser.js';
 
 const inputSchema = z.object({
   path: z.string().min(1, 'path must be a non-empty string'),
 });
 
-interface Deliverable {
-  id: string;
-  description: string;
-  evidence_path: string;
-  status: string;
-  category: string;
-}
-
 const ISSUE_REF = /^([^/]+)\/([^/#]+)#(\d+)$/;
 const SHORT_REF = /^#(\d+)$/;
 
-function isIssueRef(path: string): boolean {
-  return ISSUE_REF.test(path) || SHORT_REF.test(path);
+function envelope(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] };
 }
 
-function fetchIssueBody(ref: string): string {
-  const platform = detectPlatform();
-  if (platform === 'github') {
-    const m1 = ISSUE_REF.exec(ref);
-    const m2 = SHORT_REF.exec(ref);
-    if (m1) {
-      const raw = execSync(`gh issue view ${m1[3]} --repo ${m1[1]}/${m1[2]} --json body`, {
-        encoding: 'utf8',
-      });
-      return (JSON.parse(raw) as { body: string }).body;
-    }
-    if (m2) {
-      const raw = execSync(`gh issue view ${m2[1]} --json body`, { encoding: 'utf8' });
-      return (JSON.parse(raw) as { body: string }).body;
-    }
-  } else {
-    const m2 = SHORT_REF.exec(ref);
-    if (m2) {
-      const result = gitlabApiIssue(Number(m2[1]));
-      return result.description ?? '';
-    }
+async function fetchIssueBody(ref: string): Promise<string> {
+  const m1 = ISSUE_REF.exec(ref);
+  const m2 = SHORT_REF.exec(ref);
+  if (m1) {
+    const repo = `${m1[1]}/${m1[2]}`;
+    const result = await getAdapter({ repo }).fetchIssue({ number: Number(m1[3]), repo });
+    if ('platform_unsupported' in result) throw new Error(result.hint);
+    if (!result.ok) throw new Error(result.error);
+    return result.data.body;
+  }
+  if (m2) {
+    const result = await getAdapter().fetchIssue({ number: Number(m2[1]) });
+    if ('platform_unsupported' in result) throw new Error(result.hint);
+    if (!result.ok) throw new Error(result.error);
+    return result.data.body;
   }
   throw new Error(`unsupported issue ref format: ${ref}`);
 }
 
 async function readLocalFile(path: string): Promise<string> {
   const file = Bun.file(path);
-  if (!(await file.exists())) {
-    throw new Error(`file not found: ${path}`);
-  }
+  if (!(await file.exists())) throw new Error(`file not found: ${path}`);
   return await file.text();
 }
 
-/**
- * Extract the "Deliverables Manifest" section from a PRD markdown body.
- *
- * Looks for a heading matching /^##+\s*deliverables manifest/i, then
- * captures everything until the next same-or-lower level heading.
- */
-function extractManifestSection(markdown: string): string | null {
-  const lines = markdown.split('\n');
-  let inSection = false;
-  let sectionLevel = 0;
-  const collected: string[] = [];
-
-  for (const line of lines) {
-    const headingMatch = /^(#+)\s+(.*)$/.exec(line);
-    if (headingMatch) {
-      const level = headingMatch[1].length;
-      const title = headingMatch[2].trim();
-      if (inSection) {
-        if (level <= sectionLevel) break;
-      }
-      if (/^deliverables manifest/i.test(title)) {
-        inSection = true;
-        sectionLevel = level;
-        continue;
-      }
-    }
-    if (inSection) collected.push(line);
-  }
-
-  return inSection ? collected.join('\n').trim() : null;
-}
-
-/**
- * Parse a GitHub-flavored markdown table of deliverables into structured rows.
- * Expected columns (flexible order, case-insensitive): id, description,
- * evidence path, status, category.
- */
-function parseManifestTable(sectionMd: string): { deliverables: Deliverable[]; warnings: string[] } {
-  const warnings: string[] = [];
-  const deliverables: Deliverable[] = [];
-  const lines = sectionMd.split('\n').map(l => l.trim());
-
-  // Find the first table header row (starts with |).
-  let headerIdx = -1;
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].startsWith('|') && lines[i].includes('|', 1)) {
-      headerIdx = i;
-      break;
-    }
-  }
-  if (headerIdx === -1) {
-    warnings.push('no markdown table found in Deliverables Manifest section');
-    return { deliverables, warnings };
-  }
-
-  const headerCells = lines[headerIdx]
-    .split('|')
-    .slice(1, -1)
-    .map(c => c.trim().toLowerCase());
-
-  const colIdx = (name: string): number => {
-    return headerCells.findIndex(c => c.includes(name));
-  };
-
-  const idCol = colIdx('id');
-  const descCol = colIdx('description');
-  const pathCol = Math.max(colIdx('evidence'), colIdx('path'));
-  const statusCol = colIdx('status');
-  const catCol = colIdx('category');
-
-  // Skip separator line (|---|---|)
-  let startRow = headerIdx + 1;
-  if (startRow < lines.length && /^\|[\s\-:|]+\|$/.test(lines[startRow])) {
-    startRow += 1;
-  }
-
-  for (let i = startRow; i < lines.length; i++) {
-    const line = lines[i];
-    if (!line.startsWith('|')) break;
-    const cells = line.split('|').slice(1, -1).map(c => c.trim());
-    if (cells.length < headerCells.length) {
-      warnings.push(`row ${i - startRow + 1} has fewer cells than header, skipping`);
-      continue;
-    }
-    const get = (idx: number) => (idx >= 0 && idx < cells.length ? cells[idx] : '');
-    deliverables.push({
-      id: get(idCol),
-      description: get(descCol),
-      evidence_path: get(pathCol),
-      status: get(statusCol),
-      category: get(catCol),
-    });
-  }
-
-  return { deliverables, warnings };
+function isIssueRef(path: string): boolean {
+  return ISSUE_REF.test(path) || SHORT_REF.test(path);
 }
 
 const dodLoadManifestHandler: HandlerDef = {
@@ -162,51 +58,21 @@ const dodLoadManifestHandler: HandlerDef = {
     try {
       args = inputSchema.parse(rawArgs);
     } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
 
     try {
       const body = isIssueRef(args.path)
-        ? fetchIssueBody(args.path)
+        ? await fetchIssueBody(args.path)
         : await readLocalFile(args.path);
-
       const section = extractManifestSection(body);
       if (section === null) {
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                ok: false,
-                error: 'no Deliverables Manifest section found in PRD',
-              }),
-            },
-          ],
-        };
+        return envelope({ ok: false, error: 'no Deliverables Manifest section found in PRD' });
       }
-
       const { deliverables, warnings } = parseManifestTable(section);
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({
-              ok: true,
-              deliverables,
-              warnings,
-              source: args.path,
-            }),
-          },
-        ],
-      };
+      return envelope({ ok: true, deliverables, warnings, source: args.path });
     } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
   },
 };

--- a/lib/dod-manifest-parser.test.ts
+++ b/lib/dod-manifest-parser.test.ts
@@ -1,0 +1,109 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  extractManifestSection,
+  parseManifestTable,
+  type Deliverable,
+} from './dod-manifest-parser';
+
+const SAMPLE_PRD = `# Some PRD
+
+Intro text.
+
+## Deliverables Manifest
+
+| ID | Description | Evidence Path | Status | Category |
+|----|-------------|---------------|--------|----------|
+| D-01 | Wave init handler | handlers/wave_init.ts | done | code |
+| D-02 | Docs updated | docs/WAVE.md | pending | docs |
+
+## Next Section
+
+Out of scope for manifest parsing.
+`;
+
+describe('dod-manifest-parser', () => {
+  test('extractManifestSection — pulls Deliverables Manifest H2 block from a PRD body', () => {
+    const section = extractManifestSection(SAMPLE_PRD);
+    expect(section).not.toBeNull();
+    expect(section).toContain('| D-01 | Wave init handler |');
+    expect(section).toContain('| D-02 | Docs updated |');
+    expect(section).not.toContain('Next Section');
+    expect(section).not.toContain('Out of scope');
+  });
+
+  test('extractManifestSection — returns null when no Deliverables Manifest heading present', () => {
+    const section = extractManifestSection('# PRD\n\nNo manifest here.\n');
+    expect(section).toBeNull();
+  });
+
+  test('extractManifestSection — case-insensitive heading match', () => {
+    const md = `## DELIVERABLES MANIFEST\n\nbody\n`;
+    expect(extractManifestSection(md)).toBe('body');
+  });
+
+  test('extractManifestSection — handles H3+ nested content, stops at next H2', () => {
+    const md = `## Deliverables Manifest
+
+| ID | Description | Evidence Path | Status | Category |
+|----|-------------|---------------|--------|----------|
+| D-01 | desc | path | done | code |
+
+### Sub-detail
+
+more body
+
+## Other
+`;
+    const section = extractManifestSection(md);
+    expect(section).not.toBeNull();
+    expect(section).toContain('Sub-detail');
+    expect(section).toContain('more body');
+    expect(section).not.toContain('Other');
+  });
+
+  test('parseManifestTable — well-formed table → typed rows', () => {
+    const section = extractManifestSection(SAMPLE_PRD) ?? '';
+    const { deliverables, warnings } = parseManifestTable(section);
+    expect(warnings).toEqual([]);
+    expect(deliverables.length).toBe(2);
+    expect(deliverables[0]).toEqual({
+      id: 'D-01',
+      description: 'Wave init handler',
+      evidence_path: 'handlers/wave_init.ts',
+      status: 'done',
+      category: 'code',
+    } satisfies Deliverable);
+    expect(deliverables[1].id).toBe('D-02');
+  });
+
+  test('parseManifestTable — no markdown table → warning, empty deliverables', () => {
+    const { deliverables, warnings } = parseManifestTable('just prose, no pipes');
+    expect(deliverables).toEqual([]);
+    expect(warnings[0]).toContain('no markdown table');
+  });
+
+  test('parseManifestTable — malformed row (fewer cells) → warning, skipped', () => {
+    const md = `| ID | Description | Evidence Path | Status | Category |
+|----|-------------|---------------|--------|----------|
+| D-01 | Only three cells |
+| D-02 | Valid row | path/thing | done | code |`;
+    const { deliverables, warnings } = parseManifestTable(md);
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(deliverables.length).toBe(1);
+    expect(deliverables[0].id).toBe('D-02');
+  });
+
+  test('parseManifestTable — flexible column order', () => {
+    const md = `| Status | ID | Description | Evidence Path | Category |
+|--------|----|-------------|---------------|----------|
+| done | D-42 | flexible order | src/x.ts | code |`;
+    const { deliverables } = parseManifestTable(md);
+    expect(deliverables[0]).toEqual({
+      id: 'D-42',
+      description: 'flexible order',
+      evidence_path: 'src/x.ts',
+      status: 'done',
+      category: 'code',
+    });
+  });
+});

--- a/lib/dod-manifest-parser.ts
+++ b/lib/dod-manifest-parser.ts
@@ -1,0 +1,115 @@
+/**
+ * Markdown Deliverables Manifest parser — promoted from `dod_load_manifest`
+ * (Story 2.7, #301) so the handler can stay platform-agnostic and under the
+ * ≤80-line R-05 budget. Shape parsing is pure string work; no I/O lives here.
+ *
+ * A PRD body contains a `## Deliverables Manifest` H2 section whose content is
+ * a GitHub-flavored markdown table with flexible column ordering (id,
+ * description, evidence path, status, category). This module extracts that
+ * section and parses the table into typed rows.
+ */
+
+export interface Deliverable {
+  id: string;
+  description: string;
+  evidence_path: string;
+  status: string;
+  category: string;
+}
+
+/**
+ * Extract the "Deliverables Manifest" section from a PRD markdown body.
+ *
+ * Looks for a heading matching `/^##+\s*deliverables manifest/i`, then
+ * captures everything until the next same-or-lower level heading.
+ */
+export function extractManifestSection(markdown: string): string | null {
+  const lines = markdown.split('\n');
+  let inSection = false;
+  let sectionLevel = 0;
+  const collected: string[] = [];
+
+  for (const line of lines) {
+    const headingMatch = /^(#+)\s+(.*)$/.exec(line);
+    if (headingMatch) {
+      const level = headingMatch[1].length;
+      const title = headingMatch[2].trim();
+      if (inSection) {
+        if (level <= sectionLevel) break;
+      }
+      if (/^deliverables manifest/i.test(title)) {
+        inSection = true;
+        sectionLevel = level;
+        continue;
+      }
+    }
+    if (inSection) collected.push(line);
+  }
+
+  return inSection ? collected.join('\n').trim() : null;
+}
+
+/**
+ * Parse a GitHub-flavored markdown table of deliverables into structured rows.
+ * Expected columns (flexible order, case-insensitive): id, description,
+ * evidence path, status, category.
+ */
+export function parseManifestTable(
+  sectionMd: string,
+): { deliverables: Deliverable[]; warnings: string[] } {
+  const warnings: string[] = [];
+  const deliverables: Deliverable[] = [];
+  const lines = sectionMd.split('\n').map(l => l.trim());
+
+  // Find the first table header row (starts with |).
+  let headerIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith('|') && lines[i].includes('|', 1)) {
+      headerIdx = i;
+      break;
+    }
+  }
+  if (headerIdx === -1) {
+    warnings.push('no markdown table found in Deliverables Manifest section');
+    return { deliverables, warnings };
+  }
+
+  const headerCells = lines[headerIdx]
+    .split('|')
+    .slice(1, -1)
+    .map(c => c.trim().toLowerCase());
+
+  const colIdx = (name: string): number => headerCells.findIndex(c => c.includes(name));
+
+  const idCol = colIdx('id');
+  const descCol = colIdx('description');
+  const pathCol = Math.max(colIdx('evidence'), colIdx('path'));
+  const statusCol = colIdx('status');
+  const catCol = colIdx('category');
+
+  // Skip separator line (|---|---|).
+  let startRow = headerIdx + 1;
+  if (startRow < lines.length && /^\|[\s\-:|]+\|$/.test(lines[startRow])) {
+    startRow += 1;
+  }
+
+  for (let i = startRow; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.startsWith('|')) break;
+    const cells = line.split('|').slice(1, -1).map(c => c.trim());
+    if (cells.length < headerCells.length) {
+      warnings.push(`row ${i - startRow + 1} has fewer cells than header, skipping`);
+      continue;
+    }
+    const get = (idx: number) => (idx >= 0 && idx < cells.length ? cells[idx] : '');
+    deliverables.push({
+      id: get(idCol),
+      description: get(descCol),
+      evidence_path: get(pathCol),
+      status: get(statusCol),
+      category: get(catCol),
+    });
+  }
+
+  return { deliverables, warnings };
+}

--- a/scripts/ci/migration-allowlist.txt
+++ b/scripts/ci/migration-allowlist.txt
@@ -10,7 +10,6 @@
 #
 # Format: one basename per line. Comments (#) and blank lines ignored.
 ci_wait_run.ts
-dod_load_manifest.ts
 ibm.ts
 wave_ci_trust_level.ts
 wave_compute.ts

--- a/tests/dod_load_manifest.test.ts
+++ b/tests/dod_load_manifest.test.ts
@@ -1,14 +1,26 @@
 import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
 
-// Mock child_process for gh shell-outs.
-let execMockFn: (cmd: string) => string = () => '';
-const mockExecSync = mock((cmd: string, _opts?: unknown) => execMockFn(cmd));
+// Mock child_process registry — matched by substring so individual tests can
+// install exec fixtures for `git remote`, `gh issue view`, `glab api projects/...`.
+// The handler now dispatches through getAdapter().fetchIssue(...), which under
+// the hood still execs `gh issue view` (GitHub) / `glab api projects/...`
+// (GitLab); tests exercise the real adapter stack with only subprocess mocked.
+let execRegistry: Record<string, string> = {};
+
+function mockExec(cmd: string): string {
+  for (const [key, value] of Object.entries(execRegistry)) {
+    if (cmd.includes(key)) return value;
+  }
+  throw new Error(`Unexpected exec call: ${cmd}`);
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => mockExec(cmd));
 mock.module('child_process', () => ({ execSync: mockExecSync }));
 
 const { default: handler } = await import('../handlers/dod_load_manifest.ts');
 
 function resetMocks() {
-  execMockFn = () => '';
+  execRegistry = {};
   mockExecSync.mockClear();
 }
 
@@ -71,52 +83,83 @@ describe('dod_load_manifest handler', () => {
     expect(parsed.error).toContain('no Deliverables Manifest');
   });
 
-  test('handles_malformed_rows — warns on short rows, continues parsing', async () => {
-    const md = `## Deliverables Manifest
-
-| ID | Description | Evidence Path | Status | Category |
-|----|-------------|---------------|--------|----------|
-| D-01 | Only has three cells |
-| D-02 | Valid row | path/thing | done | code |
-`;
-    const path = await writeTempFile(md);
-    const result = await handler.execute({ path });
-    const parsed = parseResult(result);
-    expect(parsed.ok).toBe(true);
-    expect(parsed.warnings.length).toBeGreaterThan(0);
-    expect(parsed.deliverables.length).toBe(1);
-    expect(parsed.deliverables[0].id).toBe('D-02');
-  });
-
-  test('reads_from_gh_issue — #N format shells out to gh issue view', async () => {
-    execMockFn = (cmd: string) => {
-      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
-      if (cmd.includes('gh issue view 42')) {
-        return JSON.stringify({ body: SAMPLE_PRD });
-      }
-      return '';
-    };
+  test('reads_from_gh_issue — #N format shells out via adapter', async () => {
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git\n';
+    execRegistry['gh issue view 42'] = JSON.stringify({
+      number: 42,
+      title: 'PRD',
+      state: 'OPEN',
+      url: 'https://github.com/org/repo/issues/42',
+      body: SAMPLE_PRD,
+      labels: [],
+    });
     const result = await handler.execute({ path: '#42' });
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
     expect(parsed.deliverables.length).toBe(2);
   });
 
-  test('reads_from_gh_issue — org/repo#N format uses --repo flag', async () => {
-    let seenCmd = '';
-    execMockFn = (cmd: string) => {
-      if (cmd.startsWith('git remote')) return 'https://github.com/org/repo.git\n';
-      if (cmd.includes('gh issue view')) {
-        seenCmd = cmd;
-        return JSON.stringify({ body: SAMPLE_PRD });
-      }
-      return '';
-    };
+  test('reads_from_gh_issue — org/repo#N format uses --repo flag (GitHub)', async () => {
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git\n';
+    execRegistry['gh issue view 7 --json'] = JSON.stringify({
+      number: 7,
+      title: 'PRD',
+      state: 'OPEN',
+      url: 'https://github.com/acme/widgets/issues/7',
+      body: SAMPLE_PRD,
+      labels: [],
+    });
     const result = await handler.execute({ path: 'acme/widgets#7' });
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(true);
-    expect(seenCmd).toContain('--repo acme/widgets');
-    expect(seenCmd).toContain('7');
+    // Verify the adapter dispatched to the cross-repo slug.
+    const sawRepoFlag = mockExecSync.mock.calls.some(call => {
+      const cmd = call[0] as string;
+      return cmd.includes('gh issue view 7') && cmd.includes('--repo acme/widgets');
+    });
+    expect(sawRepoFlag).toBe(true);
+  });
+
+  // Regression for #283 — cross-repo ISSUE_REF on GitLab silently broke
+  // before Story 2.7. The migration moves dispatch to getAdapter().fetchIssue
+  // so the `org/project#N` branch resolves on BOTH platforms.
+  test('reads_from_gitlab_issue — org/repo#N resolves on GitLab (regression for #283)', async () => {
+    execRegistry['git remote get-url origin'] = 'https://gitlab.com/mygroup/myrepo.git\n';
+    execRegistry['glab api projects/acme%2Fwidgets/issues/7'] = JSON.stringify({
+      iid: 7,
+      title: 'PRD',
+      state: 'opened',
+      web_url: 'https://gitlab.com/acme/widgets/-/issues/7',
+      description: SAMPLE_PRD,
+      labels: [],
+    });
+    const result = await handler.execute({ path: 'acme/widgets#7' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.deliverables.length).toBe(2);
+    // Verify the adapter dispatched to the cross-repo project path, not the
+    // cwd repo slug — this is the exact gap #283 covers.
+    const sawCrossRepoCall = mockExecSync.mock.calls.some(call => {
+      const cmd = call[0] as string;
+      return cmd.includes('glab api projects/acme%2Fwidgets/issues/7');
+    });
+    expect(sawCrossRepoCall).toBe(true);
+  });
+
+  test('reads_from_gitlab_issue — bare #N uses cwd project path', async () => {
+    execRegistry['git remote get-url origin'] = 'https://gitlab.com/mygroup/myrepo.git\n';
+    execRegistry['glab api projects/mygroup%2Fmyrepo/issues/42'] = JSON.stringify({
+      iid: 42,
+      title: 'PRD',
+      state: 'opened',
+      web_url: 'https://gitlab.com/mygroup/myrepo/-/issues/42',
+      description: SAMPLE_PRD,
+      labels: [],
+    });
+    const result = await handler.execute({ path: '#42' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.deliverables.length).toBe(2);
   });
 
   test('missing_file_returns_structured_error', async () => {


### PR DESCRIPTION
## Summary

Migrates `handlers/dod_load_manifest.ts` to the platform adapter pattern, eliminating platform branching and direct subprocess calls. Closes the cross-repo GitLab gap tracked in #283 — the `org/repo#N` ref shape now dispatches through `getAdapter({repo}).fetchIssue(...)` on both GitHub and GitLab instead of the prior GitHub-only path.

## Changes

- `handlers/dod_load_manifest.ts` — rewritten as an adapter-dispatching shell (80 LOC). Removed `detectPlatform`, `execSync`, and the direct `gitlabApiIssue` import. Cross-repo branch: `ISSUE_REF.exec(ref)` → `getAdapter({repo}).fetchIssue({number, repo})`. Bare `#N` branch: `getAdapter().fetchIssue({number})`.
- `lib/dod-manifest-parser.ts` — **new** pure-string module promoting `extractManifestSection`, `parseManifestTable`, and the `Deliverable` type out of the handler (no I/O).
- `lib/dod-manifest-parser.test.ts` — **new** unit tests (H2 extraction, case-insensitive match, H3 nesting, flexible column order, malformed rows, empty input).
- `tests/dod_load_manifest.test.ts` — migrated to the exec-registry mock; exercises the real adapter stack for both `gh issue view` and `glab api projects/...`. Adds the #283 regression test asserting cross-repo project-path dispatch (`glab api projects/acme%2Fwidgets/issues/7`) rather than the cwd slug.
- `scripts/ci/migration-allowlist.txt` — removes `dod_load_manifest.ts` (gate-greps now cover 63 handlers, up from 62).

## Linked Issues

Closes #301
Closes #283

## Test Plan

- `./scripts/ci/validate.sh` → exit 0
  - codegen-handlers.sh OK
  - `bun run lint` OK
  - gate-greps: 63 non-allowlisted handlers, R-09/R-10 enforced OK
  - shellcheck OK
  - `bun test`: 1832 pass / 0 fail
  - runtime smoke: 73/73 tool-presence assertions passed
- Targeted: `bun test tests/dod_load_manifest.test.ts lib/dod-manifest-parser.test.ts` → 18 pass / 0 fail