### PR TITLE
refactor(wave_compute): migrate to platform adapter (#302)

### DIFF
--- a/handlers/wave_compute.ts
+++ b/handlers/wave_compute.ts
@@ -1,133 +1,26 @@
+// Wave-family handler — adapter-dispatching shell. Subprocess + platform
+// branching live in lib/adapters/fetch-issue-{github,gitlab}.ts (Story 2.1,
+// #295); wave-computation / sub-issue + dependency parsing live in
+// lib/wave-compute.ts (Story 2.8, #302). This handler is dispatch + envelope
+// only.
+
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { findSubIssueSection, parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
-import { computeWaves, type DepNode } from '../lib/dependency_graph';
-import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { parseIssueRef, type IssueRef } from '../lib/spec_parser';
 import { parseRepoSlug } from '../lib/shared/parse-repo-slug.js';
-import { gitlabApiIssue } from '../lib/glab.js';
-import { execSync } from 'child_process';
+import { getAdapter } from '../lib/adapters/index.js';
+import { computeWavesForEpic, type IssueFetcher } from '../lib/wave-compute.js';
 
 const inputSchema = z.object({
   epic_ref: z.string().min(1, 'epic_ref must be a non-empty string'),
 });
 
-// Mirrors REQUIRED_SECTION_ALIASES in handlers/spec_validate_structure.ts (lines 14-18).
-// Kept in lockstep so the story-self fallback applies the same "valid spec" test
-// that /prepwaves uses upstream.
-const REQUIRED_SECTION_ALIASES: Record<string, readonly string[]> = {
-  changes: ['changes', 'implementation_steps'],
-  tests: ['tests', 'test_procedures'],
-  acceptance_criteria: ['acceptance_criteria'],
-};
-
-function fetchIssue(ref: IssueRef): { body: string; title: string } {
-  const platform = detectPlatform();
-  if (platform === 'github') {
-    const repoArg = ref.owner && ref.repo ? `--repo ${ref.owner}/${ref.repo}` : '';
-    const cmd = `gh issue view ${ref.number} ${repoArg} --json body,title`.trim();
-    const raw = execSync(cmd, { encoding: 'utf8' });
-    const parsed = JSON.parse(raw) as { body?: string; title: string };
-    return { body: parsed.body ?? '', title: parsed.title };
-  }
-  const result = gitlabApiIssue(ref.number, ref.owner && ref.repo ? { owner: ref.owner, repo: ref.repo } : undefined);
-  return { body: result.description ?? '', title: result.title };
+function envelope(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] };
 }
 
-function normalizeRef(ref: string, currentSlug: string | null): string {
-  const urlM =
-    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/.exec(
-      ref,
-    );
-  if (urlM) return `${urlM[1]}/${urlM[2]}#${urlM[3]}`;
-
-  const crossM = /^([^/\s#]+)\/([^/\s#]+)#(\d+)$/.exec(ref);
-  if (crossM) return ref;
-
-  const shortM = /^#?(\d+)$/.exec(ref);
-  if (shortM) return currentSlug ? `${currentSlug}#${shortM[1]}` : `#${shortM[1]}`;
-  return ref;
-}
-
-interface SubIssue {
-  ref: string;
-  title?: string;
-}
-
-function parseTableSubIssues(section: string, currentSlug: string | null): SubIssue[] {
-  const lines = section.split('\n').map(l => l.trim());
-  const subs: SubIssue[] = [];
-  let headerIdx = -1;
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].startsWith('|') && lines[i].includes('|', 1)) {
-      headerIdx = i;
-      break;
-    }
-  }
-  if (headerIdx === -1) return [];
-  const headerCells = lines[headerIdx]
-    .split('|')
-    .slice(1, -1)
-    .map(c => c.trim().toLowerCase());
-  const issueCol = headerCells.findIndex(c => c.includes('issue'));
-  const titleCol = headerCells.findIndex(c => c.includes('title'));
-
-  let startRow = headerIdx + 1;
-  if (startRow < lines.length && /^\|[\s\-:|]+\|$/.test(lines[startRow])) startRow += 1;
-
-  for (let i = startRow; i < lines.length; i++) {
-    const line = lines[i];
-    if (!line.startsWith('|')) break;
-    const cells = line.split('|').slice(1, -1).map(c => c.trim());
-    const getCell = (idx: number) => (idx >= 0 && idx < cells.length ? cells[idx] : '');
-    const issueRaw = getCell(issueCol);
-    if (!issueRaw) continue;
-    subs.push({
-      ref: normalizeRef(issueRaw, currentSlug),
-      title: titleCol >= 0 ? getCell(titleCol) || undefined : undefined,
-    });
-  }
-  return subs;
-}
-
-function parseBulletSubIssues(section: string, currentSlug: string | null): SubIssue[] {
-  const subs: SubIssue[] = [];
-  const re = /^\s*[-*]\s*(?:\[[ xX]\]\s*)?([^\n]*)$/gm;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(section)) !== null) {
-    const text = m[1].trim();
-    if (!text) continue;
-    const refM =
-      /(?:^|\s)([^/\s#]+\/[^/\s#]+#\d+|https?:\/\/\S+\/issues\/\d+|#\d+)/.exec(text);
-    if (!refM) continue;
-    const ref = normalizeRef(refM[1], currentSlug);
-    const title = text.replace(refM[0], '').trim().replace(/^[-:*\s]+/, '').trim();
-    subs.push({ ref, title: title || undefined });
-  }
-  return subs;
-}
-
-function parseDependencies(section: string, currentSlug: string | null): string[] {
-  if (!section) return [];
-  if (/^none\b/i.test(section.trim())) return [];
-  const found = new Set<string>();
-
-  const urlRe =
-    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/g;
-  let m: RegExpExecArray | null;
-  while ((m = urlRe.exec(section)) !== null) {
-    found.add(`${m[1]}/${m[2]}#${m[3]}`);
-  }
-  const crossRe = /\b([^\s/#]+)\/([^\s/#]+)#(\d+)\b/g;
-  while ((m = crossRe.exec(section)) !== null) {
-    if (m[1].startsWith('http') || m[1].includes('.')) continue;
-    found.add(`${m[1]}/${m[2]}#${m[3]}`);
-  }
-  const shortRe = /(?<![/\w])#(\d+)\b/g;
-  while ((m = shortRe.exec(section)) !== null) {
-    const normalized = currentSlug ? `${currentSlug}#${m[1]}` : `#${m[1]}`;
-    found.add(normalized);
-  }
-  return Array.from(found);
+function repoSlug(ref: IssueRef): string | undefined {
+  return ref.owner && ref.repo ? `${ref.owner}/${ref.repo}` : undefined;
 }
 
 const waveComputeHandler: HandlerDef = {
@@ -139,215 +32,34 @@ const waveComputeHandler: HandlerDef = {
     try {
       args = inputSchema.parse(rawArgs);
     } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
 
     const ref = parseIssueRef(args.epic_ref);
     if (!ref) {
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({
-              ok: false,
-              error: `could not parse epic_ref: '${args.epic_ref}'`,
-            }),
-          },
-        ],
-      };
+      return envelope({ ok: false, error: `could not parse epic_ref: '${args.epic_ref}'` });
     }
+
+    // Adapter-backed fetcher: throws on error so the lib's existing try/catch
+    // contract (per-sub failures → warnings; epic failure → outer catch)
+    // is preserved verbatim.
+    const fetchIssue: IssueFetcher = async (r: IssueRef) => {
+      const repo = r.owner && r.repo ? `${r.owner}/${r.repo}` : undefined;
+      const result = await getAdapter({ repo }).fetchIssue({ number: r.number, repo });
+      if ('platform_unsupported' in result) throw new Error(result.hint);
+      if (!result.ok) throw new Error(result.error);
+      return { body: result.data.body, title: result.data.title };
+    };
 
     try {
       // Resolve bare `#N` refs against the EPIC's repo, not the MCP cwd.
       // Fall back to cwd's slug only when the epic_ref itself was bare.
-      const slug =
-        ref.owner && ref.repo ? `${ref.owner}/${ref.repo}` : parseRepoSlug();
-      const epicData = fetchIssue(ref);
-      const epicSections = parseSections(epicData.body).sections;
-      const subIssuesSection = findSubIssueSection(epicSections) ?? '';
-
-      const subs = [
-        ...parseTableSubIssues(subIssuesSection, slug),
-        ...parseBulletSubIssues(subIssuesSection, slug),
-      ];
-      // Dedup by ref.
-      const seen = new Set<string>();
-      const dedupedSubs: SubIssue[] = [];
-      for (const s of subs) {
-        if (!seen.has(s.ref)) {
-          seen.add(s.ref);
-          dedupedSubs.push(s);
-        }
-      }
-
-      // Story-self fallback: no sub-issues found → check whether the issue
-      // itself is a valid spec. If so, treat it as a single-issue single-wave
-      // plan. If not, error loudly (do NOT silently return an empty plan).
-      if (dedupedSubs.length === 0) {
-        const presence: Record<string, boolean> = {};
-        for (const [canonical, aliases] of Object.entries(REQUIRED_SECTION_ALIASES)) {
-          presence[`has_${canonical}`] = aliases.some(
-            alias => epicSections[alias] && epicSections[alias].trim().length > 0,
-          );
-        }
-        const specValid =
-          presence.has_changes && presence.has_tests && presence.has_acceptance_criteria;
-        if (!specValid) {
-          const missing = Object.entries(REQUIRED_SECTION_ALIASES)
-            .filter(([canonical]) => !presence[`has_${canonical}`])
-            .map(([canonical]) => canonical);
-          return {
-            content: [
-              {
-                type: 'text' as const,
-                text: JSON.stringify({
-                  ok: false,
-                  error: `no sub-issues found and epic spec is missing required sections: ${missing.join(', ')}`,
-                  missing_sections: missing,
-                }),
-              },
-            ],
-          };
-        }
-        const selfRef = slug ? `${slug}#${ref.number}` : `#${ref.number}`;
-        const selfNode: DepNode = {
-          ref: selfRef,
-          title: epicData.title,
-          depends_on: [],
-        };
-        const selfResult = computeWaves([selfNode]);
-        const selfResponse: {
-          ok: true;
-          epic_ref: string;
-          waves: typeof selfResult.waves;
-          topology: string;
-          reason: string;
-          total_issues: number;
-          fetched_count: number;
-          fallback_reason: string;
-        } = {
-          ok: true,
-          epic_ref: args.epic_ref,
-          waves: selfResult.waves,
-          topology: selfResult.topology,
-          reason: selfResult.reason,
-          total_issues: selfResult.total_issues,
-          fetched_count: 1,
-          fallback_reason: 'story-self',
-        };
-        return {
-          content: [
-            { type: 'text' as const, text: JSON.stringify(selfResponse) },
-          ],
-        };
-      }
-
-      // Fetch dependencies for each sub-issue.
-      const nodes: DepNode[] = [];
-      const failures: string[] = [];
-      let fetchedCount = 0;
-
-      for (const sub of dedupedSubs) {
-        const subRefParsed = parseIssueRef(sub.ref);
-        if (!subRefParsed) continue;
-        try {
-          const subData = fetchIssue(subRefParsed);
-          const subSections = parseSections(subData.body).sections;
-          // Use the sub-issue's own repo for resolving bare #N refs in ITS
-          // deps section — a heterogeneous epic (sub-issue in a different
-          // repo) has deps that live alongside the sub-issue, not the epic.
-          const subSlug =
-            subRefParsed.owner && subRefParsed.repo
-              ? `${subRefParsed.owner}/${subRefParsed.repo}`
-              : slug;
-          const deps = parseDependencies(subSections.dependencies ?? '', subSlug);
-          nodes.push({
-            ref: sub.ref,
-            title: sub.title ?? subData.title,
-            depends_on: deps,
-          });
-          fetchedCount++;
-        } catch (err) {
-          const errorMsg = err instanceof Error ? err.message : String(err);
-          failures.push(`failed to fetch ${sub.ref}: ${errorMsg}`);
-        }
-      }
-
-      // If ALL fetches failed, return ok: false
-      if (fetchedCount === 0 && dedupedSubs.length > 0) {
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                ok: false,
-                error: `all ${dedupedSubs.length} spec fetches failed: ${failures[0] ?? 'unknown error'}`,
-                issue_count: dedupedSubs.length,
-                fetched_count: 0,
-              }),
-            },
-          ],
-        };
-      }
-
-      const result = computeWaves(nodes);
-      if (result.error) {
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                ok: false,
-                error: result.error,
-                waves: result.waves,
-                total_issues: result.total_issues,
-              }),
-            },
-          ],
-        };
-      }
-
-      const response: {
-        ok: true;
-        epic_ref: string;
-        waves: typeof result.waves;
-        topology: string;
-        reason: string;
-        total_issues: number;
-        fetched_count: number;
-        warnings?: string[];
-        fallback_reason?: string;
-      } = {
-        ok: true,
-        epic_ref: args.epic_ref,
-        waves: result.waves,
-        topology: result.topology,
-        reason: result.reason,
-        total_issues: result.total_issues,
-        fetched_count: fetchedCount,
-      };
-
-      // Add warnings if SOME fetches failed
-      if (failures.length > 0) {
-        response.warnings = failures;
-      }
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(response),
-          },
-        ],
-      };
+      const slug = repoSlug(ref) ?? parseRepoSlug();
+      const result = await computeWavesForEpic(args.epic_ref, ref, slug, fetchIssue);
+      return envelope(result);
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error });
     }
   },
 };

