### PR TITLE
refactor(wave_topology): migrate to platform adapter (#304)

### DIFF
--- a/handlers/wave_topology.ts
+++ b/handlers/wave_topology.ts
@@ -1,11 +1,15 @@
+// Wave-family handler — adapter-dispatching shell. Subprocess + platform
+// branching live in lib/adapters/fetch-issue-{github,gitlab}.ts (Story 2.1,
+// #295); topology classification lives in lib/wave-topology.ts (Story 2.10,
+// #304). This handler is dispatch + envelope only.
+
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { parseIssueRef, parseSections, type IssueRef } from '../lib/spec_parser';
-import { computeWaves, type DepNode } from '../lib/dependency_graph';
-import { detectPlatform } from '../lib/shared/detect-platform.js';
+import { parseIssueRef, type IssueRef } from '../lib/spec_parser';
 import { parseRepoSlug } from '../lib/shared/parse-repo-slug.js';
-import { gitlabApiIssue } from '../lib/glab.js';
-import { execSync } from 'child_process';
+import { getAdapter } from '../lib/adapters/index.js';
+import type { IssueFetcher } from '../lib/wave-compute.js';
+import { computeTopology } from '../lib/wave-topology.js';
 
 const inputSchema = z
   .object({
@@ -17,75 +21,12 @@ const inputSchema = z
     'provide exactly one of issue_refs or epic_ref',
   );
 
-function fetchIssue(ref: IssueRef): { body: string; title: string } {
-  const platform = detectPlatform();
-  if (platform === 'github') {
-    const repoArg = ref.owner && ref.repo ? `--repo ${ref.owner}/${ref.repo}` : '';
-    const cmd = `gh issue view ${ref.number} ${repoArg} --json body,title`.trim();
-    const raw = execSync(cmd, { encoding: 'utf8' });
-    const parsed = JSON.parse(raw) as { body?: string; title: string };
-    return { body: parsed.body ?? '', title: parsed.title };
-  }
-  const result = gitlabApiIssue(ref.number, ref.owner && ref.repo ? { owner: ref.owner, repo: ref.repo } : undefined);
-  return { body: result.description ?? '', title: result.title };
+function envelope(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] };
 }
 
-function normalizeRef(ref: string, currentSlug: string | null): string {
-  const urlM =
-    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/.exec(
-      ref,
-    );
-  if (urlM) return `${urlM[1]}/${urlM[2]}#${urlM[3]}`;
-  const crossM = /^([^/\s#]+)\/([^/\s#]+)#(\d+)$/.exec(ref);
-  if (crossM) return ref;
-  const shortM = /^#?(\d+)$/.exec(ref);
-  if (shortM) return currentSlug ? `${currentSlug}#${shortM[1]}` : `#${shortM[1]}`;
-  return ref;
-}
-
-function parseDependencies(section: string, currentSlug: string | null): string[] {
-  if (!section || /^none\b/i.test(section.trim())) return [];
-  const found = new Set<string>();
-  const urlRe =
-    /https?:\/\/(?:github\.com|gitlab\.com)\/([^\s/]+)\/([^\s/]+)\/(?:-\/)?issues\/(\d+)/g;
-  let m: RegExpExecArray | null;
-  while ((m = urlRe.exec(section)) !== null) {
-    found.add(`${m[1]}/${m[2]}#${m[3]}`);
-  }
-  const crossRe = /\b([^\s/#]+)\/([^\s/#]+)#(\d+)\b/g;
-  while ((m = crossRe.exec(section)) !== null) {
-    if (m[1].startsWith('http') || m[1].includes('.')) continue;
-    found.add(`${m[1]}/${m[2]}#${m[3]}`);
-  }
-  const shortRe = /(?<![/\w])#(\d+)\b/g;
-  while ((m = shortRe.exec(section)) !== null) {
-    found.add(currentSlug ? `${currentSlug}#${m[1]}` : `#${m[1]}`);
-  }
-  return Array.from(found);
-}
-
-function resolveIssueList(
-  issueRefs: string[] | undefined,
-  epicRef: string | undefined,
-  slug: string | null,
-): string[] {
-  if (issueRefs) return issueRefs.map(r => normalizeRef(r, slug));
-  if (!epicRef) return [];
-  const ref = parseIssueRef(epicRef);
-  if (!ref) return [];
-  const epic = fetchIssue(ref);
-  const sections = parseSections(epic.body).sections;
-  const subSection =
-    sections.sub_issues ?? sections.subissues ?? sections.children ?? sections.tasks ?? '';
-  const refs: string[] = [];
-  const re = /(?:^|\s)([^/\s#]+\/[^/\s#]+#\d+|https?:\/\/\S+\/issues\/\d+|#\d+)/g;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(subSection)) !== null) {
-    refs.push(normalizeRef(m[1], slug));
-  }
-  // Dedup preserving order.
-  const seen = new Set<string>();
-  return refs.filter(r => !seen.has(r) && (seen.add(r), true));
+function repoSlug(ref: IssueRef): string | undefined {
+  return ref.owner && ref.repo ? `${ref.owner}/${ref.repo}` : undefined;
 }
 
 const waveTopologyHandler: HandlerDef = {
@@ -97,16 +38,23 @@ const waveTopologyHandler: HandlerDef = {
     try {
       args = inputSchema.parse(rawArgs);
     } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
 
+    // Adapter-backed fetcher: throws on error so the lib's per-sub try/catch
+    // (failures → warnings; epic failure → outer catch) is preserved verbatim.
+    const fetchIssue: IssueFetcher = async (r: IssueRef) => {
+      const repo = repoSlug(r);
+      const result = await getAdapter({ repo }).fetchIssue({ number: r.number, repo });
+      if ('platform_unsupported' in result) throw new Error(result.hint);
+      if (!result.ok) throw new Error(result.error);
+      return { body: result.data.body, title: result.data.title };
+    };
+
     try {
-      // When invoked with an epic_ref, resolve bare `#N` refs against the
-      // EPIC's repo (fallback to cwd slug for bare epic refs). When invoked
-      // with issue_refs directly, there's no epic context — use cwd slug.
+      // Resolve bare `#N` refs against the EPIC's repo (fallback to cwd slug
+      // for bare epic refs). When invoked with issue_refs directly, there's no
+      // epic context — use cwd slug.
       let slug: string | null = parseRepoSlug();
       if (args.epic_ref) {
         const epicParsed = parseIssueRef(args.epic_ref);
@@ -114,121 +62,15 @@ const waveTopologyHandler: HandlerDef = {
           slug = `${epicParsed.owner}/${epicParsed.repo}`;
         }
       }
-      const refs = resolveIssueList(args.issue_refs, args.epic_ref, slug);
-      if (refs.length === 0) {
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                ok: true,
-                topology: 'serial',
-                reason: 'no issues',
-                wave_count: 0,
-                max_parallelism: 0,
-                issue_count: 0,
-                fetched_count: 0,
-              }),
-            },
-          ],
-        };
-      }
-
-      const nodes: DepNode[] = [];
-      const failures: string[] = [];
-      let fetchedCount = 0;
-
-      for (const ref of refs) {
-        const parsed = parseIssueRef(ref);
-        if (!parsed) continue;
-        try {
-          const data = fetchIssue(parsed);
-          const sections = parseSections(data.body).sections;
-          // Use the sub-issue's own repo slug for its deps, not the epic's.
-          const refSlug =
-            parsed.owner && parsed.repo ? `${parsed.owner}/${parsed.repo}` : slug;
-          nodes.push({
-            ref,
-            depends_on: parseDependencies(sections.dependencies ?? '', refSlug),
-          });
-          fetchedCount++;
-        } catch (err) {
-          const errorMsg = err instanceof Error ? err.message : String(err);
-          failures.push(`failed to fetch ${ref}: ${errorMsg}`);
-        }
-      }
-
-      // If ALL fetches failed, return ok: false
-      if (fetchedCount === 0 && refs.length > 0) {
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                ok: false,
-                error: `all ${refs.length} spec fetches failed: ${failures[0] ?? 'unknown error'}`,
-                issue_count: refs.length,
-                fetched_count: 0,
-              }),
-            },
-          ],
-        };
-      }
-
-      const result = computeWaves(nodes);
-      if (result.error) {
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({ ok: false, error: result.error }),
-            },
-          ],
-        };
-      }
-
-      const maxParallelism = result.waves.reduce(
-        (max, w) => Math.max(max, w.issues.length),
-        0,
+      const result = await computeTopology(
+        args.issue_refs,
+        args.epic_ref,
+        slug,
+        fetchIssue,
       );
-
-      const response: {
-        ok: true;
-        topology: string;
-        reason: string;
-        wave_count: number;
-        max_parallelism: number;
-        issue_count: number;
-        fetched_count: number;
-        warnings?: string[];
-      } = {
-        ok: true,
-        topology: result.topology,
-        reason: result.reason,
-        wave_count: result.waves.length,
-        max_parallelism: maxParallelism,
-        issue_count: refs.length,
-        fetched_count: fetchedCount,
-      };
-
-      // Add warnings if SOME fetches failed
-      if (failures.length > 0) {
-        response.warnings = failures;
-      }
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(response),
-          },
-        ],
-      };
+      return envelope(result);
     } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
   },
 };

