### PR TITLE
refactor(wave_dependency_graph): migrate to platform adapter (#303)

### DIFF
--- a/handlers/wave_dependency_graph.ts
+++ b/handlers/wave_dependency_graph.ts
@@ -1,11 +1,16 @@
+// Wave-family handler — adapter-dispatching shell. Subprocess + platform
+// branching live in lib/adapters/fetch-issue-{github,gitlab}.ts (Story 2.1,
+// #295); dependency-graph parsing + topology live in
+// lib/wave-dependency-graph.ts (Story 2.9, #303). This handler is dispatch +
+// envelope only.
+
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
-import { buildGraph, computeWaves, type DepNode } from '../lib/dependency_graph';
-import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { parseIssueRef, type IssueRef } from '../lib/spec_parser';
 import { parseRepoSlug } from '../lib/shared/parse-repo-slug.js';
-import { gitlabApiIssue } from '../lib/glab.js';
-import { execSync } from 'child_process';
+import { getAdapter } from '../lib/adapters/index.js';
+import type { IssueFetcher } from '../lib/wave-compute.js';
+import { computeDependencyGraph } from '../lib/wave-dependency-graph.js';
 
 const inputSchema = z
   .object({
@@ -17,74 +22,12 @@ const inputSchema = z
     'provide exactly one of issue_refs or epic_ref',
   );
 
-function fetchIssue(ref: IssueRef): { body: string; title: string } {
-  const platform = detectPlatform();
-  if (platform === 'github') {
-    const repoArg = ref.owner && ref.repo ? `--repo ${ref.owner}/${ref.repo}` : '';
-    const cmd = `gh issue view ${ref.number} ${repoArg} --json body,title`.trim();
-    const raw = execSync(cmd, { encoding: 'utf8' });
-    const parsed = JSON.parse(raw) as { body?: string; title: string };
-    return { body: parsed.body ?? '', title: parsed.title };
-  }
-  const result = gitlabApiIssue(ref.number, ref.owner && ref.repo ? { owner: ref.owner, repo: ref.repo } : undefined);
-  return { body: result.description ?? '', title: result.title };
+function envelope(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] };
 }
 
-function normalizeRef(ref: string, currentSlug: string | null): string {
-  const urlM =
-    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/.exec(
-      ref,
-    );
-  if (urlM) return `${urlM[1]}/${urlM[2]}#${urlM[3]}`;
-  const crossM = /^([^/\s#]+)\/([^/\s#]+)#(\d+)$/.exec(ref);
-  if (crossM) return ref;
-  const shortM = /^#?(\d+)$/.exec(ref);
-  if (shortM) return currentSlug ? `${currentSlug}#${shortM[1]}` : `#${shortM[1]}`;
-  return ref;
-}
-
-function parseDependencies(section: string, currentSlug: string | null): string[] {
-  if (!section || /^none\b/i.test(section.trim())) return [];
-  const found = new Set<string>();
-  const urlRe =
-    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/g;
-  let m: RegExpExecArray | null;
-  while ((m = urlRe.exec(section)) !== null) {
-    found.add(`${m[1]}/${m[2]}#${m[3]}`);
-  }
-  const crossRe = /\b([^\s/#]+)\/([^\s/#]+)#(\d+)\b/g;
-  while ((m = crossRe.exec(section)) !== null) {
-    if (m[1].startsWith('http') || m[1].includes('.')) continue;
-    found.add(`${m[1]}/${m[2]}#${m[3]}`);
-  }
-  const shortRe = /(?<![/\w])#(\d+)\b/g;
-  while ((m = shortRe.exec(section)) !== null) {
-    found.add(currentSlug ? `${currentSlug}#${m[1]}` : `#${m[1]}`);
-  }
-  return Array.from(found);
-}
-
-function resolveIssueList(
-  issueRefs: string[] | undefined,
-  epicRef: string | undefined,
-  slug: string | null,
-): string[] {
-  if (issueRefs) return issueRefs.map(r => normalizeRef(r, slug));
-  if (!epicRef) return [];
-  const ref = parseIssueRef(epicRef);
-  if (!ref) return [];
-  const epic = fetchIssue(ref);
-  const sections = parseSections(epic.body).sections;
-  const subSection =
-    sections.sub_issues ?? sections.subissues ?? sections.children ?? sections.tasks ?? '';
-  const refs: string[] = [];
-  const re = /(?:^|\s)([^/\s#]+\/[^/\s#]+#\d+|https?:\/\/\S+\/issues\/\d+|#\d+)/g;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(subSection)) !== null) {
-    refs.push(normalizeRef(m[1], slug));
-  }
-  const seen = new Set<string>();
-  return refs.filter(r => !seen.has(r) && (seen.add(r), true));
+function repoSlug(ref: IssueRef): string | undefined {
+  return ref.owner && ref.repo ? `${ref.owner}/${ref.repo}` : undefined;
 }
 
 const waveDependencyGraphHandler: HandlerDef = {
@@ -96,16 +39,23 @@ const waveDependencyGraphHandler: HandlerDef = {
     try {
       args = inputSchema.parse(rawArgs);
     } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
 
+    // Adapter-backed fetcher: throws on error so the lib's per-sub try/catch
+    // (failures → warnings; epic failure → outer catch) is preserved verbatim.
+    const fetchIssue: IssueFetcher = async (r: IssueRef) => {
+      const repo = repoSlug(r);
+      const result = await getAdapter({ repo }).fetchIssue({ number: r.number, repo });
+      if ('platform_unsupported' in result) throw new Error(result.hint);
+      if (!result.ok) throw new Error(result.error);
+      return { body: result.data.body, title: result.data.title };
+    };
+
     try {
-      // When invoked with an epic_ref, resolve bare `#N` refs against the
-      // EPIC's repo (fallback to cwd slug for bare epic refs). When invoked
-      // with issue_refs directly, there's no epic context — use cwd slug.
+      // Resolve bare `#N` refs against the EPIC's repo (fallback to cwd slug
+      // for bare epic refs). When invoked with issue_refs directly, there's no
+      // epic context — use cwd slug.
       let slug: string | null = parseRepoSlug();
       if (args.epic_ref) {
         const epicParsed = parseIssueRef(args.epic_ref);
@@ -113,100 +63,15 @@ const waveDependencyGraphHandler: HandlerDef = {
           slug = `${epicParsed.owner}/${epicParsed.repo}`;
         }
       }
-      const refs = resolveIssueList(args.issue_refs, args.epic_ref, slug);
-      if (refs.length === 0) {
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                ok: true,
-                nodes: [],
-                edges: [],
-                fetched_count: 0,
-              }),
-            },
-          ],
-        };
-      }
-
-      const nodes: DepNode[] = [];
-      const failures: string[] = [];
-      let fetchedCount = 0;
-
-      for (const ref of refs) {
-        const parsed = parseIssueRef(ref);
-        if (!parsed) continue;
-        try {
-          const data = fetchIssue(parsed);
-          const sections = parseSections(data.body).sections;
-          // Use the sub-issue's own repo slug for its deps, not the epic's.
-          const refSlug =
-            parsed.owner && parsed.repo ? `${parsed.owner}/${parsed.repo}` : slug;
-          nodes.push({
-            ref,
-            title: data.title,
-            depends_on: parseDependencies(sections.dependencies ?? '', refSlug),
-          });
-          fetchedCount++;
-        } catch (err) {
-          const errorMsg = err instanceof Error ? err.message : String(err);
-          failures.push(`failed to fetch ${ref}: ${errorMsg}`);
-        }
-      }
-
-      // If ALL fetches failed, return ok: false
-      if (fetchedCount === 0 && refs.length > 0) {
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                ok: false,
-                error: `all ${refs.length} spec fetches failed: ${failures[0] ?? 'unknown error'}`,
-                issue_count: refs.length,
-                fetched_count: 0,
-              }),
-            },
-          ],
-        };
-      }
-
-      const graph = buildGraph(nodes);
-      const waveResult = computeWaves(nodes);
-      const response: {
-        ok: true;
-        nodes: typeof graph.nodes;
-        edges: typeof graph.edges;
-        reason: string;
-        fetched_count: number;
-        warnings?: string[];
-      } = {
-        ok: true,
-        nodes: graph.nodes,
-        edges: graph.edges,
-        reason: waveResult.reason,
-        fetched_count: fetchedCount,
-      };
-
-      // Add warnings if SOME fetches failed
-      if (failures.length > 0) {
-        response.warnings = failures;
-      }
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(response),
-          },
-        ],
-      };
+      const result = await computeDependencyGraph(
+        args.issue_refs,
+        args.epic_ref,
+        slug,
+        fetchIssue,
+      );
+      return envelope(result);
     } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
   },
 };

