### PR TITLE
refactor(ci_wait_run): migrate to platform adapter + land ciListRuns + resolveBranchSha (#313)

### DIFF
--- a/handlers/ci_wait_run.ts
+++ b/handlers/ci_wait_run.ts
@@ -1,14 +1,20 @@
-// Origin Operations family handler.
-// See docs/handlers/origin-operations-guide.md for the canonical pattern,
-// gh ↔ glab field mappings, and normalized response schemas.
+// Origin Operations family handler — adapter-dispatching shell.
+// Subprocess + platform branching + the phased state machine live in
+// lib/ci-wait-run-poll.ts and lib/adapters/ci-list-runs-{github,gitlab}.ts /
+// resolve-branch-sha-{github,gitlab}.ts per Story 2.19 (#313). See
+// docs/handlers/origin-operations-guide.md for the canonical pattern and
+// docs/platform-adapter-retrofit-devspec.md §5 for the contract.
 
-import { execSync } from 'child_process';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
+import { getAdapter } from '../lib/adapters/index.js';
 import { detectPlatform } from '../lib/shared/detect-platform.js';
 import { parseRepoSlug } from '../lib/shared/parse-repo-slug.js';
-import { gitlabApiCiList, type GitlabPipeline } from '../lib/glab.js';
-import { log } from '../logger.js';
+import {
+  waitForRun,
+  defaultSleep,
+  type WaitResult,
+} from '../lib/ci-wait-run-poll.js';
 
 const inputSchema = z
   .object({
@@ -20,10 +26,6 @@ const inputSchema = z
       .string()
       .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/, 'repo must be in owner/repo form')
       .optional(),
-    // Issue #259: anchor the wait to a specific commit SHA. When provided, the
-    // tool only returns runs whose head SHA equals expected_sha, polling until
-    // such a run appears (within timeout_sec) and then completes. Without it,
-    // the existing "most recent matching run" behavior is preserved.
     expected_sha: z
       .string()
       .regex(/^[0-9a-f]{40}$/i, 'expected_sha must be a 40-char hex commit SHA')
@@ -31,347 +33,28 @@ const inputSchema = z
   })
   .strict();
 
-type Input = z.infer<typeof inputSchema>;
-
-// Defaults.
-const DEFAULT_POLL_INTERVAL_SEC = 10;
-const MIN_POLL_INTERVAL_SEC = 5; // hard floor
-const DEFAULT_TIMEOUT_SEC = 1800; // 30 minutes
-const NO_RUN_YET_WINDOW_SEC = 60; // wait up to 60s for a run to appear before main loop
-const NO_RUN_YET_POLL_SEC = 5; // how often to poll during the no-run-yet window
-
-// Final-status domain (what we return to the caller).
-// `not_applicable` covers merge-queue-only repos whose CI has no push:main
-// trigger — there's nothing to wait on, but the merge_group run that gated
-// the PR already ran and we can surface that fact distinctly from failure.
-type FinalStatus =
-  | 'success'
-  | 'failure'
-  | 'cancelled'
-  | 'timed_out'
-  | 'not_applicable';
-
 // --- injectable sleep (tests replace with a no-op) ---
-let sleepFn: (ms: number) => Promise<void> = (ms) =>
-  new Promise((resolve) => setTimeout(resolve, ms));
-
+let sleepFn: (ms: number) => Promise<void> = defaultSleep;
 export function __setSleep(fn: (ms: number) => Promise<void>): void {
   sleepFn = fn;
 }
-
 export function __resetSleep(): void {
-  sleepFn = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  sleepFn = defaultSleep;
 }
 
-// --- small helpers ---
-
-function exec(cmd: string): string {
-  return execSync(cmd, { encoding: 'utf8' }).trim();
+function envelope(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] };
 }
 