--- a/lib/wave-topology.ts
+++ b/lib/wave-topology.ts
@@ -1,0 +1,125 @@
+// Topology-classification core — promoted out of `handlers/wave_topology.ts`
+// during Story 2.10 (#304) so the handler can be a thin adapter-dispatching
+// shell under the 80-line R-05 budget. Mirrors the shape of
+// `lib/wave-dependency-graph.ts` (Story 2.9, #303) and reuses its
+// markdown-parsing helpers (`normalizeRef`, `parseDependencies`,
+// `resolveIssueList`) to stay DRY.
+//
+// Platform-agnostic: consumes a caller-supplied `IssueFetcher` (reusing the
+// contract from lib/wave-compute.ts). The adapter layer —
+// `getAdapter().fetchIssue(...)` — lives behind that injection point, keeping
+// all markdown parsing and topology logic out of the handler layer and out
+// of subprocess-contaminated code.
+
+import { parseIssueRef } from './spec_parser';
+import { parseSections } from './spec_parser';
+import { computeWaves, type DepNode } from './dependency_graph';
+import {
+  parseDependencies,
+  resolveIssueList,
+} from './wave-dependency-graph';
+import type { IssueFetcher } from './wave-compute';
+
+/** Response envelope the handler wraps into `{content:[{text: JSON.stringify(...)}]}`. */
+export type TopologyResult =
+  | {
+      ok: true;
+      topology: string;
+      reason: string;
+      wave_count: number;
+      max_parallelism: number;
+      issue_count: number;
+      fetched_count: number;
+      warnings?: string[];
+    }
+  | {
+      ok: false;
+      error: string;
+      issue_count?: number;
+      fetched_count?: number;
+    };
+
+/**
+ * Classify the topology of an explicit issue list OR an epic's sub-issues.
+ *
+ * Contract parity with the pre-migration handler (tests/wave_topology.test.ts):
+ *   - empty refs → ok:true serial/0-waves sentinel.
+ *   - per-sub fetch failure recorded in `failures[]`; if ALL fail → ok:false.
+ *   - epic fetch failure throws → caller's outer try/catch surfaces ok:false.
+ */
+export async function computeTopology(
+  issueRefs: string[] | undefined,
+  epicRef: string | undefined,
+  slug: string | null,
+  fetchIssue: IssueFetcher,
+): Promise<TopologyResult> {
+  const refs = await resolveIssueList(issueRefs, epicRef, slug, fetchIssue);
+  if (refs.length === 0) {
+    return {
+      ok: true,
+      topology: 'serial',
+      reason: 'no issues',
+      wave_count: 0,
+      max_parallelism: 0,
+      issue_count: 0,
+      fetched_count: 0,
+    };
+  }
+
+  const nodes: DepNode[] = [];
+  const failures: string[] = [];
+  let fetchedCount = 0;
+
+  for (const ref of refs) {
+    const parsed = parseIssueRef(ref);
+    if (!parsed) continue;
+    try {
+      const data = await fetchIssue(parsed);
+      const sections = parseSections(data.body).sections;
+      // Use the sub-issue's own repo slug for its deps, not the epic's.
+      const refSlug =
+        parsed.owner && parsed.repo ? `${parsed.owner}/${parsed.repo}` : slug;
+      nodes.push({
+        ref,
+        depends_on: parseDependencies(sections.dependencies ?? '', refSlug),
+      });
+      fetchedCount++;
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      failures.push(`failed to fetch ${ref}: ${errorMsg}`);
+    }
+  }
+
+  if (fetchedCount === 0 && refs.length > 0) {
+    return {
+      ok: false,
+      error: `all ${refs.length} spec fetches failed: ${failures[0] ?? 'unknown error'}`,
+      issue_count: refs.length,
+      fetched_count: 0,
+    };
+  }
+
+  const result = computeWaves(nodes);
+  if (result.error) {
+    return { ok: false, error: result.error };
+  }
+
+  const maxParallelism = result.waves.reduce(
+    (max, w) => Math.max(max, w.issues.length),
+    0,
+  );
+
+  const response: TopologyResult = {
+    ok: true,
+    topology: result.topology,
+    reason: result.reason,
+    wave_count: result.waves.length,
+    max_parallelism: maxParallelism,
+    issue_count: refs.length,
+    fetched_count: fetchedCount,
+  };
+  if (failures.length > 0) {
+    response.warnings = failures;
+  }
+  return response;
+}