--- a/lib/wave-dependency-graph.ts
+++ b/lib/wave-dependency-graph.ts
@@ -1,0 +1,164 @@
+// Dependency-graph core — promoted out of `handlers/wave_dependency_graph.ts`
+// during Story 2.9 (#303) so the handler can be a thin adapter-dispatching
+// shell under the 80-line R-05 budget.
+//
+// This module is platform-agnostic: it consumes a caller-supplied
+// `IssueFetcher` (reusing the contract from lib/wave-compute.ts) that resolves
+// `{ body, title }` for an `IssueRef`. The adapter layer —
+// `getAdapter().fetchIssue(...)` — lives behind that injection point, keeping
+// all markdown parsing and graph topology logic out of the handler layer and
+// out of subprocess-contaminated code.
+//
+// The dependency-parsing logic here is a near-duplicate of wave-compute's
+// (`parseDependencies`). A future refactor could share — explicitly out of
+// scope for Story 2.9 per the issue spec.
+
+import { parseIssueRef, parseSections, type IssueRef } from './spec_parser';
+import { buildGraph, computeWaves, type DepNode } from './dependency_graph';
+import type { IssueFetcher } from './wave-compute';
+
+export function normalizeRef(ref: string, currentSlug: string | null): string {
+  const urlM =
+    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/.exec(
+      ref,
+    );
+  if (urlM) return `${urlM[1]}/${urlM[2]}#${urlM[3]}`;
+  const crossM = /^([^/\s#]+)\/([^/\s#]+)#(\d+)$/.exec(ref);
+  if (crossM) return ref;
+  const shortM = /^#?(\d+)$/.exec(ref);
+  if (shortM) return currentSlug ? `${currentSlug}#${shortM[1]}` : `#${shortM[1]}`;
+  return ref;
+}
+
+export function parseDependencies(section: string, currentSlug: string | null): string[] {
+  if (!section || /^none\b/i.test(section.trim())) return [];
+  const found = new Set<string>();
+  const urlRe =
+    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = urlRe.exec(section)) !== null) {
+    found.add(`${m[1]}/${m[2]}#${m[3]}`);
+  }
+  const crossRe = /\b([^\s/#]+)\/([^\s/#]+)#(\d+)\b/g;
+  while ((m = crossRe.exec(section)) !== null) {
+    if (m[1].startsWith('http') || m[1].includes('.')) continue;
+    found.add(`${m[1]}/${m[2]}#${m[3]}`);
+  }
+  const shortRe = /(?<![/\w])#(\d+)\b/g;
+  while ((m = shortRe.exec(section)) !== null) {
+    found.add(currentSlug ? `${currentSlug}#${m[1]}` : `#${m[1]}`);
+  }
+  return Array.from(found);
+}
+
+export async function resolveIssueList(
+  issueRefs: string[] | undefined,
+  epicRef: string | undefined,
+  slug: string | null,
+  fetchIssue: IssueFetcher,
+): Promise<string[]> {
+  if (issueRefs) return issueRefs.map(r => normalizeRef(r, slug));
+  if (!epicRef) return [];
+  const ref = parseIssueRef(epicRef);
+  if (!ref) return [];
+  const epic = await fetchIssue(ref);
+  const sections = parseSections(epic.body).sections;
+  const subSection =
+    sections.sub_issues ?? sections.subissues ?? sections.children ?? sections.tasks ?? '';
+  const refs: string[] = [];
+  const re = /(?:^|\s)([^/\s#]+\/[^/\s#]+#\d+|https?:\/\/\S+\/issues\/\d+|#\d+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(subSection)) !== null) {
+    refs.push(normalizeRef(m[1], slug));
+  }
+  const seen = new Set<string>();
+  return refs.filter(r => !seen.has(r) && (seen.add(r), true));
+}
+
+/** Response envelope the handler wraps into `{content:[{text: JSON.stringify(...)}]}`. */
+export type DependencyGraphResult =
+  | {
+      ok: true;
+      nodes: ReturnType<typeof buildGraph>['nodes'];
+      edges: ReturnType<typeof buildGraph>['edges'];
+      reason?: string;
+      fetched_count: number;
+      warnings?: string[];
+    }
+  | {
+      ok: false;
+      error: string;
+      issue_count?: number;
+      fetched_count?: number;
+    };
+
+/**
+ * Build the dependency graph for an explicit issue list OR an epic's sub-issues.
+ *
+ * Contract parity with the pre-migration handler (tests/wave_dependency_graph.test.ts):
+ *   - empty refs → ok:true with empty nodes/edges.
+ *   - per-sub fetch failure recorded in `failures[]`; if ALL fail → ok:false.
+ *   - epic fetch failure throws → caller's outer try/catch surfaces ok:false.
+ */
+export async function computeDependencyGraph(
+  issueRefs: string[] | undefined,
+  epicRef: string | undefined,
+  slug: string | null,
+  fetchIssue: IssueFetcher,
+): Promise<DependencyGraphResult> {
+  const refs = await resolveIssueList(issueRefs, epicRef, slug, fetchIssue);
+  if (refs.length === 0) {
+    return { ok: true, nodes: [], edges: [], fetched_count: 0 };
+  }
+
+  const nodes: DepNode[] = [];
+  const failures: string[] = [];
+  let fetchedCount = 0;
+
+  for (const ref of refs) {
+    const parsed = parseIssueRef(ref);
+    if (!parsed) continue;
+    try {
+      const data = await fetchIssue(parsed);
+      const sections = parseSections(data.body).sections;
+      // Use the sub-issue's own repo slug for its deps, not the epic's.
+      const refSlug =
+        parsed.owner && parsed.repo ? `${parsed.owner}/${parsed.repo}` : slug;
+      nodes.push({
+        ref,
+        title: data.title,
+        depends_on: parseDependencies(sections.dependencies ?? '', refSlug),
+      });
+      fetchedCount++;
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      failures.push(`failed to fetch ${ref}: ${errorMsg}`);
+    }
+  }
+
+  if (fetchedCount === 0 && refs.length > 0) {
+    return {
+      ok: false,
+      error: `all ${refs.length} spec fetches failed: ${failures[0] ?? 'unknown error'}`,
+      issue_count: refs.length,
+      fetched_count: 0,
+    };
+  }
+
+  const graph = buildGraph(nodes);
+  const waveResult = computeWaves(nodes);
+  const response: DependencyGraphResult = {
+    ok: true,
+    nodes: graph.nodes,
+    edges: graph.edges,
+    reason: waveResult.reason,
+    fetched_count: fetchedCount,
+  };
+  if (failures.length > 0) {
+    response.warnings = failures;
+  }
+  return response;
+}
+
+/** Re-export for convenience — handlers may want the `IssueRef` type. */
+export type { IssueRef } from './spec_parser';

--- a/scripts/ci/migration-allowlist.txt
+++ b/scripts/ci/migration-allowlist.txt
@@ -12,7 +12,6 @@
 ci_wait_run.ts
 ibm.ts
 wave_ci_trust_level.ts
-wave_dependency_graph.ts
 wave_finalize.ts
 wave_init.ts
 wave_previous_merged.ts


### PR DESCRIPTION
## Summary
Migrates `wave_dependency_graph` handler to the platform adapter pattern. Handler is now a thin dispatching shell (79 lines, down from 214) that delegates graph computation to `lib/wave-dependency-graph.ts` and fetches issues via `getAdapter({repo}).fetchIssue(...)`.

## Changes
- `handlers/wave_dependency_graph.ts` — rewritten as thin adapter-dispatching shell. Removed `detectPlatform`, `gitlabApiIssue`, `execSync`, and the local `fetchIssue` helper.
- `lib/wave-dependency-graph.ts` — NEW. Promoted pure logic (`normalizeRef`, `parseDependencies`, `resolveIssueList`, `computeDependencyGraph`) from the handler. Reuses `IssueFetcher` contract from `lib/wave-compute.ts`.
- `scripts/ci/migration-allowlist.txt` — removed `wave_dependency_graph.ts`.

## Linked Issues
Closes #303

## Test Plan
- `./scripts/ci/validate.sh` — all steps green (codegen, lint, gate-greps, shellcheck, tests, smoke, 73/73 tool presence assertions)
- `bun test` — 1832 pass / 0 fail / 4503 expect() calls / 124 files
- `tests/wave_dependency_graph.test.ts` — 17/17 green, unchanged