--- a/lib/wave-compute.ts
+++ b/lib/wave-compute.ts
@@ -1,0 +1,317 @@
+// Wave-computation core — promoted out of `handlers/wave_compute.ts` during
+// Story 2.8 (#302) so the handler can be a thin adapter-dispatching shell
+// under the 80-line R-05 budget.
+//
+// This module is platform-agnostic: it consumes a caller-supplied
+// `IssueFetcher` (see `fetchIssue` param) that resolves `{ body, title }` for
+// an `IssueRef`. The adapter layer — `getAdapter().fetchIssue(...)` — lives
+// behind that injection point, keeping all markdown parsing and wave-topology
+// logic out of the handler layer and out of subprocess-contaminated code.
+//
+// Everything here is deterministic + unit-testable without mocking
+// `child_process`. Upstream tests cover the aliasing + story-self fallback
+// paths via the handler's own `tests/wave_compute.test.ts`; this module
+// intentionally does not duplicate them.
+//
+// Mirrors REQUIRED_SECTION_ALIASES in handlers/spec_validate_structure.ts
+// (lines 14-18). Kept in lockstep so the story-self fallback applies the same
+// "valid spec" test that /prepwaves uses upstream.
+
+import {
+  findSubIssueSection,
+  parseIssueRef,
+  parseSections,
+  type IssueRef,
+} from './spec_parser';
+import { computeWaves, type DepNode } from './dependency_graph';
+
+export const REQUIRED_SECTION_ALIASES: Record<string, readonly string[]> = {
+  changes: ['changes', 'implementation_steps'],
+  tests: ['tests', 'test_procedures'],
+  acceptance_criteria: ['acceptance_criteria'],
+};
+
+export interface SubIssue {
+  ref: string;
+  title?: string;
+}
+
+export interface FetchedIssue {
+  body: string;
+  title: string;
+}
+
+/** Async fetcher contract. Must throw on fetch failure. */
+export type IssueFetcher = (ref: IssueRef) => Promise<FetchedIssue>;
+
+export function normalizeRef(ref: string, currentSlug: string | null): string {
+  const urlM =
+    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/.exec(
+      ref,
+    );
+  if (urlM) return `${urlM[1]}/${urlM[2]}#${urlM[3]}`;
+
+  const crossM = /^([^/\s#]+)\/([^/\s#]+)#(\d+)$/.exec(ref);
+  if (crossM) return ref;
+
+  const shortM = /^#?(\d+)$/.exec(ref);
+  if (shortM) return currentSlug ? `${currentSlug}#${shortM[1]}` : `#${shortM[1]}`;
+  return ref;
+}
+
+export function parseTableSubIssues(
+  section: string,
+  currentSlug: string | null,
+): SubIssue[] {
+  const lines = section.split('\n').map(l => l.trim());
+  const subs: SubIssue[] = [];
+  let headerIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith('|') && lines[i].includes('|', 1)) {
+      headerIdx = i;
+      break;
+    }
+  }
+  if (headerIdx === -1) return [];
+  const headerCells = lines[headerIdx]
+    .split('|')
+    .slice(1, -1)
+    .map(c => c.trim().toLowerCase());
+  const issueCol = headerCells.findIndex(c => c.includes('issue'));
+  const titleCol = headerCells.findIndex(c => c.includes('title'));
+
+  let startRow = headerIdx + 1;
+  if (startRow < lines.length && /^\|[\s\-:|]+\|$/.test(lines[startRow])) startRow += 1;
+
+  for (let i = startRow; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.startsWith('|')) break;
+    const cells = line.split('|').slice(1, -1).map(c => c.trim());
+    const getCell = (idx: number) => (idx >= 0 && idx < cells.length ? cells[idx] : '');
+    const issueRaw = getCell(issueCol);
+    if (!issueRaw) continue;
+    subs.push({
+      ref: normalizeRef(issueRaw, currentSlug),
+      title: titleCol >= 0 ? getCell(titleCol) || undefined : undefined,
+    });
+  }
+  return subs;
+}
+
+export function parseBulletSubIssues(
+  section: string,
+  currentSlug: string | null,
+): SubIssue[] {
+  const subs: SubIssue[] = [];
+  const re = /^\s*[-*]\s*(?:\[[ xX]\]\s*)?([^\n]*)$/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(section)) !== null) {
+    const text = m[1].trim();
+    if (!text) continue;
+    const refM =
+      /(?:^|\s)([^/\s#]+\/[^/\s#]+#\d+|https?:\/\/\S+\/issues\/\d+|#\d+)/.exec(text);
+    if (!refM) continue;
+    const ref = normalizeRef(refM[1], currentSlug);
+    const title = text.replace(refM[0], '').trim().replace(/^[-:*\s]+/, '').trim();
+    subs.push({ ref, title: title || undefined });
+  }
+  return subs;
+}
+
+export function parseDependencies(
+  section: string,
+  currentSlug: string | null,
+): string[] {
+  if (!section) return [];
+  if (/^none\b/i.test(section.trim())) return [];
+  const found = new Set<string>();
+
+  const urlRe =
+    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = urlRe.exec(section)) !== null) {
+    found.add(`${m[1]}/${m[2]}#${m[3]}`);
+  }
+  const crossRe = /\b([^\s/#]+)\/([^\s/#]+)#(\d+)\b/g;
+  while ((m = crossRe.exec(section)) !== null) {
+    if (m[1].startsWith('http') || m[1].includes('.')) continue;
+    found.add(`${m[1]}/${m[2]}#${m[3]}`);
+  }
+  const shortRe = /(?<![/\w])#(\d+)\b/g;
+  while ((m = shortRe.exec(section)) !== null) {
+    const normalized = currentSlug ? `${currentSlug}#${m[1]}` : `#${m[1]}`;
+    found.add(normalized);
+  }
+  return Array.from(found);
+}
+
+/** Response envelope the handler wraps into `{content:[{text: JSON.stringify(...)}]}`. */
+export type WaveComputeResult =
+  | {
+      ok: true;
+      epic_ref: string;
+      waves: ReturnType<typeof computeWaves>['waves'];
+      topology: string;
+      reason: string;
+      total_issues: number;
+      fetched_count: number;
+      warnings?: string[];
+      fallback_reason?: string;
+    }
+  | {
+      ok: false;
+      error: string;
+      missing_sections?: string[];
+      issue_count?: number;
+      fetched_count?: number;
+      waves?: ReturnType<typeof computeWaves>['waves'];
+      total_issues?: number;
+    };
+
+/**
+ * Compute dependency-ordered waves for an epic's sub-issues.
+ *
+ * - `epicRef`       caller's raw epic_ref string (for the response envelope)
+ * - `ref`           parsed `IssueRef` of the epic (owner/repo/number)
+ * - `slug`          `owner/repo` slug to resolve bare `#N` refs in the epic body
+ * - `fetchIssue`    injected async fetcher (adapter-backed in the handler)
+ *
+ * Contract parity with the pre-migration handler (tests/wave_compute.test.ts):
+ *   - epic fetch failure throws → caller's outer try/catch surfaces `ok:false`.
+ *   - per-sub fetch failure recorded in `failures[]`; if ALL fail → ok:false.
+ *   - no sub-issues + valid-spec epic → single-wave story-self fallback.
+ *   - no sub-issues + invalid-spec epic → ok:false with `missing_sections`.
+ */
+export async function computeWavesForEpic(
+  epicRef: string,
+  ref: IssueRef,
+  slug: string | null,
+  fetchIssue: IssueFetcher,
+): Promise<WaveComputeResult> {
+  const epicData = await fetchIssue(ref);
+  const epicSections = parseSections(epicData.body).sections;
+  const subIssuesSection = findSubIssueSection(epicSections) ?? '';
+
+  const subs = [
+    ...parseTableSubIssues(subIssuesSection, slug),
+    ...parseBulletSubIssues(subIssuesSection, slug),
+  ];
+  // Dedup by ref.
+  const seen = new Set<string>();
+  const dedupedSubs: SubIssue[] = [];
+  for (const s of subs) {
+    if (!seen.has(s.ref)) {
+      seen.add(s.ref);
+      dedupedSubs.push(s);
+    }
+  }
+
+  // Story-self fallback: no sub-issues found → check whether the issue itself
+  // is a valid spec. If so, treat as a single-issue single-wave plan. If not,
+  // error loudly (do NOT silently return an empty plan).
+  if (dedupedSubs.length === 0) {
+    const presence: Record<string, boolean> = {};
+    for (const [canonical, aliases] of Object.entries(REQUIRED_SECTION_ALIASES)) {
+      presence[`has_${canonical}`] = aliases.some(
+        alias => epicSections[alias] && epicSections[alias].trim().length > 0,
+      );
+    }
+    const specValid =
+      presence.has_changes && presence.has_tests && presence.has_acceptance_criteria;
+    if (!specValid) {
+      const missing = Object.entries(REQUIRED_SECTION_ALIASES)
+        .filter(([canonical]) => !presence[`has_${canonical}`])
+        .map(([canonical]) => canonical);
+      return {
+        ok: false,
+        error: `no sub-issues found and epic spec is missing required sections: ${missing.join(', ')}`,
+        missing_sections: missing,
+      };
+    }
+    const selfRef = slug ? `${slug}#${ref.number}` : `#${ref.number}`;
+    const selfNode: DepNode = {
+      ref: selfRef,
+      title: epicData.title,
+      depends_on: [],
+    };
+    const selfResult = computeWaves([selfNode]);
+    return {
+      ok: true,
+      epic_ref: epicRef,
+      waves: selfResult.waves,
+      topology: selfResult.topology,
+      reason: selfResult.reason,
+      total_issues: selfResult.total_issues,
+      fetched_count: 1,
+      fallback_reason: 'story-self',
+    };
+  }
+
+  // Fetch dependencies for each sub-issue.
+  const nodes: DepNode[] = [];
+  const failures: string[] = [];
+  let fetchedCount = 0;
+
+  for (const sub of dedupedSubs) {
+    const subRefParsed = parseIssueRef(sub.ref);
+    if (!subRefParsed) continue;
+    try {
+      const subData = await fetchIssue(subRefParsed);
+      const subSections = parseSections(subData.body).sections;
+      // Use the sub-issue's own repo for resolving bare #N refs in ITS deps
+      // section — a heterogeneous epic (sub-issue in a different repo) has
+      // deps that live alongside the sub-issue, not the epic.
+      const subSlug =
+        subRefParsed.owner && subRefParsed.repo
+          ? `${subRefParsed.owner}/${subRefParsed.repo}`
+          : slug;
+      const deps = parseDependencies(subSections.dependencies ?? '', subSlug);
+      nodes.push({
+        ref: sub.ref,
+        title: sub.title ?? subData.title,
+        depends_on: deps,
+      });
+      fetchedCount++;
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      failures.push(`failed to fetch ${sub.ref}: ${errorMsg}`);
+    }
+  }
+
+  // If ALL fetches failed, return ok: false
+  if (fetchedCount === 0 && dedupedSubs.length > 0) {
+    return {
+      ok: false,
+      error: `all ${dedupedSubs.length} spec fetches failed: ${failures[0] ?? 'unknown error'}`,
+      issue_count: dedupedSubs.length,
+      fetched_count: 0,
+    };
+  }
+
+  const result = computeWaves(nodes);
+  if (result.error) {
+    return {
+      ok: false,
+      error: result.error,
+      waves: result.waves,
+      total_issues: result.total_issues,
+    };
+  }
+
+  const response: WaveComputeResult = {
+    ok: true,
+    epic_ref: epicRef,
+    waves: result.waves,
+    topology: result.topology,
+    reason: result.reason,
+    total_issues: result.total_issues,
+    fetched_count: fetchedCount,
+  };
+
+  // Add warnings if SOME fetches failed
+  if (failures.length > 0) {
+    response.warnings = failures;
+  }
+
+  return response;
+}

--- a/scripts/ci/migration-allowlist.txt
+++ b/scripts/ci/migration-allowlist.txt
@@ -12,7 +12,6 @@
 ci_wait_run.ts
 ibm.ts
 wave_ci_trust_level.ts
-wave_compute.ts
 wave_dependency_graph.ts
 wave_finalize.ts
 wave_init.ts


### PR DESCRIPTION
## Summary
Migrate `wave_compute` handler to the platform adapter pattern. Handler shrinks to a 67-line adapter-dispatching shell; computation logic and parsers promoted to `lib/wave-compute.ts` with an injected `IssueFetcher` so the lib stays platform-agnostic.

## Changes
- `handlers/wave_compute.ts` rewritten as thin dispatcher via `getAdapter({repo}).fetchIssue(...)` (67 lines, under R-05 80-line budget). Handler-local `fetchIssue` removed.
- `lib/wave-compute.ts` NEW — exports `REQUIRED_SECTION_ALIASES`, `normalizeRef`, `parseTableSubIssues`, `parseBulletSubIssues`, `parseDependencies`, `computeWavesForEpic`. Consumes caller-supplied `IssueFetcher`; no subprocess or platform branching.
- `scripts/ci/migration-allowlist.txt` — `wave_compute.ts` removed (now enforced by gate-greps).

## Linked Issues
Closes #302

## Test Plan
- `bun test tests/wave_compute.test.ts` — 29 pass / 0 fail (102 expects)
- `./scripts/ci/validate.sh` — codegen OK, tsc lint OK, gate-greps OK (64 non-allowlisted handlers checked), shellcheck 6/6, 1832/1832 tests pass, smoke 73/73 tools asserted