-function isSha(ref: string): boolean {
-  return /^[0-9a-f]{40}$/i.test(ref);
-}
-
-function shortRef(ref: string): string {
-  return isSha(ref) ? ref.slice(0, 7) : ref;
-}
-
-function logPoll(ref: string, elapsedSec: number, status: string): void {
-  log.debug('poll', { tool: 'ci_wait_run', ref: shortRef(ref), elapsed_sec: elapsedSec, status });
-}
-
-// --- normalized poll result ---
-interface RunSnapshot {
-  run_id: number;
-  workflow_name: string;
-  status: string; // raw platform status: "queued" | "in_progress" | "completed" | ...
-  conclusion: string | null; // only populated when completed
-  url: string;
-  sha: string;
-}
-
-// Shell-quote a value so it is safe inside double quotes.
-function shellQuote(value: string): string {
-  return value.replace(/(["\\$`])/g, '\\$1');
-}
-
-// Split a validated `owner/repo` slug into the opts shape expected by
-// lib/glab.ts wrappers. Returns undefined when repo is not provided so
-// callers fall back to cwd resolution.
-function splitRepoSlug(
-  repo: string | undefined,
-): { owner: string; repo: string } | undefined {
-  if (!repo) return undefined;
-  const [owner, name] = repo.split('/', 2);
-  return { owner, repo: name };
-}
-
-// Resolve a branch ref to its HEAD commit SHA via `gh api`.
-// Only invoked when we need to compare a branch ref against a run.headSha
-// (e.g. merge-queue fallback). Uses the same authenticated gh subprocess
-// pattern the rest of the handler relies on. Returns null if resolution
-// fails for any reason — the caller treats that as "no SHA match".
-function resolveBranchToSha(slug: string, branch: string): string | null {
-  try {
-    const sha = exec(
-      `gh api repos/${slug}/git/refs/heads/${shellQuote(branch)} --jq .object.sha`
-    );
-    if (/^[0-9a-f]{40}$/i.test(sha)) return sha;
-    return null;
-  } catch {
-    return null;
+// WaitResult → response envelope. Drops undefined fields so the shape matches
+// the pre-migration handler byte-for-byte (optional fields omitted, not null).
+function resultToEnvelope(result: WaitResult) {
+  const payload: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(result)) {
+    if (v !== undefined) payload[k] = v;
   }
+  return envelope(payload);
 }
-
-// --- GitHub polling ---
-
-function githubListCmd(
-  ref: string,
-  workflowName: string | undefined,
-  repo: string | undefined,
-  expectedSha: string | undefined,
-): string {
-  const quotedRef = shellQuote(ref);
-  // When expected_sha is set, the SHA filter is the authoritative anchor —
-  // always pass it as --commit. Per spec (#259), also pass --branch when the
-  // ref is a branch name, so gh narrows by both branch and commit.
-  let refFlag: string;
-  if (expectedSha) {
-    const quotedSha = shellQuote(expectedSha);
-    refFlag = isSha(ref)
-      ? `--commit "${quotedSha}"`
-      : `--branch "${quotedRef}" --commit "${quotedSha}"`;
-  } else {
-    refFlag = isSha(ref) ? `--commit "${quotedRef}"` : `--branch "${quotedRef}"`;
-  }
-  const workflowFlag = workflowName
-    ? ` --workflow "${shellQuote(workflowName)}"`
-    : '';
-  const repoFlag = repo ? ` --repo "${shellQuote(repo)}"` : '';
-  // Pull a generous set of fields so we can surface good error messages.
-  return `gh run list ${refFlag}${workflowFlag}${repoFlag} --limit 20 --json databaseId,name,status,conclusion,url,headSha,headBranch,workflowName,createdAt,event`;
-}
-
-interface GithubRun {
-  databaseId: number;
-  name?: string;
-  workflowName?: string;
-  status: string;
-  conclusion: string | null;
-  url: string;
-  headSha: string;
-  headBranch?: string;
-  createdAt?: string;
-  event?: string;
-}
-
-function fetchGithubRuns(
-  ref: string,
-  workflowName: string | undefined,
-  repo: string | undefined,
-  expectedSha: string | undefined,
-): GithubRun[] {
-  const cmd = githubListCmd(ref, workflowName, repo, expectedSha);
-  let raw: string;
-  try {
-    raw = exec(cmd);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(
-      `gh run list failed for ref '${ref}': ${msg}. Is 'gh' authenticated and is the ref pushed to origin?`
-    );
-  }
-  if (!raw) return [];
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    throw new Error(`gh run list returned non-JSON output: ${raw.slice(0, 200)}`);
-  }
-  if (!Array.isArray(parsed)) {
-    throw new Error(
-      `gh run list returned unexpected shape (expected array): ${String(parsed).slice(0, 200)}`
-    );
-  }
-  return parsed as GithubRun[];
-}
-
-function pickGithubRun(
-  runs: GithubRun[],
-  workflowName: string | undefined
-): GithubRun | null {
-  if (runs.length === 0) return null;
-  const filtered = workflowName
-    ? runs.filter(
-        (r) => r.workflowName === workflowName || r.name === workflowName
-      )
-    : runs;
-  if (filtered.length === 0) return null;
-  // Prefer the newest run when multiple match. gh already returns in reverse chrono order,
-  // but be explicit so tests don't depend on that.
-  const sorted = [...filtered].sort((a, b) => {
-    const at = a.createdAt ? Date.parse(a.createdAt) : 0;
-    const bt = b.createdAt ? Date.parse(b.createdAt) : 0;
-    return bt - at;
-  });
-  return sorted[0];
-}
-
-function githubSnapshot(run: GithubRun): RunSnapshot {
-  return {
-    run_id: run.databaseId,
-    workflow_name: run.workflowName ?? run.name ?? '(unknown)',
-    status: run.status,
-    conclusion: run.conclusion ?? null,
-    url: run.url,
-    sha: run.headSha,
-  };
-}
-
-// --- GitLab polling ---
-
-function fetchGitlabPipelines(
-  ref: string,
-  repo: string | undefined,
-  expectedSha: string | undefined,
-): GitlabPipeline[] {
-  try {
-    const opts = splitRepoSlug(repo);
-    return gitlabApiCiList({ ref, limit: 20, sha: expectedSha }, opts);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(
-      `GitLab API pipelines list failed for ref '${ref}': ${msg}. Is 'glab' authenticated and is the ref pushed to origin?`
-    );
-  }
-}
-
-function pickGitlabPipeline(
-  pipelines: GitlabPipeline[],
-  workflowName: string | undefined
-): GitlabPipeline | null {
-  if (pipelines.length === 0) return null;
-  // GitLab doesn't really have "workflow names" the way GH Actions does; filter by `source`
-  // if the caller asked, otherwise take the newest.
-  const filtered = workflowName
-    ? pipelines.filter((p) => p.source === workflowName)
-    : pipelines;
-  if (filtered.length === 0) return null;
-  const sorted = [...filtered].sort((a, b) => {
-    const at = a.created_at;
-    const bt = b.created_at;
-    const ap = at ? Date.parse(at) : 0;
-    const bp = bt ? Date.parse(bt) : 0;
-    return bp - ap;
-  });
-  return sorted[0];
-}
-
-// GitLab pipeline status values: created, waiting_for_resource, preparing, pending, running,
-// success, failed, canceled, skipped, manual, scheduled.
-// Normalize to the same vocabulary the handler uses internally.
-function normalizeGitlabStatus(status: string): {
-  status: string;
-  conclusion: string | null;
-} {
-  switch (status) {
-    case 'success':
-      return { status: 'completed', conclusion: 'success' };
-    case 'failed':
-      return { status: 'completed', conclusion: 'failure' };
-    case 'canceled':
-    case 'cancelled':
-      return { status: 'completed', conclusion: 'cancelled' };
-    case 'skipped':
-      // Treat skipped as success — there's nothing to wait on.
-      return { status: 'completed', conclusion: 'success' };
-    case 'running':
-    case 'pending':
-    case 'preparing':
-    case 'waiting_for_resource':
-    case 'created':
-    case 'scheduled':
-    case 'manual':
-      return { status: 'in_progress', conclusion: null };
-    default:
-      return { status, conclusion: null };
-  }
-}
-
-function gitlabSnapshot(pipeline: GitlabPipeline): RunSnapshot {
-  const normalized = normalizeGitlabStatus(pipeline.status);
-  return {
-    run_id: pipeline.id,
-    workflow_name: pipeline.source ?? '(gitlab pipeline)',
-    status: normalized.status,
-    conclusion: normalized.conclusion,
-    url: pipeline.web_url,
-    sha: pipeline.sha,
-  };
-}
-
-// --- unified fetch ---
-
-function fetchSnapshot(
-  platform: 'github' | 'gitlab',
-  ref: string,
-  workflowName: string | undefined,
-  repo: string | undefined,
-  expectedSha: string | undefined,
-): RunSnapshot | null {
-  if (platform === 'github') {
-    const runs = fetchGithubRuns(ref, workflowName, repo, expectedSha);
-    // Defense-in-depth: even if gh somehow returns runs that don't match the
-    // SHA filter (e.g. server-side filter quirks), drop any whose headSha
-    // doesn't equal expected_sha. This is what makes the "ignores other runs
-    // on the same branch" guarantee airtight.
-    const filtered = expectedSha
-      ? runs.filter(
-          (r) => r.headSha?.toLowerCase() === expectedSha.toLowerCase(),
-        )
-      : runs;
-    const picked = pickGithubRun(filtered, workflowName);
-    return picked ? githubSnapshot(picked) : null;
-  }
-  const pipelines = fetchGitlabPipelines(ref, repo, expectedSha);
-  // Same defense-in-depth for GitLab — only return pipelines whose sha
-  // matches when expected_sha is provided.
-  const filtered = expectedSha
-    ? pipelines.filter(
-        (p) => p.sha?.toLowerCase() === expectedSha.toLowerCase(),
-      )
-    : pipelines;
-  const picked = pickGitlabPipeline(filtered, workflowName);
-  return picked ? gitlabSnapshot(picked) : null;
-}
-
-// --- conclusion normalization (GitHub conclusions: success, failure, cancelled,
-//     timed_out, action_required, neutral, skipped, stale) ---
-
-function normalizeConclusion(
-  conclusion: string | null
-): FinalStatus | 'unknown' {
-  if (!conclusion) return 'unknown';
-  switch (conclusion) {
-    case 'success':
-    case 'skipped':
-    case 'neutral':
-      return 'success';
-    case 'failure':
-    case 'timed_out':
-    case 'action_required':
-    case 'stale':
-      return 'failure';
-    case 'cancelled':
-    case 'canceled':
-      return 'cancelled';
-    default:
-      return 'unknown';
-  }
-}
-
-// --- the main handler ---
 
 const ciWaitRunHandler: HandlerDef = {
   name: 'ci_wait_run',
@@ -379,243 +62,18 @@ const ciWaitRunHandler: HandlerDef = {
     "Block on a CI workflow/pipeline run for a commit SHA or branch ref, polling server-side until it completes or times out. Returns the final status without burning agent tokens in a busy-wait loop. Merge-queue-only GitHub repos (workflows gated on `merge_group`/`pull_request` with no `push` trigger) are handled specially: if no push-triggered runs exist for the ref but a `merge_group` run matches its HEAD SHA, returns `final_status: \"not_applicable\"` with `reason: \"merge_group_validated\"` — distinguishable from a real failure.",
   inputSchema,
   async execute(rawArgs: unknown) {
-    let args: Input;
+    let args: z.infer<typeof inputSchema>;
     try {
-      args = inputSchema.parse(rawArgs) as Input;
+      args = inputSchema.parse(rawArgs);
     } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
-
-    // Enforce hard floor on poll interval.
-    const requestedInterval = args.poll_interval_sec ?? DEFAULT_POLL_INTERVAL_SEC;
-    const pollIntervalSec = Math.max(requestedInterval, MIN_POLL_INTERVAL_SEC);
-    const timeoutSec = args.timeout_sec ?? DEFAULT_TIMEOUT_SEC;
-    const ref = args.ref;
-    const workflowName = args.workflow_name;
-    const repo = args.repo;
-    // Issue #259: when expected_sha is provided, the wait is anchored to a
-    // specific commit. The no-run-yet window must be the full timeout (the
-    // new run for that SHA may legitimately take minutes to register), not
-    // the default 60s.
-    const expectedSha = args.expected_sha?.toLowerCase();
-    const noRunYetWindowSec = expectedSha ? timeoutSec : NO_RUN_YET_WINDOW_SEC;
-
     const platform = detectPlatform();
-    const startMs = Date.now();
-    const elapsedSec = (): number =>
-      Math.floor((Date.now() - startMs) / 1000);
-
-    try {
-      // --- Phase 0 (GitHub only): merge-queue pre-flight ---
-      // If the ref has NO push-triggered runs but DOES have a merge_group run
-      // matching its HEAD SHA, treat that as validation — don't wait for a
-      // push-triggered run that will never arrive.
-      if (platform === 'github') {
-        const initialRuns = fetchGithubRuns(ref, workflowName, repo, expectedSha);
-        if (initialRuns.length > 0) {
-          const anyPush = initialRuns.some((r) => r.event === 'push');
-          if (!anyPush) {
-            // Resolve ref to a HEAD SHA for comparison against run.headSha.
-            // Issue #259: when expected_sha is provided, that IS the head SHA
-            // we care about — skip the branch-to-SHA resolution.
-            let headSha: string | null = expectedSha ?? (isSha(ref) ? ref.toLowerCase() : null);
-            if (!headSha) {
-              // When `repo` is explicitly provided, skip cwd-based slug
-              // parsing and pass the caller's slug directly.
-              const slug = repo ?? parseRepoSlug();
-              if (slug) headSha = resolveBranchToSha(slug, ref);
-            }
-            const mergeGroupMatch = initialRuns.find(
-              (r) =>
-                r.event === 'merge_group' &&
-                headSha !== null &&
-                r.headSha?.toLowerCase() === headSha
-            );
-            if (mergeGroupMatch) {
-              return {
-                content: [
-                  {
-                    type: 'text' as const,
-                    text: JSON.stringify({
-                      ok: true,
-                      final_status: 'not_applicable' satisfies FinalStatus,
-                      reason: 'merge_group_validated',
-                      run_id: mergeGroupMatch.databaseId,
-                      workflow_name:
-                        mergeGroupMatch.workflowName ??
-                        mergeGroupMatch.name ??
-                        '(unknown)',
-                      url: mergeGroupMatch.url,
-                      ref,
-                      sha: mergeGroupMatch.headSha,
-                      waited_sec: 0,
-                    }),
-                  },
-                ],
-              };
-            }
-            // No push-triggered runs and no matching merge_group run. Fail
-            // fast with a structured not_applicable error — distinguishable
-            // from a real CI failure and from a generic timeout.
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({
-                    ok: false,
-                    final_status: 'not_applicable' satisfies FinalStatus,
-                    error: `ref '${ref}' has no push-triggered workflows and no matching merge_group run found`,
-                    ref,
-                  }),
-                },
-              ],
-            };
-          }
-          // At least one push-triggered run exists — fall through to the
-          // existing poll loop. (Phase 1 will re-fetch and pick up the run.)
-        }
-        // Empty initial list → fall through; existing phase 1 handles
-        // no-run-yet window and the "no CI run found" error.
-      }
-
-      // --- Phase 1: wait for a run to appear (no-run-yet window) ---
-      // When expected_sha is set the window equals timeout_sec so we don't
-      // give up early on a new run that just hasn't registered yet (#259).
-      let snapshot: RunSnapshot | null = null;
-      while (elapsedSec() < noRunYetWindowSec) {
-        snapshot = fetchSnapshot(platform, ref, workflowName, repo, expectedSha);
-        if (snapshot) break;
-        logPoll(ref, elapsedSec(), 'no_run_yet');
-        // Also honor the overall timeout — don't exceed it here.
-        if (elapsedSec() >= timeoutSec) break;
-        // Use the configured poll interval when waiting for a specific SHA;
-        // the 5s default is too aggressive over a long timeout.
-        const sleepSec = expectedSha ? pollIntervalSec : NO_RUN_YET_POLL_SEC;
-        await sleepFn(sleepSec * 1000);
-      }
-
-      if (!snapshot) {
-        // No run appeared in the window. That's a timeout, but with a specific explanation.
-        const waited = elapsedSec();
-        const filterMsg = workflowName
-          ? ` (filtered by workflow_name='${workflowName}')`
-          : '';
-        const shaMsg = expectedSha
-          ? ` with head SHA '${expectedSha}'`
-          : '';
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                ok: false,
-                error: `No CI run found for ref '${ref}'${shaMsg}${filterMsg} after waiting ${waited}s. The pipeline may not have been triggered, or the ref has not been pushed to origin. Verify with: gh run list --${isSha(ref) ? 'commit' : 'branch'} ${ref}`,
-                waited_sec: waited,
-                ref,
-                platform,
-                ...(expectedSha ? { expected_sha: expectedSha } : {}),
-              }),
-            },
-          ],
-        };
-      }
-
-      // --- Phase 2: poll the run until it completes or we time out ---
-      // Log the first snapshot we picked up.
-      logPoll(ref, elapsedSec(), snapshot.status);
-
-      while (snapshot.status !== 'completed') {
-        if (elapsedSec() >= timeoutSec) {
-          return {
-            content: [
-              {
-                type: 'text' as const,
-                text: JSON.stringify({
-                  ok: true,
-                  run_id: snapshot.run_id,
-                  workflow_name: snapshot.workflow_name,
-                  final_status: 'timed_out' satisfies FinalStatus,
-                  url: snapshot.url,
-                  ref,
-                  sha: snapshot.sha,
-                  waited_sec: elapsedSec(),
-                  message: `ci_wait_run hit timeout_sec=${timeoutSec} while run was still '${snapshot.status}'. The run is still executing on the server — check ${snapshot.url}.`,
-                }),
-              },
-            ],
-          };
-        }
-        await sleepFn(pollIntervalSec * 1000);
-        // Refresh snapshot.
-        const next = fetchSnapshot(platform, ref, workflowName, repo, expectedSha);
-        if (!next) {
-          // Unusual — the run vanished between polls. Keep the previous snapshot and log.
-          logPoll(ref, elapsedSec(), `${snapshot.status}(stale,no_run_returned)`);
-          continue;
-        }
-        snapshot = next;
-        logPoll(ref, elapsedSec(), snapshot.status);
-      }
-
-      // --- Phase 3: completed — map conclusion to final_status ---
-      const finalStatus = normalizeConclusion(snapshot.conclusion);
-      if (finalStatus === 'unknown') {
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                ok: false,
-                error: `Run completed with unrecognized conclusion '${snapshot.conclusion ?? 'null'}'. run_id=${snapshot.run_id} url=${snapshot.url}`,
-                run_id: snapshot.run_id,
-                workflow_name: snapshot.workflow_name,
-                url: snapshot.url,
-                ref,
-                sha: snapshot.sha,
-                waited_sec: elapsedSec(),
-              }),
-            },
-          ],
-        };
-      }
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({
-              ok: true,
-              run_id: snapshot.run_id,
-              workflow_name: snapshot.workflow_name,
-              final_status: finalStatus,
-              url: snapshot.url,
-              ref,
-              sha: snapshot.sha,
-              waited_sec: elapsedSec(),
-            }),
-          },
-        ],
-      };
-    } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({
-              ok: false,
-              error,
-              ref,
-              platform,
-              waited_sec: elapsedSec(),
-            }),
-          },
-        ],
-      };
-    }
+    const result = await waitForRun(
+      { ...args, cwd_repo_slug: args.repo ?? parseRepoSlug(), platform },
+      { adapter: getAdapter({ repo: args.repo }), sleep: sleepFn, now: Date.now },
+    );
+    return resultToEnvelope(result);
   },
 };
 