--- a/scripts/ci/migration-allowlist.txt
+++ b/scripts/ci/migration-allowlist.txt
@@ -16,4 +16,3 @@ wave_finalize.ts
 wave_init.ts
 wave_previous_merged.ts
 wave_reconcile_mrs.ts
-wave_topology.ts


### PR DESCRIPTION
## Summary
Migrate `wave_topology` handler from platform-branching (execSync `gh issue view` + `gitlabApiIssue` + `detectPlatform`) to the platform adapter pattern. Handler shrinks from 237 lines to a 78-line adapter-dispatch shell modeled on `wave_dependency_graph`.

## Changes
- `handlers/wave_topology.ts`: replaced platform-branching shell with adapter-dispatch via `getAdapter({repo}).fetchIssue(...)` through an `IssueFetcher` shim.
- `lib/wave-topology.ts`: NEW. Exports `computeTopology(...)` — platform-agnostic core. Reuses `parseDependencies` + `resolveIssueList` from `lib/wave-dependency-graph.ts` to stay DRY.
- `scripts/ci/migration-allowlist.txt`: removed `wave_topology.ts` (7 handlers remaining on the allowlist).
- `tests/wave_topology.test.ts`: UNCHANGED — `mock.module('child_process', ...)` transparently intercepts the adapter layer.

## Linked Issues
Closes #304

## Test Plan
- `./scripts/ci/validate.sh` → exit 0, 73/73 per-tool assertions
- `./scripts/ci/gate-greps.sh` → OK (66 non-allowlisted handlers)
- `bun test tests/wave_topology.test.ts` → 15 pass / 0 fail / 51 expect() calls
- `bun test` (full suite) → 1832 pass / 0 fail / 4503 expect() calls across 124 files