--- a/lib/adapters/ci-list-runs-github.test.ts
+++ b/lib/adapters/ci-list-runs-github.test.ts
@@ -1,0 +1,211 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { AdapterResult, CiListRunsResponse } from './types.ts';
+
+// Subprocess-boundary tests for the GitHub ciListRuns adapter (R-15).
+// Integration-level coverage (handler envelope + polling phases) stays in
+// tests/ci_wait_run.test.ts; this file owns the argv-shape + normalization
+// assertions that prove the adapter speaks `gh run list` correctly.
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { ciListRunsGithub } = await import('./ci-list-runs-github.ts');
+
+function on(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
+function expectOk(
+  r: AdapterResult<CiListRunsResponse>,
+): asserts r is { ok: true; data: CiListRunsResponse } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectErr(
+  r: AdapterResult<CiListRunsResponse>,
+): asserts r is { ok: false; error: string; code: string } {
+  if (!('ok' in r) || r.ok) {
+    throw new Error(`expected error result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+}
+
+function ghRun(overrides: Record<string, unknown> = {}) {
+  return {
+    databaseId: 12345,
+    name: 'CI',
+    workflowName: 'CI',
+    status: 'in_progress',
+    conclusion: null,
+    url: 'https://github.com/org/repo/actions/runs/12345',
+    headSha: '1234567890abcdef1234567890abcdef12345678',
+    headBranch: 'feature/1-demo',
+    createdAt: '2026-04-07T12:00:00Z',
+    event: 'push',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('ciListRunsGithub — subprocess boundary', () => {
+  test('argv: --branch for non-SHA ref; normalizes single run with event', async () => {
+    on('gh run list', JSON.stringify([ghRun({ event: 'push' })]));
+
+    const result = await ciListRunsGithub({ ref: 'feature/1-demo', limit: 20 });
+    expectOk(result);
+    expect(result.data.length).toBe(1);
+    const run = result.data[0];
+    expect(run.run_id).toBe(12345);
+    expect(run.workflow_name).toBe('CI');
+    expect(run.status).toBe('in_progress');
+    expect(run.conclusion).toBeNull();
+    expect(run.head_sha).toBe('1234567890abcdef1234567890abcdef12345678');
+    expect(run.head_branch).toBe('feature/1-demo');
+    expect(run.event).toBe('push');
+
+    const call = findCall('gh run list');
+    expect(call).toContain('--branch');
+    expect(call).toContain('feature/1-demo');
+    expect(call).not.toContain('--commit');
+    expect(call).toContain('--limit');
+    expect(call).toContain('20');
+    expect(call).toContain('event');
+  });
+
+  test('argv: --commit for 40-char hex SHA ref', async () => {
+    const sha = 'a'.repeat(40);
+    on('gh run list', JSON.stringify([ghRun({ headSha: sha })]));
+
+    await ciListRunsGithub({ ref: sha, limit: 5 });
+    const call = findCall('gh run list');
+    expect(call).toContain('--commit');
+    expect(call).toContain(sha);
+    expect(call).not.toContain('--branch');
+  });
+
+  test('argv: expected_sha with branch ref passes BOTH --branch and --commit', async () => {
+    const sha = 'b'.repeat(40);
+    on('gh run list', JSON.stringify([ghRun({ headSha: sha })]));
+
+    await ciListRunsGithub({ ref: 'main', expected_sha: sha, limit: 20 });
+    const call = findCall('gh run list');
+    expect(call).toContain('--branch');
+    expect(call).toContain('main');
+    expect(call).toContain('--commit');
+    expect(call).toContain(sha);
+  });
+
+  test('argv: expected_sha with SHA ref passes ONLY --commit (no --branch)', async () => {
+    const sha = 'c'.repeat(40);
+    on('gh run list', JSON.stringify([ghRun({ headSha: sha })]));
+
+    await ciListRunsGithub({ ref: sha, expected_sha: sha, limit: 20 });
+    const call = findCall('gh run list');
+    expect(call).toContain('--commit');
+    expect(call).not.toContain('--branch');
+  });
+
+  test('argv: --workflow and --repo forwarded', async () => {
+    on('gh run list', JSON.stringify([]));
+
+    await ciListRunsGithub({
+      ref: 'main',
+      workflow_name: 'Deploy',
+      repo: 'other-org/other-repo',
+      limit: 20,
+    });
+    const call = findCall('gh run list');
+    expect(call).toContain('--workflow');
+    expect(call).toContain('Deploy');
+    expect(call).toContain('--repo');
+    expect(call).toContain('other-org/other-repo');
+  });
+
+  test('empty array returns ok with empty data', async () => {
+    on('gh run list', JSON.stringify([]));
+
+    const result = await ciListRunsGithub({ ref: 'main', limit: 20 });
+    expectOk(result);
+    expect(result.data).toEqual([]);
+  });
+
+  test('empty stdout returns ok with empty data', async () => {
+    on('gh run list', '');
+
+    const result = await ciListRunsGithub({ ref: 'main', limit: 20 });
+    expectOk(result);
+    expect(result.data).toEqual([]);
+  });
+
+  test('normalizes merge_group event (feeds the pre-flight detector)', async () => {
+    on(
+      'gh run list',
+      JSON.stringify([ghRun({ event: 'merge_group', databaseId: 777 })]),
+    );
+
+    const result = await ciListRunsGithub({ ref: 'main', limit: 20 });
+    expectOk(result);
+    expect(result.data[0].event).toBe('merge_group');
+    expect(result.data[0].run_id).toBe(777);
+  });
+
+  test('workflowName preferred over name for workflow_name field', async () => {
+    on(
+      'gh run list',
+      JSON.stringify([ghRun({ name: 'fallback', workflowName: 'Real CI' })]),
+    );
+
+    const result = await ciListRunsGithub({ ref: 'main', limit: 20 });
+    expectOk(result);
+    expect(result.data[0].workflow_name).toBe('Real CI');
+  });
+
+  test('returns AdapterResult.error on gh failure (not thrown)', async () => {
+    on('gh run list', () => {
+      const err = new Error('gh: not authenticated') as ThrowableError;
+      err.stderr = 'gh: not authenticated';
+      err.status = 1;
+      throw err;
+    });
+
+    const result = await ciListRunsGithub({ ref: 'main', limit: 20 });
+    expectErr(result);
+    expect(result.code).toBe('gh_run_list_failed');
+    expect(result.error).toContain('gh run list failed');
+  });
+});

--- a/lib/adapters/ci-list-runs-github.ts
+++ b/lib/adapters/ci-list-runs-github.ts
@@ -1,0 +1,136 @@
+/**
+ * GitHub `ciListRuns` adapter implementation — the `ci_wait_run` keystone
+ * hybrid sub-call (Story 2.19, #313).
+ *
+ * Lifted from `handlers/ci_wait_run.ts`'s local `fetchGithubRuns` helper.
+ * Returns a richer normalized record than `ciRunStatus` / `ciRunsForBranch` —
+ * the `event` field (for `merge_group` detection) and `head_sha` (for the
+ * `expected_sha` anchor) are what set this sub-call apart from the existing
+ * fully-migrated CI adapters. Those fields drive the Phase 0 merge-queue
+ * pre-flight inside `lib/ci-wait-run-poll.ts`.
+ *
+ * Argv composition:
+ *   gh run list (--commit <sha> | --branch <ref>) [--workflow <name>]
+ *     [--repo <slug>] --limit <n>
+ *     --json databaseId,name,status,conclusion,url,headSha,headBranch,
+ *            workflowName,createdAt,event
+ *
+ * When `expected_sha` is set, the SHA is the authoritative anchor: always
+ * passed as `--commit`. For branch refs we ALSO pass `--branch` so `gh`
+ * narrows by both. When `expected_sha` is omitted, the ref itself drives
+ * selection (SHA → `--commit`; branch name → `--branch`).
+ *
+ * Errors surface as typed `AdapterResult.error` so the polling loop never
+ * has to try/catch.
+ */
+
+import { execSync } from 'child_process';
+import { runArgv } from '../shared/error-norm.js';
+import type {
+  AdapterResult,
+  CiListRunsArgs,
+  CiListRunsResponse,
+  NormalizedCiRun,
+} from './types.js';
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+interface GhRun {
+  databaseId: number;
+  name?: string;
+  workflowName?: string;
+  status: string;
+  conclusion: string | null;
+  url: string;
+  headSha: string;
+  headBranch?: string;
+  createdAt?: string;
+  event?: string;
+}
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+function isSha(ref: string): boolean {
+  return SHA_PATTERN.test(ref);
+}
+
+function normalizeGh(run: GhRun): NormalizedCiRun {
+  return {
+    run_id: run.databaseId,
+    workflow_name: run.workflowName ?? run.name ?? '(unknown)',
+    status: run.status,
+    conclusion: run.conclusion ?? null,
+    url: run.url,
+    head_sha: run.headSha,
+    head_branch: run.headBranch ?? null,
+    created_at: run.createdAt ?? null,
+    event: run.event ?? null,
+  };
+}
+
+export async function ciListRunsGithub(
+  args: CiListRunsArgs,
+): Promise<AdapterResult<CiListRunsResponse>> {
+  try {
+    const cwd = projectDir();
+
+    const cmd: string[] = ['gh', 'run', 'list'];
+    // Ref selection. When expected_sha is provided the SHA is authoritative
+    // (always --commit); for branch refs we additionally pass --branch so
+    // `gh` narrows by both. Without expected_sha the ref drives selection.
+    if (args.expected_sha !== undefined) {
+      if (!isSha(args.ref)) cmd.push('--branch', args.ref);
+      cmd.push('--commit', args.expected_sha);
+    } else if (isSha(args.ref)) {
+      cmd.push('--commit', args.ref);
+    } else {
+      cmd.push('--branch', args.ref);
+    }
+    if (args.workflow_name !== undefined) {
+      cmd.push('--workflow', args.workflow_name);
+    }
+    if (args.repo !== undefined) {
+      cmd.push('--repo', args.repo);
+    }
+    cmd.push('--limit', String(args.limit));
+    cmd.push(
+      '--json',
+      'databaseId,name,status,conclusion,url,headSha,headBranch,workflowName,createdAt,event',
+    );
+
+    const result = runArgv(cmd, cwd);
+    if (result.exitCode !== 0) {
+      return {
+        ok: false,
+        code: 'gh_run_list_failed',
+        error: `gh run list failed: ${result.stderr.trim() || result.stdout.trim()}`,
+      };
+    }
+
+    const raw = result.stdout.trim();
+    if (!raw) return { ok: true, data: [] };
+
+    const runs = JSON.parse(raw) as GhRun[];
+    if (!Array.isArray(runs)) {
+      return {
+        ok: false,
+        code: 'gh_run_list_bad_shape',
+        error: `gh run list returned non-array JSON: ${String(runs).slice(0, 200)}`,
+      };
+    }
+    return { ok: true, data: runs.map(normalizeGh) };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'unexpected_error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// `execSync` is intentionally re-imported above so that adapter-level test
+// files can `mock.module('child_process', ...)` and intercept this module's
+// subprocess calls without needing access to the handler's mock setup.
+void execSync;

--- a/lib/adapters/ci-list-runs-gitlab.test.ts
+++ b/lib/adapters/ci-list-runs-gitlab.test.ts
@@ -1,0 +1,195 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { AdapterResult, CiListRunsResponse } from './types.ts';
+
+// Subprocess-boundary tests for the GitLab ciListRuns adapter (R-15).
+// Integration-level coverage stays in tests/ci_wait_run.test.ts; this file
+// owns the argv-shape and normalization assertions.
+//
+// The adapter routes its subprocess through `gitlabApiCiList` in
+// `lib/glab.ts` today (per Story 2.19 spec — `lib/glab.ts` deletion is
+// deferred to Phase 3 Story 3.1). So we mock `child_process.execSync`
+// directly AND stub `parseRepoSlug` so `gitlabApiCiList`'s `git remote`
+// peek doesn't need a real repo.
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+mock.module('../shared/parse-repo-slug.js', () => ({
+  parseRepoSlug: () => 'org/repo',
+}));
+
+const { ciListRunsGitlab } = await import('./ci-list-runs-gitlab.ts');
+
+function on(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
+function expectOk(
+  r: AdapterResult<CiListRunsResponse>,
+): asserts r is { ok: true; data: CiListRunsResponse } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function expectErr(
+  r: AdapterResult<CiListRunsResponse>,
+): asserts r is { ok: false; error: string; code: string } {
+  if (!('ok' in r) || r.ok) {
+    throw new Error(`expected error result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+}
+
+function glPipeline(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 999,
+    status: 'running',
+    ref: 'feature/1-demo',
+    sha: '1234567890abcdef1234567890abcdef12345678',
+    web_url: 'https://gitlab.com/org/repo/-/pipelines/999',
+    source: 'push',
+    created_at: '2026-04-07T12:00:00Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('ciListRunsGitlab — subprocess boundary', () => {
+  test('argv: calls glab api pipelines with ref query; normalizes with event=null', async () => {
+    on('glab api projects/org%2Frepo/pipelines', JSON.stringify([glPipeline()]));
+
+    const result = await ciListRunsGitlab({ ref: 'feature/1-demo', limit: 20 });
+    expectOk(result);
+    expect(result.data.length).toBe(1);
+    const run = result.data[0];
+    expect(run.run_id).toBe(999);
+    expect(run.workflow_name).toBe('push');
+    expect(run.status).toBe('running');
+    expect(run.head_sha).toBe('1234567890abcdef1234567890abcdef12345678');
+    expect(run.head_branch).toBe('feature/1-demo');
+    // GitLab has no event concept — always null (R-03 asymmetry signal).
+    expect(run.event).toBeNull();
+
+    const call = findCall('glab api');
+    expect(call).toContain('projects/org%2Frepo/pipelines');
+    expect(call).toContain('ref=feature');
+    expect(call).toContain('per_page=20');
+  });
+
+  test('argv: explicit repo slug is URL-encoded into projects path', async () => {
+    on(
+      'glab api projects/other-org%2Fother-repo/pipelines',
+      JSON.stringify([glPipeline()]),
+    );
+
+    const result = await ciListRunsGitlab({
+      ref: 'main',
+      repo: 'other-org/other-repo',
+      limit: 20,
+    });
+    expectOk(result);
+
+    const call = findCall('glab api');
+    expect(call).toContain('projects/other-org%2Fother-repo/pipelines');
+    expect(call).not.toContain('projects/org%2Frepo');
+  });
+
+  test('expected_sha threads through as sha= query param and filters defensively', async () => {
+    const target = 'a'.repeat(40);
+    const other = 'b'.repeat(40);
+    on(
+      'glab api projects/org%2Frepo/pipelines',
+      JSON.stringify([
+        glPipeline({ id: 1, sha: other }),
+        glPipeline({ id: 2, sha: target }),
+      ]),
+    );
+
+    const result = await ciListRunsGitlab({
+      ref: 'main',
+      expected_sha: target,
+      limit: 20,
+    });
+    expectOk(result);
+    // Defense-in-depth: only the run with matching SHA survives.
+    expect(result.data.length).toBe(1);
+    expect(result.data[0].run_id).toBe(2);
+
+    const call = findCall('glab api');
+    expect(call).toContain(`sha=${target}`);
+  });
+
+  test('workflow_name filters client-side against the source field', async () => {
+    on(
+      'glab api projects/org%2Frepo/pipelines',
+      JSON.stringify([
+        glPipeline({ id: 1, source: 'push' }),
+        glPipeline({ id: 2, source: 'schedule' }),
+      ]),
+    );
+
+    const result = await ciListRunsGitlab({
+      ref: 'main',
+      workflow_name: 'schedule',
+      limit: 20,
+    });
+    expectOk(result);
+    expect(result.data.length).toBe(1);
+    expect(result.data[0].run_id).toBe(2);
+    expect(result.data[0].workflow_name).toBe('schedule');
+  });
+
+  test('empty pipelines list returns ok with empty data', async () => {
+    on('glab api projects/org%2Frepo/pipelines', JSON.stringify([]));
+
+    const result = await ciListRunsGitlab({ ref: 'main', limit: 20 });
+    expectOk(result);
+    expect(result.data).toEqual([]);
+  });
+
+  test('returns AdapterResult.error on glab failure (not thrown)', async () => {
+    on('glab api', () => {
+      const err = new Error('glab: not authenticated') as ThrowableError;
+      err.stderr = 'glab: not authenticated';
+      err.status = 1;
+      throw err;
+    });
+
+    const result = await ciListRunsGitlab({ ref: 'main', limit: 20 });
+    expectErr(result);
+    expect(result.code).toBe('glab_api_pipelines_failed');
+  });
+});

--- a/lib/adapters/ci-list-runs-gitlab.ts
+++ b/lib/adapters/ci-list-runs-gitlab.ts
@@ -1,0 +1,97 @@
+/**
+ * GitLab `ciListRuns` adapter implementation — the `ci_wait_run` keystone
+ * hybrid sub-call (Story 2.19, #313).
+ *
+ * Mirrors `ci-list-runs-github.ts` — both implement the same normalized
+ * `NormalizedCiRun[]` shape; `ci_wait_run`'s polling loop (in
+ * `lib/ci-wait-run-poll.ts`) reads these records without branching on
+ * platform.
+ *
+ * GitLab divergences:
+ * - `event` is always `null`. GitLab pipelines don't carry a trigger-event
+ *   in the GitHub-Actions sense; merge-queue pre-flight never fires for
+ *   GitLab (R-03 typed asymmetry).
+ * - `workflow_name` filtering is client-side against the `source` field —
+ *   GitLab pipelines have no "workflow name". When the caller passes a
+ *   `workflow_name` we fetch more pipelines than requested and filter down.
+ * - `expected_sha` threads through as the `?sha=` query param on the GitLab
+ *   REST endpoint; `gitlabApiCiList` handles the encoding.
+ *
+ * `gitlabApiCiList` lives in `lib/glab.ts` today and is shared across the
+ * CI family. Phase 3 Story 3.1 deletes `lib/glab.ts` wholesale; this adapter
+ * will in-line the `glab api` invocation at that time.
+ */
+
+import { execSync } from 'child_process';
+import { gitlabApiCiList, type GitlabPipeline } from '../glab.js';
+import type {
+  AdapterResult,
+  CiListRunsArgs,
+  CiListRunsResponse,
+  NormalizedCiRun,
+} from './types.js';
+
+function splitRepoSlug(
+  repo: string | undefined,
+): { owner: string; repo: string } | undefined {
+  if (!repo) return undefined;
+  const [owner, name] = repo.split('/', 2);
+  return { owner, repo: name };
+}
+
+function normalizeGl(pipeline: GitlabPipeline): NormalizedCiRun {
+  return {
+    run_id: pipeline.id,
+    workflow_name: pipeline.source ?? '(gitlab pipeline)',
+    status: pipeline.status,
+    conclusion: null,
+    url: pipeline.web_url,
+    head_sha: pipeline.sha,
+    head_branch: pipeline.ref ?? null,
+    created_at: pipeline.created_at ?? null,
+    // GitLab has no GitHub-Actions-style trigger-event. Always null — the
+    // merge-queue pre-flight skips on this signal (R-03 typed asymmetry).
+    event: null,
+  };
+}
+
+export async function ciListRunsGitlab(
+  args: CiListRunsArgs,
+): Promise<AdapterResult<CiListRunsResponse>> {
+  try {
+    const pipelines = gitlabApiCiList(
+      { ref: args.ref, limit: args.limit, sha: args.expected_sha },
+      splitRepoSlug(args.repo),
+    );
+
+    // Defense-in-depth: even if glab returns pipelines that don't match
+    // `sha=<expected_sha>`, drop them. Mirrors the pre-migration handler's
+    // airtight "ignores other runs on the same branch" guarantee.
+    const shaFiltered = args.expected_sha
+      ? pipelines.filter(
+          (p) =>
+            p.sha?.toLowerCase() === (args.expected_sha as string).toLowerCase(),
+        )
+      : pipelines;
+
+    // GitLab pipelines have no workflow-name concept; fall back to client-side
+    // filtering against the `source` field when the caller provided a filter.
+    const workflowFiltered = args.workflow_name
+      ? shaFiltered.filter((p) => p.source === args.workflow_name)
+      : shaFiltered;
+
+    return { ok: true, data: workflowFiltered.map(normalizeGl) };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'glab_api_pipelines_failed',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// `execSync` is intentionally re-imported above so that adapter-level test
+// files can `mock.module('child_process', ...)` and intercept the subprocess
+// calls inside `gitlabApiCiList` without needing access to the handler's
+// mock setup.
+void execSync;

--- a/lib/adapters/github.ts
+++ b/lib/adapters/github.ts
@@ -15,12 +15,14 @@
 
 import type { PlatformAdapter } from './types.js';
 import { ciFailedJobsGithub } from './ci-failed-jobs-github.js';
+import { ciListRunsGithub } from './ci-list-runs-github.js';
 import { ciRunLogsGithub } from './ci-run-logs-github.js';
 import { ciRunStatusGithub } from './ci-run-status-github.js';
 import { ciRunsForBranchGithub } from './ci-runs-for-branch-github.js';
 import { fetchIssueGithub } from './fetch-issue-github.js';
 import { fetchPrForBranchGithub } from './fetch-pr-for-branch-github.js';
 import { fetchPrStateGithub } from './fetch-pr-state-github.js';
+import { resolveBranchShaGithub } from './resolve-branch-sha-github.js';
 import { labelCreateGithub } from './label-create-github.js';
 import { labelListGithub } from './label-list-github.js';
 import { prCommentGithub } from './pr-comment-github.js';
@@ -66,4 +68,6 @@ export const githubAdapter: PlatformAdapter = {
   fetchIssue: fetchIssueGithub,
   fetchPrState: fetchPrStateGithub,
   fetchPrForBranch: fetchPrForBranchGithub,
+  ciListRuns: ciListRunsGithub,
+  resolveBranchSha: resolveBranchShaGithub,
 };

--- a/lib/adapters/gitlab.ts
+++ b/lib/adapters/gitlab.ts
@@ -16,12 +16,14 @@
 
 import type { PlatformAdapter } from './types.js';
 import { ciFailedJobsGitlab } from './ci-failed-jobs-gitlab.js';
+import { ciListRunsGitlab } from './ci-list-runs-gitlab.js';
 import { ciRunLogsGitlab } from './ci-run-logs-gitlab.js';
 import { ciRunStatusGitlab } from './ci-run-status-gitlab.js';
 import { ciRunsForBranchGitlab } from './ci-runs-for-branch-gitlab.js';
 import { fetchIssueGitlab } from './fetch-issue-gitlab.js';
 import { fetchPrForBranchGitlab } from './fetch-pr-for-branch-gitlab.js';
 import { fetchPrStateGitlab } from './fetch-pr-state-gitlab.js';
+import { resolveBranchShaGitlab } from './resolve-branch-sha-gitlab.js';
 import { labelCreateGitlab } from './label-create-gitlab.js';
 import { labelListGitlab } from './label-list-gitlab.js';
 import { prCommentGitlab } from './pr-comment-gitlab.js';
@@ -67,4 +69,6 @@ export const gitlabAdapter: PlatformAdapter = {
   fetchIssue: fetchIssueGitlab,
   fetchPrState: fetchPrStateGitlab,
   fetchPrForBranch: fetchPrForBranchGitlab,
+  ciListRuns: ciListRunsGitlab,
+  resolveBranchSha: resolveBranchShaGitlab,
 };

--- a/lib/adapters/resolve-branch-sha-github.test.ts
+++ b/lib/adapters/resolve-branch-sha-github.test.ts
@@ -1,0 +1,136 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type {
+  AdapterResult,
+  ResolveBranchShaResponse,
+} from './types.ts';
+
+// Subprocess-boundary tests for the GitHub resolveBranchSha adapter (R-15).
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { resolveBranchShaGithub } = await import(
+  './resolve-branch-sha-github.ts'
+);
+
+function on(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
+function expectOk(
+  r: AdapterResult<ResolveBranchShaResponse | null>,
+): asserts r is { ok: true; data: ResolveBranchShaResponse | null } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('resolveBranchShaGithub — subprocess boundary', () => {
+  test('argv: gh api repos/<slug>/git/refs/heads/<branch> --jq .object.sha', async () => {
+    const sha = 'a'.repeat(40);
+    on('gh api repos/org/repo/git/refs/heads/main', sha);
+
+    const result = await resolveBranchShaGithub({ branch: 'main', repo: 'org/repo' });
+    expectOk(result);
+    expect(result.data).toEqual({ sha });
+
+    const call = findCall('gh api');
+    expect(call).toContain('repos/org/repo/git/refs/heads/main');
+    expect(call).toContain('--jq');
+    expect(call).toContain('.object.sha');
+  });
+
+  test('soft-fails to null when gh errors (preserves pre-migration contract)', async () => {
+    on('gh api', () => {
+      const err = new Error('gh: 404') as ThrowableError;
+      err.stderr = 'gh: not found';
+      err.status = 1;
+      throw err;
+    });
+
+    const result = await resolveBranchShaGithub({ branch: 'main', repo: 'org/repo' });
+    expectOk(result);
+    expect(result.data).toBeNull();
+  });
+
+  test('returns null when stdout is not a valid 40-char SHA', async () => {
+    on('gh api', 'not-a-sha');
+
+    const result = await resolveBranchShaGithub({ branch: 'main', repo: 'org/repo' });
+    expectOk(result);
+    expect(result.data).toBeNull();
+  });
+
+  test('returns null when repo is omitted (no slug to target)', async () => {
+    const result = await resolveBranchShaGithub({ branch: 'main' });
+    expectOk(result);
+    expect(result.data).toBeNull();
+    // Must not have shelled out at all.
+    expect(execCalls.length).toBe(0);
+  });
+
+  test('rejects invalid branch characters', async () => {
+    const result = await resolveBranchShaGithub({
+      branch: 'bad; rm -rf /',
+      repo: 'org/repo',
+    });
+    expect('ok' in result && result.ok).toBe(false);
+    expect((result as { code: string }).code).toBe('invalid_branch');
+  });
+
+  test('rejects invalid repo slug', async () => {
+    const result = await resolveBranchShaGithub({
+      branch: 'main',
+      repo: 'no-slash',
+    });
+    expect('ok' in result && result.ok).toBe(false);
+    expect((result as { code: string }).code).toBe('invalid_repo');
+  });
+
+  test('passes branch names with slashes (feature/1-demo) unharmed', async () => {
+    const sha = 'b'.repeat(40);
+    on('gh api repos/org/repo/git/refs/heads/feature/1-demo', sha);
+
+    const result = await resolveBranchShaGithub({
+      branch: 'feature/1-demo',
+      repo: 'org/repo',
+    });
+    expectOk(result);
+    expect(result.data).toEqual({ sha });
+  });
+});

--- a/lib/adapters/resolve-branch-sha-github.ts
+++ b/lib/adapters/resolve-branch-sha-github.ts
@@ -1,0 +1,93 @@
+/**
+ * GitHub `resolveBranchSha` adapter implementation — the `ci_wait_run`
+ * branch→SHA sub-call (Story 2.19, #313).
+ *
+ * Lifted from `handlers/ci_wait_run.ts`'s local `resolveBranchToSha` helper.
+ * Called by the polling loop ONLY when it needs to compare a branch ref
+ * against a `run.headSha` (e.g., merge-queue Phase 0 pre-flight). When
+ * `expected_sha` is provided — or the ref is already a SHA — the call is
+ * skipped entirely.
+ *
+ * Returns `{sha}` on successful resolution; `null` when resolution fails for
+ * any reason (missing repo, deleted branch, unauthenticated `gh`). The
+ * caller treats a `null` data payload as "no SHA match" — same semantics as
+ * the pre-migration helper's `try { … } catch { return null }`.
+ *
+ * Argv: `gh api repos/<slug>/git/refs/heads/<branch> --jq .object.sha`.
+ */
+
+import { execSync } from 'child_process';
+import { runArgv } from '../shared/error-norm.js';
+import type {
+  AdapterResult,
+  ResolveBranchShaArgs,
+  ResolveBranchShaResponse,
+} from './types.js';
+
+const GITHUB_REPO_SLUG = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+const BRANCH_CHARSET = /^[A-Za-z0-9._\-/]+$/;
+const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+export async function resolveBranchShaGithub(
+  args: ResolveBranchShaArgs,
+): Promise<AdapterResult<ResolveBranchShaResponse | null>> {
+  try {
+    if (!BRANCH_CHARSET.test(args.branch)) {
+      return {
+        ok: false,
+        code: 'invalid_branch',
+        error: `resolveBranchShaGithub: invalid branch ${JSON.stringify(args.branch)}`,
+      };
+    }
+    if (args.repo !== undefined && !GITHUB_REPO_SLUG.test(args.repo)) {
+      return {
+        ok: false,
+        code: 'invalid_repo',
+        error: `resolveBranchShaGithub: invalid repo slug ${JSON.stringify(args.repo)}`,
+      };
+    }
+
+    const slug = args.repo;
+    if (slug === undefined) {
+      // No slug resolution is available at this layer — callers are expected
+      // to pass an explicit slug (or resolve cwd via `parseRepoSlug()`
+      // upstream). Surface `null` so the polling loop treats it as "no SHA
+      // match" rather than exploding.
+      return { ok: true, data: null };
+    }
+
+    const cmd = [
+      'gh',
+      'api',
+      `repos/${slug}/git/refs/heads/${args.branch}`,
+      '--jq',
+      '.object.sha',
+    ];
+    const result = runArgv(cmd, projectDir());
+    if (result.exitCode !== 0) {
+      // Soft-fail: the pre-migration helper swallowed all errors and
+      // returned null. Preserve that contract so "branch doesn't exist" /
+      // "unauthenticated" collapses to "no SHA match" instead of an error.
+      return { ok: true, data: null };
+    }
+
+    const sha = result.stdout.trim();
+    if (!SHA_PATTERN.test(sha)) return { ok: true, data: null };
+    return { ok: true, data: { sha } };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'unexpected_error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// `execSync` is intentionally re-imported above so that adapter-level test
+// files can `mock.module('child_process', ...)` and intercept this module's
+// subprocess calls.
+void execSync;

--- a/lib/adapters/resolve-branch-sha-gitlab.test.ts
+++ b/lib/adapters/resolve-branch-sha-gitlab.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from 'bun:test';
+import { resolveBranchShaGitlab } from './resolve-branch-sha-gitlab.ts';
+
+// R-03 typed-asymmetry test: GitLab doesn't need branch→SHA resolution
+// (pipelines attach to branch names directly). The adapter must return a
+// `platform_unsupported` signal — not a fake-success null, not a throw.
+
+describe('resolveBranchShaGitlab — R-03 typed asymmetry', () => {
+  test('returns platform_unsupported with a descriptive hint', async () => {
+    const result = await resolveBranchShaGitlab({ branch: 'main' });
+    if (!('platform_unsupported' in result)) {
+      throw new Error(
+        `expected platform_unsupported, got ${JSON.stringify(result)}`,
+      );
+    }
+    expect(result.platform_unsupported).toBe(true);
+    // The hint must describe WHY — callers need the signal, not a generic stub.
+    expect(result.hint.toLowerCase()).toContain('gitlab');
+    expect(result.hint.toLowerCase()).toContain('branch');
+  });
+
+  test('platform_unsupported regardless of args', async () => {
+    const result = await resolveBranchShaGitlab({
+      branch: 'feature/1-demo',
+      repo: 'org/repo',
+    });
+    expect('platform_unsupported' in result).toBe(true);
+  });
+});

--- a/lib/adapters/resolve-branch-sha-gitlab.ts
+++ b/lib/adapters/resolve-branch-sha-gitlab.ts
@@ -1,0 +1,31 @@
+/**
+ * GitLab `resolveBranchSha` adapter implementation — the `ci_wait_run`
+ * branch→SHA sub-call (Story 2.19, #313).
+ *
+ * This is a PERMANENT `platform_unsupported` stub per R-03 typed-asymmetry.
+ * Branch→SHA resolution on GitLab isn't a pre-condition for the CI wait —
+ * GitLab pipelines attach to branch names directly via the `ref=` query on
+ * the pipelines endpoint. The GitHub merge-queue pre-flight that needs this
+ * resolution doesn't exist on GitLab (merge trains operate differently).
+ *
+ * Returning `platform_unsupported` (rather than throwing or returning
+ * `{ok: true, data: null}`) is the point of R-03: callers that hit this on
+ * a GitLab repo get a TYPED signal that the concept doesn't map, not a
+ * fake-success `null` that might be mistaken for "branch doesn't exist".
+ */
+
+import type {
+  AdapterResult,
+  ResolveBranchShaArgs,
+  ResolveBranchShaResponse,
+} from './types.js';
+
+export async function resolveBranchShaGitlab(
+  _args: ResolveBranchShaArgs,
+): Promise<AdapterResult<ResolveBranchShaResponse | null>> {
+  return {
+    platform_unsupported: true,
+    hint:
+      'branch→SHA not needed — GitLab CI pipelines attach to branch names directly',
+  };
+}

--- a/lib/adapters/types.test.ts
+++ b/lib/adapters/types.test.ts
@@ -55,6 +55,11 @@ describe('PlatformAdapter contract', () => {
   // Story 2.16 (#310): labelList
   // Story 2.17 (#311): workItem (+ closes #281 cross-platform PR/MR asymmetry)
   // Story 2.18 (#312): ibm (+ fetchPrForBranch — `ibm` keystone sub-call)
+  // Story 2.19 (#313): ci_wait_run hybrid migration (+ ciListRuns +
+  //                    resolveBranchSha — `ci_wait_run` keystone sub-calls).
+  //                    `ciWaitRun` itself remains stubbed — the handler routes
+  //                    through the two sub-calls inside lib/ci-wait-run-poll.ts,
+  //                    not through the top-level method.
   const MIGRATED_METHODS = new Set<string>([
     'prCreate',
     'prDiff',
@@ -69,11 +74,13 @@ describe('PlatformAdapter contract', () => {
     'fetchIssue',
     'fetchPrForBranch',
     'ciFailedJobs',
+    'ciListRuns',
     'ciRunLogs',
     'ciRunStatus',
     'ciRunsForBranch',
     'labelCreate',
     'labelList',
+    'resolveBranchSha',
     'workItem',
   ]);
 

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -277,6 +277,64 @@ export type CiWaitRunArgs = unknown;
 export type CiWaitRunResponse = unknown;
 
 /**
+ * Hybrid sub-call (Story 2.19, #313). `ciListRuns` is the slim per-ref CI-run
+ * lister used by `ci_wait_run`'s polling loop and the Phase 0 merge-queue
+ * pre-flight. Narrower than `ciRunsForBranch` (which returns the full
+ * `CiRunsForBranchRun[]` for a branch only, and never exposes `event`); this
+ * call returns the shape the wait loop actually needs: `event` (for
+ * `merge_group` detection) and `head_sha` (for the expected_sha anchor).
+ *
+ * GitLab pipelines don't carry a trigger-event in the way GitHub Actions runs
+ * do, so `event` is always `null` on GitLab. `head_sha` is populated on both
+ * platforms.
+ *
+ * `workflow_name` / `expected_sha` filter behavior mirrors the pre-migration
+ * handler: GitHub pushes both into the argv (`--workflow`, `--commit`) so the
+ * server narrows; GitLab pushes `expected_sha` as `?sha=` and filters
+ * `workflow_name` client-side against `source`.
+ */
+export interface CiListRunsArgs {
+  ref: string;
+  workflow_name?: string;
+  repo?: string;
+  expected_sha?: string;
+  limit: number;
+}
+
+export interface NormalizedCiRun {
+  run_id: number;
+  workflow_name: string;
+  /** Raw platform status — GitHub `queued | in_progress | completed | …`; GitLab `created | running | success | …`. Consumers that need a normalized status should go through `ciRunStatus`. */
+  status: string;
+  /** Raw platform conclusion or `null` when still running. Same caveat as `status`. */
+  conclusion: string | null;
+  url: string;
+  head_sha: string;
+  head_branch: string | null;
+  created_at: string | null;
+  /** GitHub: workflow event trigger (`push | pull_request | merge_group | …`). GitLab: always `null`. */
+  event: string | null;
+}
+
+export type CiListRunsResponse = NormalizedCiRun[];
+
+/**
+ * Hybrid sub-call (Story 2.19, #313). `resolveBranchSha` collapses the
+ * `fetchBranchToSha` helper lifted from the pre-migration `ci_wait_run`
+ * handler. Returns `{ sha }` on success or `null` when the ref cannot be
+ * resolved. On GitLab the concept doesn't apply (pipelines attach to branch
+ * names directly); GitLab returns `platform_unsupported` with a hint.
+ */
+export interface ResolveBranchShaArgs {
+  branch: string;
+  repo?: string;
+}
+
+export interface ResolveBranchShaResponse {
+  sha: string;
+}
+
+/**
  * `ci_run_status` args/response (Story 2.13, #307). Full-migration of the
  * latest-run lookup for a commit SHA or branch ref, optionally filtered by
  * workflow name.
@@ -654,11 +712,20 @@ export interface PlatformAdapter {
   // and post-merge URL/sha lookup.
   // `fetchIssue` (Story 2.1) is the keystone sub-call for Phase 2 — consumed
   // by 10 handlers that all read the same normalized issue shape.
+  // `ciListRuns` + `resolveBranchSha` (Story 2.19) are the `ci_wait_run`
+  // keystone sub-calls — consumed by the polling loop in
+  // `lib/ci-wait-run-poll.ts` and the Phase 0 merge-queue pre-flight.
   fetchIssue(args: FetchIssueArgs): Promise<AdapterResult<AdapterIssue>>;
   fetchPrState(args: FetchPrStateArgs): Promise<AdapterResult<PrStateInfo>>;
   fetchPrForBranch(
     args: FetchPrForBranchArgs,
   ): Promise<AdapterResult<PrForBranchRef | null>>;
+  ciListRuns(
+    args: CiListRunsArgs,
+  ): Promise<AdapterResult<CiListRunsResponse>>;
+  resolveBranchSha(
+    args: ResolveBranchShaArgs,
+  ): Promise<AdapterResult<ResolveBranchShaResponse | null>>;
 }
 
 // ---------------------------------------------------------------------------
@@ -697,6 +764,8 @@ export const PLATFORM_ADAPTER_METHODS = [
   'fetchIssue',
   'fetchPrState',
   'fetchPrForBranch',
+  'ciListRuns',
+  'resolveBranchSha',
 ] as const;
 
 export type PlatformAdapterMethod = (typeof PLATFORM_ADAPTER_METHODS)[number];

--- a/lib/ci-wait-run-poll.test.ts
+++ b/lib/ci-wait-run-poll.test.ts
@@ -1,0 +1,468 @@
+import { describe, test, expect } from 'bun:test';
+import { waitForRun } from './ci-wait-run-poll.ts';
+import type {
+  AdapterResult,
+  CiListRunsArgs,
+  CiListRunsResponse,
+  NormalizedCiRun,
+  PlatformAdapter,
+  ResolveBranchShaArgs,
+  ResolveBranchShaResponse,
+} from './adapters/types.ts';
+
+// Platform-agnostic polling loop tests (R-15). The loop's job is to orchestrate
+// the `ciListRuns` + `resolveBranchSha` sub-calls across the four phases
+// (merge-queue pre-flight, no-run-yet window, poll-to-completion, terminal
+// normalization). These tests drive it directly with an injected adapter and a
+// fake clock — zero subprocess work, zero real time.
+
+type CiListRunsImpl = (
+  args: CiListRunsArgs,
+) => Promise<AdapterResult<CiListRunsResponse>>;
+type ResolveBranchShaImpl = (
+  args: ResolveBranchShaArgs,
+) => Promise<AdapterResult<ResolveBranchShaResponse | null>>;
+
+function makeAdapter(
+  ciListRuns: CiListRunsImpl,
+  resolveBranchSha: ResolveBranchShaImpl = async () => ({
+    ok: true,
+    data: null,
+  }),
+): Pick<PlatformAdapter, 'ciListRuns' | 'resolveBranchSha'> {
+  return { ciListRuns, resolveBranchSha };
+}
+
+function ghRun(overrides: Partial<NormalizedCiRun> = {}): NormalizedCiRun {
+  return {
+    run_id: 1,
+    workflow_name: 'CI',
+    status: 'in_progress',
+    conclusion: null,
+    url: 'https://github.com/org/repo/actions/runs/1',
+    head_sha: 'a'.repeat(40),
+    head_branch: 'main',
+    created_at: '2026-04-07T12:00:00Z',
+    event: 'push',
+    ...overrides,
+  };
+}
+
+function glPipeline(overrides: Partial<NormalizedCiRun> = {}): NormalizedCiRun {
+  return {
+    run_id: 1,
+    workflow_name: 'push',
+    status: 'running',
+    conclusion: null,
+    url: 'https://gitlab.com/org/repo/-/pipelines/1',
+    head_sha: 'a'.repeat(40),
+    head_branch: 'main',
+    created_at: '2026-04-07T12:00:00Z',
+    event: null,
+    ...overrides,
+  };
+}
+
+function fakeClock() {
+  let now = 1_700_000_000_000;
+  return {
+    now: () => now,
+    sleep: async (ms: number) => {
+      now += ms;
+    },
+    advance: (ms: number) => {
+      now += ms;
+    },
+  };
+}
+
+describe('waitForRun — phase machine', () => {
+  test('Phase 3: GitHub run already complete with success → final_status=success', async () => {
+    const adapter = makeAdapter(async () => ({
+      ok: true,
+      data: [ghRun({ status: 'completed', conclusion: 'success' })],
+    }));
+    const clock = fakeClock();
+
+    const result = await waitForRun(
+      { ref: 'main', platform: 'github' },
+      { adapter, sleep: clock.sleep, now: clock.now },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.final_status).toBe('success');
+    expect(result.run_id).toBe(1);
+  });
+
+  test('Phase 3: GitHub failure conclusion → final_status=failure', async () => {
+    const adapter = makeAdapter(async () => ({
+      ok: true,
+      data: [ghRun({ status: 'completed', conclusion: 'failure' })],
+    }));
+    const clock = fakeClock();
+
+    const result = await waitForRun(
+      { ref: 'main', platform: 'github' },
+      { adapter, sleep: clock.sleep, now: clock.now },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.final_status).toBe('failure');
+  });
+
+  test('Phase 3: GitHub cancelled → final_status=cancelled', async () => {
+    const adapter = makeAdapter(async () => ({
+      ok: true,
+      data: [ghRun({ status: 'completed', conclusion: 'cancelled' })],
+    }));
+    const clock = fakeClock();
+
+    const result = await waitForRun(
+      { ref: 'main', platform: 'github' },
+      { adapter, sleep: clock.sleep, now: clock.now },
+    );
+    expect(result.final_status).toBe('cancelled');
+  });
+
+  test('Phase 3: unknown conclusion → ok:false with error', async () => {
+    const adapter = makeAdapter(async () => ({
+      ok: true,
+      data: [ghRun({ status: 'completed', conclusion: 'mystery' })],
+    }));
+    const clock = fakeClock();
+
+    const result = await waitForRun(
+      { ref: 'main', platform: 'github' },
+      { adapter, sleep: clock.sleep, now: clock.now },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('mystery');
+  });
+
+  test('Phase 0: merge_group-only repo with matching SHA → not_applicable success', async () => {
+    const sha = 'b'.repeat(40);
+    const adapter = makeAdapter(async () => ({
+      ok: true,
+      data: [
+        ghRun({
+          run_id: 555,
+          status: 'completed',
+          conclusion: 'success',
+          event: 'merge_group',
+          head_sha: sha,
+          url: 'https://github.com/org/repo/actions/runs/555',
+        }),
+      ],
+    }));
+    const clock = fakeClock();
+
+    const result = await waitForRun(
+      { ref: sha, platform: 'github' },
+      { adapter, sleep: clock.sleep, now: clock.now },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.final_status).toBe('not_applicable');
+    if (result.ok) {
+      expect(result.reason).toBe('merge_group_validated');
+      expect(result.run_id).toBe(555);
+      expect(result.waited_sec).toBe(0);
+    }
+  });
+
+  test('Phase 0: merge_group-only with NO matching SHA → not_applicable error', async () => {
+    const refSha = 'c'.repeat(40);
+    const otherSha = 'd'.repeat(40);
+    const adapter = makeAdapter(async () => ({
+      ok: true,
+      data: [
+        ghRun({
+          run_id: 444,
+          status: 'completed',
+          conclusion: 'success',
+          event: 'merge_group',
+          head_sha: otherSha,
+        }),
+      ],
+    }));
+    const clock = fakeClock();
+
+    const result = await waitForRun(
+      { ref: refSha, platform: 'github' },
+      { adapter, sleep: clock.sleep, now: clock.now },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.final_status).toBe('not_applicable');
+      expect(result.error).toContain('no push-triggered workflows');
+    }
+  });
+
+  test('Phase 0: push-triggered run present → falls through to poll loop (regression)', async () => {
+    const adapter = makeAdapter(async () => ({
+      ok: true,
+      data: [
+        ghRun({
+          run_id: 777,
+          status: 'completed',
+          conclusion: 'success',
+          event: 'push',
+        }),
+      ],
+    }));
+    const clock = fakeClock();
+
+    const result = await waitForRun(
+      { ref: 'main', platform: 'github' },
+      { adapter, sleep: clock.sleep, now: clock.now },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.final_status).toBe('success');
+    if (result.ok) expect(result.run_id).toBe(777);
+  });
+
+  test('Phase 0: merge_group branch ref resolves via resolveBranchSha', async () => {
+    const targetSha = 'e'.repeat(40);
+    const adapter = makeAdapter(
+      async () => ({
+        ok: true,
+        data: [
+          ghRun({
+            run_id: 888,
+            status: 'completed',
+            conclusion: 'success',
+            event: 'merge_group',
+            head_sha: targetSha,
+          }),
+        ],
+      }),
+      async () => ({ ok: true, data: { sha: targetSha } }),
+    );
+    const clock = fakeClock();
+
+    const result = await waitForRun(
+      {
+        ref: 'feature/1-demo',
+        repo: 'explicit-org/explicit-repo',
+        platform: 'github',
+      },
+      { adapter, sleep: clock.sleep, now: clock.now },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.final_status).toBe('not_applicable');
+    if (result.ok) expect(result.reason).toBe('merge_group_validated');
+  });
+
+  test('Phase 1: no-run-yet then run appears and completes → success', async () => {
+    const responses: NormalizedCiRun[][] = [
+      [], // pre-flight
+      [], // phase 1 poll 1
+      [ghRun({ status: 'in_progress' })], // phase 1 poll 2 → transition to phase 2
+      [ghRun({ status: 'completed', conclusion: 'success' })], // phase 2
+    ];
+    let call = 0;
+    const adapter = makeAdapter(async () => {
+      const data = responses[Math.min(call, responses.length - 1)];
+      call++;
+      return { ok: true, data };
+    });
+    const clock = fakeClock();
+
+    const result = await waitForRun(
+      { ref: 'main', platform: 'github' },
+      { adapter, sleep: clock.sleep, now: clock.now },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.final_status).toBe('success');
+  });
+
+  test('Phase 1: no run ever appears → timeout error with helpful message', async () => {
+    const adapter = makeAdapter(async () => ({ ok: true, data: [] }));
+    const clock = fakeClock();
+
+    const result = await waitForRun(
+      { ref: 'main', platform: 'github', timeout_sec: 30, poll_interval_sec: 10 },
+      { adapter, sleep: clock.sleep, now: clock.now },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.toLowerCase()).toContain('no ci run found');
+      expect(result.waited_sec).toBeGreaterThanOrEqual(30);
+    }
+  });
+
+  test('Phase 2: stays in_progress past timeout → final_status=timed_out', async () => {
+    const adapter = makeAdapter(async () => ({
+      ok: true,
+      data: [ghRun({ status: 'in_progress' })],
+    }));
+    const clock = fakeClock();
+
+    const result = await waitForRun(
+      { ref: 'main', platform: 'github', timeout_sec: 30, poll_interval_sec: 10 },
+      { adapter, sleep: clock.sleep, now: clock.now },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.final_status).toBe('timed_out');
+    if (result.ok) expect(result.waited_sec).toBeGreaterThanOrEqual(30);
+  });
+
+  test('workflow_name filter: non-matching runs are skipped', async () => {
+    const adapter = makeAdapter(async () => ({
+      ok: true,
+      data: [
+        ghRun({ run_id: 111, workflow_name: 'Lint', status: 'in_progress' }),
+        ghRun({
+          run_id: 222,
+          workflow_name: 'Build',
+          status: 'completed',
+          conclusion: 'success',
+        }),
+      ],
+    }));
+    const clock = fakeClock();
+
+    const result = await waitForRun(
+      { ref: 'main', workflow_name: 'Build', platform: 'github' },
+      { adapter, sleep: clock.sleep, now: clock.now },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.run_id).toBe(222);
+      expect(result.final_status).toBe('success');
+    }
+  });
+
+  test('expected_sha filters out runs whose head_sha mismatches (defense-in-depth)', async () => {
+    const target = 'a'.repeat(40);
+    const other = 'b'.repeat(40);
+    const adapter = makeAdapter(async () => ({
+      ok: true,
+      data: [
+        ghRun({
+          run_id: 1,
+          status: 'completed',
+          conclusion: 'success',
+          head_sha: other,
+        }),
+        ghRun({
+          run_id: 2,
+          status: 'completed',
+          conclusion: 'success',
+          head_sha: target,
+          created_at: '2026-04-08T12:01:00Z',
+          event: 'push',
+        }),
+      ],
+    }));
+    const clock = fakeClock();
+
+    const result = await waitForRun(
+      {
+        ref: 'main',
+        expected_sha: target,
+        platform: 'github',
+        timeout_sec: 600,
+        poll_interval_sec: 10,
+      },
+      { adapter, sleep: clock.sleep, now: clock.now },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.run_id).toBe(2);
+      expect(result.sha).toBe(target);
+    }
+  });
+
+  test('GitLab: running → success maps to final_status=success (status normalization)', async () => {
+    const responses: NormalizedCiRun[][] = [
+      [glPipeline({ status: 'running' })],
+      [glPipeline({ status: 'success' })],
+    ];
+    let call = 0;
+    const adapter = makeAdapter(async () => {
+      const data = responses[Math.min(call, responses.length - 1)];
+      call++;
+      return { ok: true, data };
+    });
+    const clock = fakeClock();
+
+    const result = await waitForRun(
+      { ref: 'main', platform: 'gitlab' },
+      { adapter, sleep: clock.sleep, now: clock.now },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.final_status).toBe('success');
+  });
+
+  test('GitLab: failed maps to final_status=failure', async () => {
+    const adapter = makeAdapter(async () => ({
+      ok: true,
+      data: [glPipeline({ status: 'failed' })],
+    }));
+    const clock = fakeClock();
+
+    const result = await waitForRun(
+      { ref: 'main', platform: 'gitlab' },
+      { adapter, sleep: clock.sleep, now: clock.now },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.final_status).toBe('failure');
+  });
+
+  test('GitLab: canceled maps to final_status=cancelled', async () => {
+    const adapter = makeAdapter(async () => ({
+      ok: true,
+      data: [glPipeline({ status: 'canceled' })],
+    }));
+    const clock = fakeClock();
+
+    const result = await waitForRun(
+      { ref: 'main', platform: 'gitlab' },
+      { adapter, sleep: clock.sleep, now: clock.now },
+    );
+    expect(result.final_status).toBe('cancelled');
+  });
+
+  test('adapter error surfaces as top-level ok:false', async () => {
+    const adapter = makeAdapter(async () => ({
+      ok: false,
+      code: 'gh_run_list_failed',
+      error: 'gh: not authenticated',
+    }));
+    const clock = fakeClock();
+
+    const result = await waitForRun(
+      { ref: 'main', platform: 'github' },
+      { adapter, sleep: clock.sleep, now: clock.now },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('gh: not authenticated');
+  });
+
+  test('poll_interval_sec hard floor — values below 5 clamp to 5', async () => {
+    const responses: NormalizedCiRun[][] = [
+      [ghRun({ status: 'in_progress' })],
+      [ghRun({ status: 'in_progress' })],
+      [ghRun({ status: 'completed', conclusion: 'success' })],
+    ];
+    let call = 0;
+    const sleeps: number[] = [];
+    const adapter = makeAdapter(async () => {
+      const data = responses[Math.min(call, responses.length - 1)];
+      call++;
+      return { ok: true, data };
+    });
+    const clock = fakeClock();
+    const sleep = async (ms: number) => {
+      sleeps.push(ms);
+      await clock.sleep(ms);
+    };
+
+    const result = await waitForRun(
+      { ref: 'main', platform: 'github', poll_interval_sec: 1 },
+      { adapter, sleep, now: clock.now },
+    );
+    expect(result.ok).toBe(true);
+    // At least one sleep at exactly 5000ms (the clamped floor).
+    const mainLoopSleeps = sleeps.filter((ms) => ms === 5000);
+    expect(mainLoopSleeps.length).toBeGreaterThan(0);
+  });
+});

--- a/lib/ci-wait-run-poll.ts
+++ b/lib/ci-wait-run-poll.ts
@@ -1,0 +1,468 @@
+/**
+ * Platform-agnostic polling loop + merge-queue pre-flight for `ci_wait_run`
+ * (Story 2.19, #313).
+ *
+ * Lifted out of `handlers/ci_wait_run.ts` so the phased state machine isn't
+ * duplicated per platform — same architectural rule as `lib/pr-wait-ci-poll.ts`
+ * and `lib/pr-merge-wait-poll.ts`. Every subprocess touch goes through the
+ * routed `getAdapter()` (via the `ciListRuns` + `resolveBranchSha` sub-calls),
+ * so this module remains free of `gh`/`glab` invocations and platform
+ * branching.
+ *
+ * Phases preserved verbatim from the pre-migration handler:
+ * - Phase 0 (GitHub-only): merge-queue pre-flight. If the ref has NO
+ *   push-triggered runs but DOES have a `merge_group` run matching its HEAD
+ *   SHA, return `final_status: 'not_applicable'` with
+ *   `reason: 'merge_group_validated'`. No push-triggered runs AND no
+ *   matching merge_group → structured `not_applicable` error.
+ * - Phase 1: wait for a run to appear (no-run-yet window). When
+ *   `expected_sha` is set the window equals `timeout_sec`; otherwise a
+ *   60s floor.
+ * - Phase 2: poll the run until it completes or we time out.
+ * - Phase 3: completed — map conclusion to `final_status`.
+ *
+ * Injectable `now`/`sleep` makes tests instant. The adapter object is
+ * injectable too (`deps.adapter`) so tests can drive it directly without
+ * going through `getAdapter()`.
+ */
+
+import type {
+  CiListRunsArgs,
+  NormalizedCiRun,
+  PlatformAdapter,
+  ResolveBranchShaArgs,
+} from './adapters/types.js';
+import { log } from '../logger.js';
+
+// Defaults — lifted verbatim from the pre-migration handler.
+export const DEFAULT_POLL_INTERVAL_SEC = 10;
+export const MIN_POLL_INTERVAL_SEC = 5;
+export const DEFAULT_TIMEOUT_SEC = 1800;
+export const NO_RUN_YET_WINDOW_SEC = 60;
+export const NO_RUN_YET_POLL_SEC = 5;
+export const LIST_LIMIT = 20;
+
+export type FinalStatus =
+  | 'success'
+  | 'failure'
+  | 'cancelled'
+  | 'timed_out'
+  | 'not_applicable';
+
+export interface WaitArgs {
+  ref: string;
+  workflow_name?: string;
+  poll_interval_sec?: number;
+  timeout_sec?: number;
+  repo?: string;
+  expected_sha?: string;
+  /** Original cwd-derived slug for branch→SHA resolution when `repo` is omitted. */
+  cwd_repo_slug?: string | null;
+  platform: 'github' | 'gitlab';
+}
+
+export interface WaitDeps {
+  adapter: Pick<PlatformAdapter, 'ciListRuns' | 'resolveBranchSha'>;
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+}
+
+export type WaitResult =
+  | {
+      ok: true;
+      final_status: FinalStatus;
+      /** Present only on merge_group_validated path. */
+      reason?: 'merge_group_validated';
+      run_id?: number;
+      workflow_name?: string;
+      url?: string;
+      ref: string;
+      sha?: string;
+      waited_sec: number;
+      message?: string;
+    }
+  | {
+      ok: false;
+      error: string;
+      final_status?: FinalStatus;
+      run_id?: number;
+      workflow_name?: string;
+      url?: string;
+      ref: string;
+      sha?: string;
+      waited_sec: number;
+      platform?: 'github' | 'gitlab';
+      expected_sha?: string;
+    };
+
+function isSha(ref: string): boolean {
+  return /^[0-9a-f]{40}$/i.test(ref);
+}
+
+function shortRef(ref: string): string {
+  return isSha(ref) ? ref.slice(0, 7) : ref;
+}
+
+function logPoll(ref: string, elapsedSec: number, status: string): void {
+  log.debug('poll', {
+    tool: 'ci_wait_run',
+    ref: shortRef(ref),
+    elapsed_sec: elapsedSec,
+    status,
+  });
+}
+
+/** Snapshot we pass between phases. Slice of NormalizedCiRun + normalized status. */
+export interface RunSnapshot {
+  run_id: number;
+  workflow_name: string;
+  /** Platform-normalized: `completed` | `in_progress` | raw-other. */
+  status: string;
+  /** Normalized conclusion or null when still running. */
+  conclusion: string | null;
+  url: string;
+  sha: string;
+}
+
+// GitLab pipeline status values normalize to the same vocabulary the handler
+// used internally. Lifted verbatim.
+function normalizeGitlabStatus(status: string): {
+  status: string;
+  conclusion: string | null;
+} {
+  switch (status) {
+    case 'success':
+      return { status: 'completed', conclusion: 'success' };
+    case 'failed':
+      return { status: 'completed', conclusion: 'failure' };
+    case 'canceled':
+    case 'cancelled':
+      return { status: 'completed', conclusion: 'cancelled' };
+    case 'skipped':
+      // Treat skipped as success — there's nothing to wait on.
+      return { status: 'completed', conclusion: 'success' };
+    case 'running':
+    case 'pending':
+    case 'preparing':
+    case 'waiting_for_resource':
+    case 'created':
+    case 'scheduled':
+    case 'manual':
+      return { status: 'in_progress', conclusion: null };
+    default:
+      return { status, conclusion: null };
+  }
+}
+
+function snapshotFromRun(
+  run: NormalizedCiRun,
+  platform: 'github' | 'gitlab',
+): RunSnapshot {
+  if (platform === 'github') {
+    return {
+      run_id: run.run_id,
+      workflow_name: run.workflow_name,
+      status: run.status,
+      conclusion: run.conclusion,
+      url: run.url,
+      sha: run.head_sha,
+    };
+  }
+  const normalized = normalizeGitlabStatus(run.status);
+  return {
+    run_id: run.run_id,
+    workflow_name: run.workflow_name,
+    status: normalized.status,
+    conclusion: normalized.conclusion,
+    url: run.url,
+    sha: run.head_sha,
+  };
+}
+
+function pickRun(
+  runs: NormalizedCiRun[],
+  workflowName: string | undefined,
+  platform: 'github' | 'gitlab',
+): NormalizedCiRun | null {
+  if (runs.length === 0) return null;
+  const filtered = workflowName
+    ? runs.filter((r) =>
+        platform === 'github'
+          ? r.workflow_name === workflowName
+          : r.workflow_name === workflowName,
+      )
+    : runs;
+  if (filtered.length === 0) return null;
+  // Prefer the newest run when multiple match. List output is already reverse-
+  // chronological; be explicit so tests don't depend on that.
+  const sorted = [...filtered].sort((a, b) => {
+    const at = a.created_at ? Date.parse(a.created_at) : 0;
+    const bt = b.created_at ? Date.parse(b.created_at) : 0;
+    return bt - at;
+  });
+  return sorted[0];
+}
+
+// GitHub conclusions: success, failure, cancelled, timed_out, action_required,
+// neutral, skipped, stale — normalize to FinalStatus.
+function normalizeConclusion(
+  conclusion: string | null,
+): FinalStatus | 'unknown' {
+  if (!conclusion) return 'unknown';
+  switch (conclusion) {
+    case 'success':
+    case 'skipped':
+    case 'neutral':
+      return 'success';
+    case 'failure':
+    case 'timed_out':
+    case 'action_required':
+    case 'stale':
+      return 'failure';
+    case 'cancelled':
+    case 'canceled':
+      return 'cancelled';
+    default:
+      return 'unknown';
+  }
+}
+
+async function listRuns(
+  deps: WaitDeps,
+  args: CiListRunsArgs,
+): Promise<NormalizedCiRun[]> {
+  const result = await deps.adapter.ciListRuns(args);
+  if ('platform_unsupported' in result) {
+    throw new Error(`ciListRuns platform_unsupported: ${result.hint}`);
+  }
+  if (!result.ok) throw new Error(result.error);
+  return result.data;
+}
+
+async function resolveBranch(
+  deps: WaitDeps,
+  args: ResolveBranchShaArgs,
+): Promise<string | null> {
+  const result = await deps.adapter.resolveBranchSha(args);
+  if ('platform_unsupported' in result) return null;
+  if (!result.ok) return null;
+  return result.data ? result.data.sha : null;
+}
+
+/**
+ * Phase 0: GitHub-only merge-queue pre-flight.
+ *
+ * Returns a terminal `WaitResult` when the merge-queue path is hit
+ * (either `merge_group_validated` success or the structured
+ * `not_applicable` error); returns `null` to fall through to Phase 1.
+ */
+async function mergeQueuePreflight(
+  args: WaitArgs,
+  deps: WaitDeps,
+  expectedSha: string | undefined,
+  elapsedSec: () => number,
+): Promise<WaitResult | null> {
+  if (args.platform !== 'github') return null;
+
+  const initialRuns = await listRuns(deps, {
+    ref: args.ref,
+    workflow_name: args.workflow_name,
+    repo: args.repo,
+    expected_sha: expectedSha,
+    limit: LIST_LIMIT,
+  });
+  if (initialRuns.length === 0) return null;
+
+  const anyPush = initialRuns.some((r) => r.event === 'push');
+  if (anyPush) return null;
+
+  // No push-triggered runs. Resolve head SHA to compare against merge_group
+  // runs. When expected_sha is set, that IS the head SHA; when ref is itself
+  // a SHA, use it directly.
+  let headSha: string | null =
+    expectedSha ?? (isSha(args.ref) ? args.ref.toLowerCase() : null);
+  if (!headSha) {
+    const slug = args.repo ?? args.cwd_repo_slug ?? undefined;
+    if (slug) {
+      headSha = await resolveBranch(deps, { branch: args.ref, repo: slug });
+      if (headSha) headSha = headSha.toLowerCase();
+    }
+  }
+
+  const mergeGroupMatch = initialRuns.find(
+    (r) =>
+      r.event === 'merge_group' &&
+      headSha !== null &&
+      r.head_sha?.toLowerCase() === headSha,
+  );
+  if (mergeGroupMatch) {
+    return {
+      ok: true,
+      final_status: 'not_applicable',
+      reason: 'merge_group_validated',
+      run_id: mergeGroupMatch.run_id,
+      workflow_name: mergeGroupMatch.workflow_name,
+      url: mergeGroupMatch.url,
+      ref: args.ref,
+      sha: mergeGroupMatch.head_sha,
+      waited_sec: 0,
+    };
+  }
+
+  // No push-triggered runs and no matching merge_group run. Structured
+  // `not_applicable` error — distinguishable from a real CI failure.
+  return {
+    ok: false,
+    final_status: 'not_applicable',
+    error: `ref '${args.ref}' has no push-triggered workflows and no matching merge_group run found`,
+    ref: args.ref,
+    waited_sec: elapsedSec(),
+  };
+}
+
+async function fetchSnapshot(
+  args: WaitArgs,
+  deps: WaitDeps,
+  expectedSha: string | undefined,
+): Promise<RunSnapshot | null> {
+  const runs = await listRuns(deps, {
+    ref: args.ref,
+    workflow_name: args.workflow_name,
+    repo: args.repo,
+    expected_sha: expectedSha,
+    limit: LIST_LIMIT,
+  });
+  // Defense-in-depth: drop runs whose head_sha doesn't match expected_sha.
+  // Covers server-side filter quirks that let non-matching runs slip through.
+  const filtered = expectedSha
+    ? runs.filter((r) => r.head_sha?.toLowerCase() === expectedSha.toLowerCase())
+    : runs;
+  const picked = pickRun(filtered, args.workflow_name, args.platform);
+  return picked ? snapshotFromRun(picked, args.platform) : null;
+}
+
+/** The full `ci_wait_run` state machine. Handler is a thin dispatcher around this. */
+export async function waitForRun(
+  args: WaitArgs,
+  deps: WaitDeps,
+): Promise<WaitResult> {
+  const requestedInterval = args.poll_interval_sec ?? DEFAULT_POLL_INTERVAL_SEC;
+  const pollIntervalSec = Math.max(requestedInterval, MIN_POLL_INTERVAL_SEC);
+  const timeoutSec = args.timeout_sec ?? DEFAULT_TIMEOUT_SEC;
+  const expectedSha = args.expected_sha?.toLowerCase();
+  const noRunYetWindowSec = expectedSha ? timeoutSec : NO_RUN_YET_WINDOW_SEC;
+
+  const startMs = deps.now();
+  const elapsedSec = (): number => Math.floor((deps.now() - startMs) / 1000);
+
+  try {
+    // --- Phase 0 (GitHub only): merge-queue pre-flight ---
+    const preflight = await mergeQueuePreflight(
+      args,
+      deps,
+      expectedSha,
+      elapsedSec,
+    );
+    if (preflight) return preflight;
+
+    // --- Phase 1: wait for a run to appear (no-run-yet window) ---
+    let snapshot: RunSnapshot | null = null;
+    while (elapsedSec() < noRunYetWindowSec) {
+      snapshot = await fetchSnapshot(args, deps, expectedSha);
+      if (snapshot) break;
+      logPoll(args.ref, elapsedSec(), 'no_run_yet');
+      if (elapsedSec() >= timeoutSec) break;
+      const sleepSec = expectedSha ? pollIntervalSec : NO_RUN_YET_POLL_SEC;
+      await deps.sleep(sleepSec * 1000);
+    }
+
+    if (!snapshot) {
+      const waited = elapsedSec();
+      const filterMsg = args.workflow_name
+        ? ` (filtered by workflow_name='${args.workflow_name}')`
+        : '';
+      const shaMsg = expectedSha ? ` with head SHA '${expectedSha}'` : '';
+      return {
+        ok: false,
+        error:
+          `No CI run found for ref '${args.ref}'${shaMsg}${filterMsg} after waiting ${waited}s. ` +
+          `The pipeline may not have been triggered, or the ref has not been pushed to origin. ` +
+          `Verify with: gh run list --${isSha(args.ref) ? 'commit' : 'branch'} ${args.ref}`,
+        waited_sec: waited,
+        ref: args.ref,
+        platform: args.platform,
+        ...(expectedSha ? { expected_sha: expectedSha } : {}),
+      };
+    }
+
+    // --- Phase 2: poll the run until it completes or we time out ---
+    logPoll(args.ref, elapsedSec(), snapshot.status);
+
+    while (snapshot.status !== 'completed') {
+      if (elapsedSec() >= timeoutSec) {
+        return {
+          ok: true,
+          run_id: snapshot.run_id,
+          workflow_name: snapshot.workflow_name,
+          final_status: 'timed_out',
+          url: snapshot.url,
+          ref: args.ref,
+          sha: snapshot.sha,
+          waited_sec: elapsedSec(),
+          message:
+            `ci_wait_run hit timeout_sec=${timeoutSec} while run was still '${snapshot.status}'. ` +
+            `The run is still executing on the server — check ${snapshot.url}.`,
+        };
+      }
+      await deps.sleep(pollIntervalSec * 1000);
+      const next = await fetchSnapshot(args, deps, expectedSha);
+      if (!next) {
+        logPoll(args.ref, elapsedSec(), `${snapshot.status}(stale,no_run_returned)`);
+        continue;
+      }
+      snapshot = next;
+      logPoll(args.ref, elapsedSec(), snapshot.status);
+    }
+
+    // --- Phase 3: completed — map conclusion to final_status ---
+    const finalStatus = normalizeConclusion(snapshot.conclusion);
+    if (finalStatus === 'unknown') {
+      return {
+        ok: false,
+        error:
+          `Run completed with unrecognized conclusion '${snapshot.conclusion ?? 'null'}'. ` +
+          `run_id=${snapshot.run_id} url=${snapshot.url}`,
+        run_id: snapshot.run_id,
+        workflow_name: snapshot.workflow_name,
+        url: snapshot.url,
+        ref: args.ref,
+        sha: snapshot.sha,
+        waited_sec: elapsedSec(),
+      };
+    }
+
+    return {
+      ok: true,
+      run_id: snapshot.run_id,
+      workflow_name: snapshot.workflow_name,
+      final_status: finalStatus,
+      url: snapshot.url,
+      ref: args.ref,
+      sha: snapshot.sha,
+      waited_sec: elapsedSec(),
+    };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      error,
+      ref: args.ref,
+      platform: args.platform,
+      waited_sec: elapsedSec(),
+    };
+  }
+}
+
+export function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/scripts/ci/migration-allowlist.txt
+++ b/scripts/ci/migration-allowlist.txt
@@ -9,7 +9,6 @@
 # off-by-one that was reconciled to disk reality).
 #
 # Format: one basename per line. Comments (#) and blank lines ignored.
-ci_wait_run.ts
 wave_ci_trust_level.ts
 wave_finalize.ts
 wave_init.ts

--- a/tests/ci_wait_run.test.ts
+++ b/tests/ci_wait_run.test.ts
@@ -10,11 +10,21 @@ type RegistryValue = string | string[];
 let execRegistry: Record<string, RegistryValue> = {};
 let execCallLog: string[] = [];
 
+// Story 2.19 (#313): post-migration, subprocess calls go through `runArgv`
+// which single-quotes every argv element. To keep the existing registry keys
+// (`'gh run list'`, `'gh api repos/...'`, etc.) matching, strip single quotes
+// from the cmd before matching. `glab api ...` calls still pass through
+// `execGlab` (raw string), so those are unaffected by the normalization.
+function normalizeCmd(cmd: string): string {
+  return cmd.replace(/'/g, '');
+}
+
 function mockExec(cmd: string): string {
   execCallLog.push(cmd);
+  const normalized = normalizeCmd(cmd);
   const keys = Object.keys(execRegistry).sort((a, b) => b.length - a.length);
   for (const key of keys) {
-    if (cmd.includes(key)) {
+    if (cmd.includes(key) || normalized.includes(key)) {
       const value = execRegistry[key];
       if (Array.isArray(value)) {
         if (value.length === 0) {
@@ -40,6 +50,16 @@ const { __setSleep, __resetSleep } = handlerMod;
 
 function parseResult(content: Array<{ type: string; text: string }>) {
   return JSON.parse(content[0].text) as Record<string, unknown>;
+}
+
+// Post-migration, gh/glab calls run through `runArgv`'s shell-escaped argv:
+// each element is single-quoted. Use this helper to filter & inspect cmd
+// strings regardless of quoting style.
+function ghRunListCalls(): string[] {
+  return execCallLog.filter((c) => normalizeCmd(c).includes('gh run list'));
+}
+function glabApiCalls(): string[] {
+  return execCallLog.filter((c) => normalizeCmd(c).includes('glab api'));
 }
 
 // Helpers to construct fake gh/glab output.
@@ -269,7 +289,7 @@ describe('ci_wait_run handler', () => {
     const data = parseResult(result.content);
     expect(data.ok).toBe(true);
     // Verify the exec call used --commit, not --branch.
-    const ghCalls = execCallLog.filter((c) => c.startsWith('gh run list'));
+    const ghCalls = ghRunListCalls();
     expect(ghCalls.length).toBeGreaterThan(0);
     expect(ghCalls[0]).toContain('--commit');
     expect(ghCalls[0]).not.toContain('--branch');
@@ -285,7 +305,7 @@ describe('ci_wait_run handler', () => {
     const result = await ciWaitRunHandler.execute({ ref: 'feature/1-demo' });
     const data = parseResult(result.content);
     expect(data.ok).toBe(true);
-    const ghCalls = execCallLog.filter((c) => c.startsWith('gh run list'));
+    const ghCalls = ghRunListCalls();
     expect(ghCalls.length).toBeGreaterThan(0);
     expect(ghCalls[0]).toContain('--branch');
     expect(ghCalls[0]).not.toContain('--commit');
@@ -487,9 +507,9 @@ describe('ci_wait_run handler', () => {
     const data = parseResult(result.content);
     expect(data.ok).toBe(true);
     expect(data.final_status).toBe('success');
-    const ghCalls = execCallLog.filter((c) => c.startsWith('gh run list'));
+    const ghCalls = ghRunListCalls();
     expect(ghCalls.length).toBeGreaterThan(0);
-    expect(ghCalls[0]).toContain('--repo "other-org/other-repo"');
+    expect(normalizeCmd(ghCalls[0])).toContain('--repo other-org/other-repo');
   });
 
   // GitHub merge-queue fallback with explicit repo → must skip parseRepoSlug()
@@ -531,11 +551,11 @@ describe('ci_wait_run handler', () => {
     // slug — the handler must have skipped `parseRepoSlug()` (which would
     // have returned `cwd-org/cwd-repo`) and used the caller's `repo` directly.
     const apiCalls = execCallLog.filter((c) =>
-      c.includes('gh api repos/other-org/other-repo/git/refs/heads/main'),
+      normalizeCmd(c).includes('gh api repos/other-org/other-repo/git/refs/heads/main'),
     );
     expect(apiCalls.length).toBe(1);
     const wrongApiCalls = execCallLog.filter((c) =>
-      c.includes('gh api repos/cwd-org/cwd-repo/git/refs/'),
+      normalizeCmd(c).includes('gh api repos/cwd-org/cwd-repo/git/refs/'),
     );
     expect(wrongApiCalls.length).toBe(0);
   });
@@ -559,7 +579,7 @@ describe('ci_wait_run handler', () => {
     expect(data.ok).toBe(true);
     expect(data.final_status).toBe('success');
 
-    const glabCalls = execCallLog.filter((c) => c.startsWith('glab api'));
+    const glabCalls = glabApiCalls();
     expect(glabCalls.length).toBeGreaterThan(0);
     // Every glab call must target the explicit encoded slug.
     for (const c of glabCalls) {
@@ -596,7 +616,7 @@ describe('ci_wait_run handler', () => {
     expect(data.reason).toBe('merge_group_validated');
     // Must not have asked the cwd for a SHA.
     const wrongApiCalls = execCallLog.filter((c) =>
-      c.includes('gh api repos/cwd-org/cwd-repo/git/refs/'),
+      normalizeCmd(c).includes('gh api repos/cwd-org/cwd-repo/git/refs/'),
     );
     expect(wrongApiCalls.length).toBe(0);
   });
@@ -645,10 +665,10 @@ describe('ci_wait_run handler', () => {
     expect(data.sha).toBe(targetSha);
     // Every gh run list call must have included --commit "<targetSha>" so we
     // never even saw runs for `previousSha`.
-    const ghCalls = execCallLog.filter((c) => c.startsWith('gh run list'));
+    const ghCalls = ghRunListCalls();
     expect(ghCalls.length).toBeGreaterThan(0);
     for (const c of ghCalls) {
-      expect(c).toContain(`--commit "${targetSha}"`);
+      expect(normalizeCmd(c)).toContain(`--commit ${targetSha}`);
     }
     // Sanity: previousSha must never have leaked into a query.
     for (const c of ghCalls) {
@@ -701,9 +721,9 @@ describe('ci_wait_run handler', () => {
     expect(data.final_status).toBe('success');
     // The gh run list call must NOT have included --commit (ref is a branch
     // name and no expected_sha was provided).
-    const ghCalls = execCallLog.filter((c) => c.startsWith('gh run list'));
+    const ghCalls = ghRunListCalls();
     expect(ghCalls.length).toBeGreaterThan(0);
-    expect(ghCalls[0]).toContain('--branch "main"');
+    expect(normalizeCmd(ghCalls[0])).toContain('--branch main');
     expect(ghCalls[0]).not.toContain('--commit');
   });
 
@@ -778,7 +798,7 @@ describe('ci_wait_run handler', () => {
     expect(data.run_id).toBe(7777);
     expect(data.sha).toBe(targetSha);
     // Verify the glab call carried the encoded sha=<targetSha> query param.
-    const glabCalls = execCallLog.filter((c) => c.startsWith('glab api'));
+    const glabCalls = glabApiCalls();
     expect(glabCalls.length).toBeGreaterThan(0);
     for (const c of glabCalls) {
       expect(c).toContain(`sha=${targetSha}`);


### PR DESCRIPTION
## Summary

Hybrid migration of `ci_wait_run` to the platform-adapter pattern. Lands two new `PlatformAdapter` keystone sub-calls (`ciListRuns`, `resolveBranchSha`) with R-03 typed asymmetry on GitLab's `resolveBranchSha`. Extracts the four-phase polling state machine to `lib/ci-wait-run-poll.ts`. Handler collapsed to exactly 80 lines (ceiling per AC).

## Changes

- `lib/adapters/types.ts` — added `CiListRunsArgs`, `NormalizedCiRun`, `CiListRunsResponse`, `ResolveBranchShaArgs`, `ResolveBranchShaResponse`; extended `PlatformAdapter` + `PLATFORM_ADAPTER_METHODS`.
- `lib/adapters/ci-list-runs-github.ts` + `ci-list-runs-gitlab.ts` — new adapters (gh `run list` event+head_sha+limit; GitLab via `gitlabApiCiList` with client-side workflow_name filter).
- `lib/adapters/resolve-branch-sha-github.ts` — `gh api repos/<slug>/git/refs/heads/<branch>`; soft-fails to `null`.
- `lib/adapters/resolve-branch-sha-gitlab.ts` — PERMANENT `platform_unsupported` stub (R-03).
- `lib/adapters/github.ts` + `gitlab.ts` — wired the four new adapters.
- `lib/adapters/types.test.ts` — `'ciListRuns'` + `'resolveBranchSha'` in `MIGRATED_METHODS`.
- `lib/ci-wait-run-poll.ts` — NEW platform-agnostic state machine (Phase 0 merge-queue pre-flight, Phase 1 no-run-yet, Phase 2 poll-to-completion, Phase 3 conclusion normalization); injectable `now`/`sleep` for instant tests.
- `handlers/ci_wait_run.ts` — 80 lines; dispatches through `getAdapter()` + `waitForRun`.
- `scripts/ci/migration-allowlist.txt` — removed `ci_wait_run.ts`.
- Colocated tests: 43 new tests across 5 files.
- `tests/ci_wait_run.test.ts` — normalized shell-escaped argv via `normalizeCmd` helper; 31 tests green.

## Linked Issues

Closes #313

## Test Plan

- `./scripts/ci/validate.sh` — exit 0 (codegen, tsc, gate-greps, shellcheck, 1908 tests, runtime smoke 73/73)
- `bun test` — 1908 pass / 0 fail / 4662 expect() calls
- `wc -l handlers/ci_wait_run.ts` — 80 (ceiling exactly)
- `grep ci_wait_run scripts/ci/migration-allowlist.txt` — no match