### PR TITLE
refactor(wave_init): migrate to platform adapter + land createBranch (#316)

### DIFF
--- a/handlers/wave_init.ts
+++ b/handlers/wave_init.ts
@@ -1,449 +1,78 @@
+// Wave-init handler — platform-agnostic shell. Platform calls go through
+// `getAdapter()`; plan/state helpers live in `lib/wave_init_plan.ts`.
+// Story 2.22 (#316).
 import { execSync } from 'child_process';
-import { writeFileSync } from 'fs';
 import { join } from 'path';
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
-import { detectPlatform } from '../lib/shared/detect-platform.js';
 import { parseRepoSlug } from '../lib/shared/parse-repo-slug.js';
+import { getAdapter } from '../lib/adapters/index.js';
+import {
+  projectDir, writePlanFile, statusDir, readJson, countIssuesFromPlan,
+  extendModePrescan, readPhasesWavesTotals, bootstrapKahunaBranch,
+  branchExistsOnRemote, type PlanData, type StateData,
+} from '../lib/wave_init_plan.js';
 
 const inputSchema = z.object({
   plan_json: z.string().min(1, 'plan_json must be a non-empty JSON string'),
   extend: z.boolean().optional().default(false),
   project_root: z.string().optional(),
-  repo: z
-    .string()
-    .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/, 'repo must be owner/repo format')
-    .optional(),
-  // KAHUNA bootstrap (devspec §5.1.3). Optional; absence preserves the
-  // pre-KAHUNA behavior end-to-end (CT-03 backward compat).
-  kahuna: z
-    .object({
-      epic_id: z.number().int().positive(),
-      slug: z.string().min(1).regex(/^[a-z0-9][a-z0-9-]*$/, 'slug must be kebab-case (lowercase, digits, hyphens)'),
-    })
-    .optional(),
+  repo: z.string().regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/, 'repo must be owner/repo format').optional(),
+  kahuna: z.object({
+    epic_id: z.number().int().positive(),
+    slug: z.string().min(1).regex(/^[a-z0-9][a-z0-9-]*$/, 'slug must be kebab-case (lowercase, digits, hyphens)'),
+  }).optional(),
 });
 
-type Input = z.infer<typeof inputSchema>;
-
-interface PlanWave {
-  id?: string;
-  issues?: unknown[];
-}
-
-interface PlanPhase {
-  waves?: PlanWave[];
-}
-
-interface PlanData {
-  phases?: PlanPhase[];
-}
-
-interface StateData {
-  waves?: Record<string, unknown>;
-}
-
-interface PhasesWavesData {
-  phases?: Array<{ waves?: unknown[] }>;
-}
-
-function projectDir(override?: string): string {
-  if (override !== undefined && override.length > 0) return override;
-  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
-}
-
-function writePlanFile(planJson: string): string {
-  const path = `/tmp/wave-init-plan-${Date.now()}-${Math.floor(Math.random() * 1e6)}.json`;
-  writeFileSync(path, planJson);
-  return path;
-}
-
-async function fileExists(path: string): Promise<boolean> {
-  return await Bun.file(path).exists();
-}
-
-async function readJson(path: string): Promise<unknown> {
-  return await Bun.file(path).json();
-}
-
-async function statusDir(root: string): Promise<string> {
-  // Prefer .sdlc/waves/ if .sdlc/ exists; otherwise fall back to .claude/status/.
-  const sdlc = join(root, '.sdlc');
-  if (await fileExists(sdlc)) return join(sdlc, 'waves');
-  return join(root, '.claude', 'status');
-}
-
-function countIssuesFromPlan(plan: PlanData): {
-  phases_added: number;
-  waves_added: number;
-  issues_added: number;
-} {
-  const phases = plan.phases ?? [];
-  let waves_added = 0;
-  let issues_added = 0;
-  for (const phase of phases) {
-    for (const wave of phase.waves ?? []) {
-      waves_added += 1;
-      issues_added += (wave.issues ?? []).length;
-    }
-  }
-  return {
-    phases_added: phases.length,
-    waves_added,
-    issues_added,
-  };
-}
-
-function extractPlanWaveIds(plan: PlanData): string[] {
-  const ids: string[] = [];
-  for (const phase of plan.phases ?? []) {
-    for (const wave of phase.waves ?? []) {
-      if (typeof wave.id === 'string' && wave.id.length > 0) {
-        ids.push(wave.id);
-      }
-    }
-  }
-  return ids;
-}
-
-// ---------------------------------------------------------------------------
-// KAHUNA bootstrap helpers (devspec §5.1.3)
-// ---------------------------------------------------------------------------
-
-function shellEscape(s: string): string {
-  return `'${s.replace(/'/g, `'\\''`)}'`;
-}
-
-function execOk(cmd: string, cwd: string): { ok: boolean; stdout: string; stderr: string } {
-  try {
-    const stdout = execSync(cmd, { encoding: 'utf8', cwd });
-    return { ok: true, stdout: stdout.trim(), stderr: '' };
-  } catch (err) {
-    const e = err as { stderr?: Buffer | string; stdout?: Buffer | string; message?: string };
-    const stderr = (typeof e.stderr === 'string' ? e.stderr : e.stderr?.toString() ?? '') ?? '';
-    const stdout = (typeof e.stdout === 'string' ? e.stdout : e.stdout?.toString() ?? '') ?? '';
-    return { ok: false, stdout: stdout.trim(), stderr: stderr.trim() || e.message || '' };
-  }
-}
-
-function branchExistsOnRemote(cwd: string, branch: string): boolean {
-  const out = execOk(`git ls-remote --heads origin ${shellEscape(branch)}`, cwd);
-  return out.ok && out.stdout.length > 0;
-}
-
-const SHA_RE = /^[0-9a-f]{40}$/;
-
-function getMainHeadSha(cwd: string, repoSlug: string | null, platform: 'github' | 'gitlab', baseBranch: string): string {
-  // `gh api` and `glab api` resolve repo context from the URL path itself —
-  // no `--repo` flag (that belongs to the porcelain subcommands like
-  // `gh pr ...`). The slug is validated by parseRepoSlug's regex; baseBranch
-  // is shell-escaped because it originates from operator-controlled plan_json.
-  if (platform === 'github') {
-    const slug = repoSlug ?? ':owner/:repo';
-    const out = execOk(
-      `gh api repos/${slug}/branches/${shellEscape(baseBranch)} --jq .commit.sha`,
-      cwd,
-    );
-    if (!out.ok || out.stdout.length === 0) {
-      throw new Error(`failed to read ${baseBranch} HEAD SHA: ${out.stderr || 'empty response'}`);
-    }
-    if (!SHA_RE.test(out.stdout)) {
-      throw new Error(`unexpected SHA from gh api: ${out.stdout.slice(0, 80)}`);
-    }
-    return out.stdout;
-  }
-  // GitLab
-  const slug = repoSlug ?? '';
-  const encoded = slug.replace(/\//g, '%2F');
-  const out = execOk(
-    `glab api projects/${encoded}/repository/branches/${shellEscape(baseBranch)}`,
-    cwd,
-  );
-  if (!out.ok) {
-    throw new Error(`failed to read ${baseBranch} HEAD SHA: ${out.stderr || 'empty response'}`);
-  }
-  try {
-    const parsed = JSON.parse(out.stdout) as { commit?: { id?: string } };
-    const sha = parsed.commit?.id;
-    if (typeof sha !== 'string' || !SHA_RE.test(sha)) {
-      throw new Error(`unexpected branches API shape: invalid or missing commit.id`);
-    }
-    return sha;
-  } catch (err) {
-    throw new Error(`failed to parse ${baseBranch} branches API: ${err instanceof Error ? err.message : String(err)}`);
-  }
-}
-
-function createKahunaBranch(
-  cwd: string,
-  repoSlug: string | null,
-  platform: 'github' | 'gitlab',
-  branch: string,
-  sha: string,
-): void {
-  if (platform === 'github') {
-    const slug = repoSlug ?? ':owner/:repo';
-    const out = execOk(
-      `gh api repos/${slug}/git/refs -X POST -f ref=${shellEscape(`refs/heads/${branch}`)} -f sha=${shellEscape(sha)}`,
-      cwd,
-    );
-    if (!out.ok) {
-      throw new Error(`failed to create branch ${branch}: ${out.stderr || out.stdout}`);
-    }
-    return;
-  }
-  // GitLab — POST /projects/:id/repository/branches?branch=<name>&ref=<sha>
-  const encoded = (repoSlug ?? '').replace(/\//g, '%2F');
-  const out = execOk(
-    `glab api projects/${encoded}/repository/branches -X POST -f branch=${shellEscape(branch)} -f ref=${shellEscape(sha)}`,
-    cwd,
-  );
-  if (!out.ok) {
-    throw new Error(`failed to create branch ${branch}: ${out.stderr || out.stdout}`);
-  }
-}
-
-function recordKahunaBranchInState(cwd: string, branch: string): void {
-  const out = execOk(`wave-status set-kahuna-branch ${shellEscape(branch)}`, cwd);
-  if (!out.ok) {
-    throw new Error(`wave-status set-kahuna-branch failed: ${out.stderr || out.stdout}`);
-  }
-}
-
-interface KahunaBootstrapResult {
-  ok: true;
-  kahuna_branch: string;
-  created: boolean; // true if newly created, false if reused
-}
-
-interface KahunaBootstrapError {
-  ok: false;
-  error: string;
-}
-
-async function bootstrapKahunaBranch(
-  cwd: string,
-  kahuna: { epic_id: number; slug: string },
-  baseBranch: string,
-  readState: () => Promise<{ kahuna_branch?: string | null }>,
-): Promise<KahunaBootstrapResult | KahunaBootstrapError> {
-  const desired = `kahuna/${kahuna.epic_id}-${kahuna.slug}`;
-  const platform = detectPlatform();
-  const repoSlug = parseRepoSlug();
-
-  const state = await readState();
-  const recorded = state.kahuna_branch ?? null;
-
-  if (recorded === desired) {
-    // State already records the desired branch — verify presence on remote.
-    if (branchExistsOnRemote(cwd, desired)) {
-      return { ok: true, kahuna_branch: desired, created: false };
-    }
-    // Recorded but missing from remote: state and platform are out of sync.
-    // Refuse rather than silently recreate; this is a corruption signal that
-    // warrants human attention (matches the spirit of the spec's orphan rule).
-    return {
-      ok: false,
-      error: `kahuna_branch ${desired} is recorded in state but missing from remote — manual triage required`,
-    };
-  }
-
-  if (recorded !== null && recorded !== desired) {
-    // State has a different kahuna_branch — refuse rather than overwrite.
-    return {
-      ok: false,
-      error: `wave state already records kahuna_branch '${recorded}' which does not match requested '${desired}'`,
-    };
-  }
-
-  // recorded === null: state is unset. Check the remote for an orphan.
-  if (branchExistsOnRemote(cwd, desired)) {
-    return {
-      ok: false,
-      error: `orphan kahuna branch ${desired} exists on remote but is not recorded in state — manual triage required`,
-    };
-  }
-
-  // Fresh creation path.
-  const sha = getMainHeadSha(cwd, repoSlug, platform, baseBranch);
-  createKahunaBranch(cwd, repoSlug, platform, desired, sha);
-  recordKahunaBranchInState(cwd, desired);
-  return { ok: true, kahuna_branch: desired, created: true };
-}
+const envelope = (payload: unknown) => ({ content: [{ type: 'text' as const, text: JSON.stringify(payload) }] });
+const shellQuote = (s: string) => `'${s.replace(/'/g, `'\\''`)}'`;
 
 const waveInitHandler: HandlerDef = {
   name: 'wave_init',
   description:
     'Initialize a wave plan from structured JSON; supports --extend mode. ' +
-    'Optional `kahuna` argument bootstraps a `kahuna/<epic_id>-<slug>` integration branch ' +
-    'off the plan\'s base_branch (default `main`) and records it in wave state — used by ' +
-    'autonomous /wavemachine flows; pre-KAHUNA callers omit `kahuna` and see no behavior change.',
+    'Optional `kahuna` argument bootstraps a `kahuna/<epic_id>-<slug>` branch ' +
+    'off the plan\'s base_branch (default `main`) and records it in wave state.',
   inputSchema,
   async execute(rawArgs: unknown) {
-    let args: Input;
-    try {
-      args = inputSchema.parse(rawArgs);
-    } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
-    }
+    let args: z.infer<typeof inputSchema>;
+    try { args = inputSchema.parse(rawArgs); }
+    catch (err) { return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) }); }
 
-    // Extend-mode collision pre-scan: defense in depth on top of the CLI's
-    // own collision guard. Parse the plan, read the existing state file, and
-    // refuse before touching the CLI if any wave IDs already exist.
+    const cwd = projectDir(args.project_root);
     if (args.extend) {
-      let planParsed: PlanData;
-      try {
-        planParsed = JSON.parse(args.plan_json) as PlanData;
-      } catch (err) {
-        const detail = err instanceof Error ? err.message : String(err);
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                ok: false,
-                error: `plan_json is not valid JSON: ${detail}`,
-              }),
-            },
-          ],
-        };
-      }
-
-      try {
-        const dir = await statusDir(projectDir(args.project_root));
-        const statePath = join(dir, 'state.json');
-
-        if (!(await fileExists(statePath))) {
-          return {
-            content: [
-              {
-                type: 'text' as const,
-                text: JSON.stringify({ ok: false, error: 'no existing plan found' }),
-              },
-            ],
-          };
-        }
-
-        const state = (await readJson(statePath)) as StateData;
-        const existingIds = new Set(Object.keys(state.waves ?? {}));
-        const incomingIds = extractPlanWaveIds(planParsed);
-        const colliding = incomingIds.filter(id => existingIds.has(id));
-
-        if (colliding.length > 0) {
-          return {
-            content: [
-              {
-                type: 'text' as const,
-                text: JSON.stringify({
-                  ok: false,
-                  error: `wave ID collision: ${colliding.join(', ')} already exist`,
-                  colliding_ids: colliding,
-                }),
-              },
-            ],
-          };
-        }
-      } catch (err) {
-        const error = err instanceof Error ? err.message : String(err);
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-        };
-      }
+      const pre = await extendModePrescan(args.plan_json, cwd);
+      if (!pre.ok) return envelope(pre);
     }
-
     try {
       const planFile = writePlanFile(args.plan_json);
       const extendFlag = args.extend ? ' --extend' : '';
-      // Single-quote the repo value before interpolating into the shell
-      // string. The Zod regex already restricts the character set to shell-
-      // safe chars, but explicit quoting is defense-in-depth + consistent
-      // with how issue_ref and mr_ref are handled in the other wave handlers.
-      const repoFlag = args.repo
-        ? ` --repo '${args.repo.replace(/'/g, `'\\''`)}'`
-        : '';
-      const cmd = `wave-status init${extendFlag}${repoFlag} ${planFile}`;
-      execSync(cmd, {
-        cwd: projectDir(args.project_root),
-        encoding: 'utf8',
-      });
+      const repoFlag = args.repo ? ` --repo ${shellQuote(args.repo)}` : '';
+      execSync(`wave-status init${extendFlag}${repoFlag} ${planFile}`, { cwd, encoding: 'utf8' });
 
-      // Rich success payload: count what the plan added, then re-read the
-      // phases-waves.json the CLI just wrote to report project totals.
-      const planParsed = JSON.parse(args.plan_json) as PlanData;
-      const { phases_added, waves_added, issues_added } = countIssuesFromPlan(planParsed);
+      const plan = JSON.parse(args.plan_json) as PlanData;
+      const counts = countIssuesFromPlan(plan);
+      const totals = await readPhasesWavesTotals(cwd);
 
-      let total_phases = 0;
-      let total_waves = 0;
-      try {
-        const dir = await statusDir(projectDir(args.project_root));
-        const phasesPath = join(dir, 'phases-waves.json');
-        if (await fileExists(phasesPath)) {
-          const phasesData = (await readJson(phasesPath)) as PhasesWavesData;
-          const phases = phasesData.phases ?? [];
-          total_phases = phases.length;
-          for (const p of phases) {
-            total_waves += (p.waves ?? []).length;
-          }
-        }
-      } catch {
-        // If the phases file can't be read, leave totals at 0 rather than
-        // failing the whole call — the CLI already succeeded.
-      }
-
-      // KAHUNA bootstrap (devspec §5.1.3): runs after init/extend has written
-      // state.json, so we can read+update it. Failures here surface as
-      // ok:false but do NOT roll back the wave init — the plan is already
-      // recorded; the operator can retry the kahuna step.
-      let kahunaBranch: string | undefined;
-      let kahunaCreated: boolean | undefined;
+      let kahuna: { kahuna_branch: string; kahuna_created: boolean } | undefined;
       if (args.kahuna !== undefined) {
-        const cwd = projectDir(args.project_root);
-        const planParsedForBase = JSON.parse(args.plan_json) as PlanData & { base_branch?: string };
-        const baseBranch = typeof planParsedForBase.base_branch === 'string' && planParsedForBase.base_branch.length > 0
-          ? planParsedForBase.base_branch
-          : 'main';
-        const dir = await statusDir(cwd);
-        const statePath = join(dir, 'state.json');
-        const result = await bootstrapKahunaBranch(
-          cwd,
-          args.kahuna,
-          baseBranch,
-          async () => (await readJson(statePath)) as { kahuna_branch?: string | null },
-        );
-        if (!result.ok) {
-          return {
-            content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error: result.error }) }],
-          };
-        }
-        kahunaBranch = result.kahuna_branch;
-        kahunaCreated = result.created;
+        const baseBranch = typeof plan.base_branch === 'string' && plan.base_branch.length > 0 ? plan.base_branch : 'main';
+        const statePath = join(await statusDir(cwd), 'state.json');
+        const slug = args.repo ?? parseRepoSlug() ?? undefined;
+        const result = await bootstrapKahunaBranch(cwd, args.kahuna, baseBranch,
+          async () => (await readJson(statePath)) as StateData,
+          {
+            adapter: getAdapter({ repo: slug }), slug,
+            recordKahunaBranch: (b) => { execSync(`wave-status set-kahuna-branch ${shellQuote(b)}`, { cwd, encoding: 'utf8' }); },
+            branchPresentOnRemote: (b) => branchExistsOnRemote(cwd, b),
+          });
+        if (!result.ok) return envelope({ ok: false, error: result.error });
+        kahuna = { kahuna_branch: result.kahuna_branch, kahuna_created: result.created };
       }
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({
-              ok: true,
-              mode: args.extend ? 'extend' : 'init',
-              phases_added,
-              waves_added,
-              issues_added,
-              total_phases,
-              total_waves,
-              ...(kahunaBranch !== undefined ? { kahuna_branch: kahunaBranch, kahuna_created: kahunaCreated } : {}),
-            }),
-          },
-        ],
-      };
+      return envelope({ ok: true, mode: args.extend ? 'extend' : 'init', ...counts, ...totals, ...(kahuna ?? {}) });
     } catch (err) {
-      const error = err instanceof Error ? err.message : String(err);
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify({ ok: false, error }) }],
-      };
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
   },
 };

--- a/lib/adapters/create-branch-github.test.ts
+++ b/lib/adapters/create-branch-github.test.ts
@@ -1,0 +1,152 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { AdapterResult } from './types.ts';
+
+// Subprocess-boundary tests for the GitHub createBranch adapter (R-15).
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { createBranchGithub } = await import('./create-branch-github.ts');
+
+function on(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
+function expectOk(r: AdapterResult<void>): asserts r is { ok: true; data: void } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+}
+
+const VALID_SHA = 'a'.repeat(40);
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('createBranchGithub — subprocess boundary', () => {
+  test('argv: gh api repos/<slug>/git/refs -X POST -f ref=refs/heads/<branch> -f sha=<sha>', async () => {
+    on('gh api repos/org/repo/git/refs', '');
+
+    const result = await createBranchGithub({
+      branch: 'kahuna/42-wave-status-cli',
+      sha: VALID_SHA,
+      repo: 'org/repo',
+    });
+    expectOk(result);
+
+    const call = findCall('gh api');
+    expect(call).toContain('repos/org/repo/git/refs');
+    expect(call).toContain('-X');
+    expect(call).toContain('POST');
+    expect(call).toContain('-f');
+    // After shell-unquoting, the -f key=value pairs are present.
+    const flat = unquote(call);
+    expect(flat).toContain('ref=refs/heads/kahuna/42-wave-status-cli');
+    expect(flat).toContain(`sha=${VALID_SHA}`);
+  });
+
+  test('void return on success', async () => {
+    on('gh api', '');
+    const result = await createBranchGithub({
+      branch: 'feature/1-demo',
+      sha: VALID_SHA,
+      repo: 'org/repo',
+    });
+    expectOk(result);
+    expect(result.data).toBeUndefined();
+  });
+
+  test('returns ok:false when gh exits non-zero', async () => {
+    on('gh api', () => {
+      const err = new Error('gh: Reference already exists') as ThrowableError;
+      err.stderr = 'Reference already exists';
+      err.status = 1;
+      throw err;
+    });
+
+    const result = await createBranchGithub({
+      branch: 'kahuna/1-foo',
+      sha: VALID_SHA,
+      repo: 'org/repo',
+    });
+    expect('ok' in result && result.ok).toBe(false);
+    expect((result as { code: string }).code).toBe('gh_create_branch_failed');
+    expect((result as { error: string }).error).toContain('kahuna/1-foo');
+  });
+
+  test('does NOT pass --repo flag (gh api is path-resolved)', async () => {
+    on('gh api', '');
+    await createBranchGithub({
+      branch: 'kahuna/1-foo',
+      sha: VALID_SHA,
+      repo: 'org/repo',
+    });
+    const call = findCall('gh api');
+    expect(call).not.toContain('--repo');
+  });
+
+  test('rejects invalid branch characters', async () => {
+    const result = await createBranchGithub({
+      branch: 'bad; rm -rf /',
+      sha: VALID_SHA,
+      repo: 'org/repo',
+    });
+    expect('ok' in result && result.ok).toBe(false);
+    expect((result as { code: string }).code).toBe('invalid_branch');
+    expect(execCalls.length).toBe(0);
+  });
+
+  test('rejects invalid sha', async () => {
+    const result = await createBranchGithub({
+      branch: 'main',
+      sha: 'not-a-sha',
+      repo: 'org/repo',
+    });
+    expect('ok' in result && result.ok).toBe(false);
+    expect((result as { code: string }).code).toBe('invalid_sha');
+    expect(execCalls.length).toBe(0);
+  });
+
+  test('rejects invalid repo slug', async () => {
+    const result = await createBranchGithub({
+      branch: 'main',
+      sha: VALID_SHA,
+      repo: 'no-slash',
+    });
+    expect('ok' in result && result.ok).toBe(false);
+    expect((result as { code: string }).code).toBe('invalid_repo');
+    expect(execCalls.length).toBe(0);
+  });
+});

--- a/lib/adapters/create-branch-github.ts
+++ b/lib/adapters/create-branch-github.ts
@@ -1,0 +1,90 @@
+/**
+ * GitHub `createBranch` adapter implementation.
+ *
+ * Lifted from `handlers/wave_init.ts`'s local `createKahunaBranch` helper per
+ * Story 2.22 (#316). Creates a new branch ref pointing at an explicit SHA.
+ *
+ * Argv: `gh api repos/<slug>/git/refs -X POST -f ref=refs/heads/<branch>
+ *        -f sha=<sha>`.
+ *
+ * `gh api` resolves repo context from the URL path — no `--repo` flag
+ * (that belongs to porcelain subcommands like `gh pr …`). The slug must
+ * match `owner/repo`; branch/sha are validated against narrow regexes.
+ *
+ * Returns `void` on success. There's no "already exists" idempotent path —
+ * the handler's state/remote pre-check catches that case before the call.
+ */
+
+import { execSync } from 'child_process';
+import { runArgv } from '../shared/error-norm.js';
+import type { AdapterResult, CreateBranchArgs } from './types.js';
+
+const GITHUB_REPO_SLUG = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+const BRANCH_CHARSET = /^[A-Za-z0-9._\-/]+$/;
+const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+export async function createBranchGithub(
+  args: CreateBranchArgs,
+): Promise<AdapterResult<void>> {
+  try {
+    if (!BRANCH_CHARSET.test(args.branch)) {
+      return {
+        ok: false,
+        code: 'invalid_branch',
+        error: `createBranchGithub: invalid branch ${JSON.stringify(args.branch)}`,
+      };
+    }
+    if (!SHA_PATTERN.test(args.sha)) {
+      return {
+        ok: false,
+        code: 'invalid_sha',
+        error: `createBranchGithub: invalid sha ${JSON.stringify(args.sha)}`,
+      };
+    }
+    if (args.repo !== undefined && !GITHUB_REPO_SLUG.test(args.repo)) {
+      return {
+        ok: false,
+        code: 'invalid_repo',
+        error: `createBranchGithub: invalid repo slug ${JSON.stringify(args.repo)}`,
+      };
+    }
+
+    const slug = args.repo ?? ':owner/:repo';
+    const cmd = [
+      'gh',
+      'api',
+      `repos/${slug}/git/refs`,
+      '-X',
+      'POST',
+      '-f',
+      `ref=refs/heads/${args.branch}`,
+      '-f',
+      `sha=${args.sha}`,
+    ];
+    const result = runArgv(cmd, projectDir());
+    if (result.exitCode !== 0) {
+      return {
+        ok: false,
+        code: 'gh_create_branch_failed',
+        error: `failed to create branch ${args.branch}: ${result.stderr.trim() || result.stdout.trim()}`,
+      };
+    }
+
+    return { ok: true, data: undefined };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'unexpected_error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// `execSync` is intentionally re-imported above so that adapter-level test
+// files can `mock.module('child_process', ...)` and intercept this module's
+// subprocess calls.
+void execSync;

--- a/lib/adapters/create-branch-gitlab.test.ts
+++ b/lib/adapters/create-branch-gitlab.test.ts
@@ -1,0 +1,166 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { AdapterResult } from './types.ts';
+
+// Subprocess-boundary tests for the GitLab createBranch adapter (R-15).
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { createBranchGitlab } = await import('./create-branch-gitlab.ts');
+
+function on(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
+function expectOk(r: AdapterResult<void>): asserts r is { ok: true; data: void } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+}
+
+const VALID_SHA = 'b'.repeat(40);
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('createBranchGitlab — subprocess boundary', () => {
+  test('argv: glab api projects/<encoded>/repository/branches -X POST -f branch=<name> -f ref=<sha>', async () => {
+    on('glab api projects/my-group%2Fmy-repo/repository/branches', '');
+
+    const result = await createBranchGitlab({
+      branch: 'kahuna/7-feature-x',
+      sha: VALID_SHA,
+      repo: 'my-group/my-repo',
+    });
+    expectOk(result);
+
+    const call = findCall('glab api');
+    expect(call).toContain('projects/my-group%2Fmy-repo/repository/branches');
+    expect(call).toContain('-X');
+    expect(call).toContain('POST');
+    const flat = unquote(call);
+    expect(flat).toContain('branch=kahuna/7-feature-x');
+    expect(flat).toContain(`ref=${VALID_SHA}`);
+  });
+
+  test('void return on success', async () => {
+    on('glab api', '');
+    const result = await createBranchGitlab({
+      branch: 'feature/1-demo',
+      sha: VALID_SHA,
+      repo: 'org/repo',
+    });
+    expectOk(result);
+    expect(result.data).toBeUndefined();
+  });
+
+  test('returns ok:false when glab exits non-zero', async () => {
+    on('glab api', () => {
+      const err = new Error('glab: Branch already exists') as ThrowableError;
+      err.stderr = 'Branch already exists';
+      err.status = 1;
+      throw err;
+    });
+
+    const result = await createBranchGitlab({
+      branch: 'kahuna/1-foo',
+      sha: VALID_SHA,
+      repo: 'org/repo',
+    });
+    expect('ok' in result && result.ok).toBe(false);
+    expect((result as { code: string }).code).toBe('glab_create_branch_failed');
+    expect((result as { error: string }).error).toContain('kahuna/1-foo');
+  });
+
+  test('does NOT pass -R flag (glab api is path-resolved)', async () => {
+    on('glab api', '');
+    await createBranchGitlab({
+      branch: 'kahuna/1-foo',
+      sha: VALID_SHA,
+      repo: 'org/repo',
+    });
+    const call = findCall('glab api');
+    // Extract argv-like tokens; the command format uses "-X POST" but never
+    // "-R <slug>" — the slug lives in the URL path, not as a porcelain flag.
+    const postR = call.match(/\s-R\s/);
+    expect(postR).toBeNull();
+  });
+
+  test('rejects invalid branch characters', async () => {
+    const result = await createBranchGitlab({
+      branch: 'bad; rm -rf /',
+      sha: VALID_SHA,
+      repo: 'org/repo',
+    });
+    expect('ok' in result && result.ok).toBe(false);
+    expect((result as { code: string }).code).toBe('invalid_branch');
+    expect(execCalls.length).toBe(0);
+  });
+
+  test('rejects invalid sha', async () => {
+    const result = await createBranchGitlab({
+      branch: 'main',
+      sha: 'not-a-sha',
+      repo: 'org/repo',
+    });
+    expect('ok' in result && result.ok).toBe(false);
+    expect((result as { code: string }).code).toBe('invalid_sha');
+    expect(execCalls.length).toBe(0);
+  });
+
+  test('rejects invalid repo slug', async () => {
+    const result = await createBranchGitlab({
+      branch: 'main',
+      sha: VALID_SHA,
+      repo: 'no-slash',
+    });
+    expect('ok' in result && result.ok).toBe(false);
+    expect((result as { code: string }).code).toBe('invalid_repo');
+    expect(execCalls.length).toBe(0);
+  });
+
+  test('supports nested group slugs (org/sub/repo → org%2Fsub%2Frepo)', async () => {
+    on('glab api projects/org%2Fsub%2Frepo/repository/branches', '');
+
+    const result = await createBranchGitlab({
+      branch: 'kahuna/1-foo',
+      sha: VALID_SHA,
+      repo: 'org/sub/repo',
+    });
+    expectOk(result);
+    const call = findCall('glab api');
+    expect(call).toContain('projects/org%2Fsub%2Frepo/repository/branches');
+  });
+});

--- a/lib/adapters/create-branch-gitlab.ts
+++ b/lib/adapters/create-branch-gitlab.ts
@@ -1,0 +1,91 @@
+/**
+ * GitLab `createBranch` adapter implementation.
+ *
+ * Lifted from `handlers/wave_init.ts`'s local `createKahunaBranch` helper per
+ * Story 2.22 (#316). Mirrors `create-branch-github.ts` — the handler dispatches
+ * to either depending on cwd platform.
+ *
+ * Argv: `glab api projects/<encoded>/repository/branches -X POST
+ *        -f branch=<name> -f ref=<sha>`.
+ *
+ * The `:id` slug is `%2F`-encoded from `owner/repo`. `glab api` resolves repo
+ * context from the URL path — no `-R <slug>` flag (that belongs to porcelain
+ * subcommands).
+ *
+ * Returns `void` on success. There's no "already exists" idempotent path —
+ * the handler's state/remote pre-check catches that case before the call.
+ */
+
+import { execSync } from 'child_process';
+import { runArgv } from '../shared/error-norm.js';
+import type { AdapterResult, CreateBranchArgs } from './types.js';
+
+const GITLAB_REPO_SLUG = /^[A-Za-z0-9._-]+(\/[A-Za-z0-9._-]+)+$/;
+const BRANCH_CHARSET = /^[A-Za-z0-9._\-/]+$/;
+const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+export async function createBranchGitlab(
+  args: CreateBranchArgs,
+): Promise<AdapterResult<void>> {
+  try {
+    if (!BRANCH_CHARSET.test(args.branch)) {
+      return {
+        ok: false,
+        code: 'invalid_branch',
+        error: `createBranchGitlab: invalid branch ${JSON.stringify(args.branch)}`,
+      };
+    }
+    if (!SHA_PATTERN.test(args.sha)) {
+      return {
+        ok: false,
+        code: 'invalid_sha',
+        error: `createBranchGitlab: invalid sha ${JSON.stringify(args.sha)}`,
+      };
+    }
+    if (args.repo !== undefined && !GITLAB_REPO_SLUG.test(args.repo)) {
+      return {
+        ok: false,
+        code: 'invalid_repo',
+        error: `createBranchGitlab: invalid repo slug ${JSON.stringify(args.repo)}`,
+      };
+    }
+
+    const encoded = (args.repo ?? '').replace(/\//g, '%2F');
+    const cmd = [
+      'glab',
+      'api',
+      `projects/${encoded}/repository/branches`,
+      '-X',
+      'POST',
+      '-f',
+      `branch=${args.branch}`,
+      '-f',
+      `ref=${args.sha}`,
+    ];
+    const result = runArgv(cmd, projectDir());
+    if (result.exitCode !== 0) {
+      return {
+        ok: false,
+        code: 'glab_create_branch_failed',
+        error: `failed to create branch ${args.branch}: ${result.stderr.trim() || result.stdout.trim()}`,
+      };
+    }
+
+    return { ok: true, data: undefined };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'unexpected_error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// `execSync` is intentionally re-imported above so that adapter-level test
+// files can `mock.module('child_process', ...)` and intercept this module's
+// subprocess calls.
+void execSync;

--- a/lib/adapters/github.ts
+++ b/lib/adapters/github.ts
@@ -19,6 +19,7 @@ import { ciListRunsGithub } from './ci-list-runs-github.js';
 import { ciRunLogsGithub } from './ci-run-logs-github.js';
 import { ciRunStatusGithub } from './ci-run-status-github.js';
 import { ciRunsForBranchGithub } from './ci-runs-for-branch-github.js';
+import { createBranchGithub } from './create-branch-github.js';
 import { fetchIssueGithub } from './fetch-issue-github.js';
 import { fetchIssueClosureGithub } from './fetch-issue-closure-github.js';
 import { fetchPrForBranchGithub } from './fetch-pr-for-branch-github.js';
@@ -74,4 +75,5 @@ export const githubAdapter: PlatformAdapter = {
   findMergedPrForBranchPrefix: findMergedPrForBranchPrefixGithub,
   ciListRuns: ciListRunsGithub,
   resolveBranchSha: resolveBranchShaGithub,
+  createBranch: createBranchGithub,
 };

--- a/lib/adapters/gitlab.ts
+++ b/lib/adapters/gitlab.ts
@@ -20,6 +20,7 @@ import { ciListRunsGitlab } from './ci-list-runs-gitlab.js';
 import { ciRunLogsGitlab } from './ci-run-logs-gitlab.js';
 import { ciRunStatusGitlab } from './ci-run-status-gitlab.js';
 import { ciRunsForBranchGitlab } from './ci-runs-for-branch-gitlab.js';
+import { createBranchGitlab } from './create-branch-gitlab.js';
 import { fetchIssueGitlab } from './fetch-issue-gitlab.js';
 import { fetchIssueClosureGitlab } from './fetch-issue-closure-gitlab.js';
 import { fetchPrForBranchGitlab } from './fetch-pr-for-branch-gitlab.js';
@@ -75,4 +76,5 @@ export const gitlabAdapter: PlatformAdapter = {
   findMergedPrForBranchPrefix: findMergedPrForBranchPrefixGitlab,
   ciListRuns: ciListRunsGitlab,
   resolveBranchSha: resolveBranchShaGitlab,
+  createBranch: createBranchGitlab,
 };

--- a/lib/adapters/resolve-branch-sha-gitlab.test.ts
+++ b/lib/adapters/resolve-branch-sha-gitlab.test.ts
@@ -1,29 +1,163 @@
-import { describe, test, expect } from 'bun:test';
-import { resolveBranchShaGitlab } from './resolve-branch-sha-gitlab.ts';
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type {
+  AdapterResult,
+  ResolveBranchShaResponse,
+} from './types.ts';
 
-// R-03 typed-asymmetry test: GitLab doesn't need branch→SHA resolution
-// (pipelines attach to branch names directly). The adapter must return a
-// `platform_unsupported` signal — not a fake-success null, not a throw.
+// Subprocess-boundary tests for the GitLab resolveBranchSha adapter (R-15).
+// Story 2.22 (#316) upgraded this adapter from the permanent `platform_unsupported`
+// stub (Story 2.19) to a real body lifted from the pre-migration `wave_init`
+// handler so KAHUNA bootstrap can resolve the base-branch HEAD SHA on GitLab.
 
-describe('resolveBranchShaGitlab — R-03 typed asymmetry', () => {
-  test('returns platform_unsupported with a descriptive hint', async () => {
-    const result = await resolveBranchShaGitlab({ branch: 'main' });
-    if (!('platform_unsupported' in result)) {
-      throw new Error(
-        `expected platform_unsupported, got ${JSON.stringify(result)}`,
-      );
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+let execRegistry: Array<{ match: string; respond: string | (() => string) }> = [];
+let execCalls: string[] = [];
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => {
+  execCalls.push(cmd);
+  const flat = unquote(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match) || flat.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
     }
-    expect(result.platform_unsupported).toBe(true);
-    // The hint must describe WHY — callers need the signal, not a generic stub.
-    expect(result.hint.toLowerCase()).toContain('gitlab');
-    expect(result.hint.toLowerCase()).toContain('branch');
+  }
+  const err = new Error(`Unexpected exec: ${cmd}`) as ThrowableError;
+  err.stderr = `Unexpected exec: ${cmd}`;
+  err.status = 127;
+  throw err;
+});
+
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { resolveBranchShaGitlab } = await import('./resolve-branch-sha-gitlab.ts');
+
+function on(match: string, respond: string | (() => string)): void {
+  execRegistry.push({ match, respond });
+}
+
+function expectOk(
+  r: AdapterResult<ResolveBranchShaResponse | null>,
+): asserts r is { ok: true; data: ResolveBranchShaResponse | null } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function findCall(needle: string): string {
+  return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('resolveBranchShaGitlab — subprocess boundary', () => {
+  test('argv: glab api projects/<encoded>/repository/branches/<branch>', async () => {
+    const sha = 'a'.repeat(40);
+    on(
+      'glab api projects/org%2Frepo/repository/branches/main',
+      JSON.stringify({ commit: { id: sha } }),
+    );
+
+    const result = await resolveBranchShaGitlab({ branch: 'main', repo: 'org/repo' });
+    expectOk(result);
+    expect(result.data).toEqual({ sha });
+
+    const call = findCall('glab api');
+    expect(call).toContain('projects/org%2Frepo/repository/branches/main');
   });
 
-  test('platform_unsupported regardless of args', async () => {
+  test('soft-fails to null when glab errors (mirrors GitHub contract)', async () => {
+    on('glab api', () => {
+      const err = new Error('glab: 404') as ThrowableError;
+      err.stderr = 'glab: not found';
+      err.status = 1;
+      throw err;
+    });
+
+    const result = await resolveBranchShaGitlab({ branch: 'main', repo: 'org/repo' });
+    expectOk(result);
+    expect(result.data).toBeNull();
+  });
+
+  test('returns null when commit.id is missing or invalid', async () => {
+    on('glab api', JSON.stringify({ commit: { id: 'not-a-sha' } }));
+
+    const result = await resolveBranchShaGitlab({ branch: 'main', repo: 'org/repo' });
+    expectOk(result);
+    expect(result.data).toBeNull();
+  });
+
+  test('returns null when stdout is not valid JSON', async () => {
+    on('glab api', 'not-json');
+
+    const result = await resolveBranchShaGitlab({ branch: 'main', repo: 'org/repo' });
+    expectOk(result);
+    expect(result.data).toBeNull();
+  });
+
+  test('returns null when repo is omitted (no slug to target)', async () => {
+    const result = await resolveBranchShaGitlab({ branch: 'main' });
+    expectOk(result);
+    expect(result.data).toBeNull();
+    expect(execCalls.length).toBe(0);
+  });
+
+  test('rejects invalid branch characters', async () => {
+    const result = await resolveBranchShaGitlab({
+      branch: 'bad; rm -rf /',
+      repo: 'org/repo',
+    });
+    expect('ok' in result && result.ok).toBe(false);
+    expect((result as { code: string }).code).toBe('invalid_branch');
+  });
+
+  test('rejects invalid repo slug', async () => {
+    const result = await resolveBranchShaGitlab({
+      branch: 'main',
+      repo: 'no-slash',
+    });
+    expect('ok' in result && result.ok).toBe(false);
+    expect((result as { code: string }).code).toBe('invalid_repo');
+  });
+
+  test('passes branch names with slashes (feature/1-demo) unharmed', async () => {
+    const sha = 'b'.repeat(40);
+    on(
+      'glab api projects/org%2Frepo/repository/branches/feature/1-demo',
+      JSON.stringify({ commit: { id: sha } }),
+    );
+
     const result = await resolveBranchShaGitlab({
       branch: 'feature/1-demo',
       repo: 'org/repo',
     });
-    expect('platform_unsupported' in result).toBe(true);
+    expectOk(result);
+    expect(result.data).toEqual({ sha });
+  });
+
+  test('supports nested group slugs (org/sub/repo → org%2Fsub%2Frepo)', async () => {
+    const sha = 'c'.repeat(40);
+    on(
+      'glab api projects/org%2Fsub%2Frepo/repository/branches/main',
+      JSON.stringify({ commit: { id: sha } }),
+    );
+
+    const result = await resolveBranchShaGitlab({
+      branch: 'main',
+      repo: 'org/sub/repo',
+    });
+    expectOk(result);
+    expect(result.data).toEqual({ sha });
   });
 });

--- a/lib/adapters/resolve-branch-sha-gitlab.ts
+++ b/lib/adapters/resolve-branch-sha-gitlab.ts
@@ -1,31 +1,102 @@
 /**
- * GitLab `resolveBranchSha` adapter implementation — the `ci_wait_run`
- * branch→SHA sub-call (Story 2.19, #313).
+ * GitLab `resolveBranchSha` adapter implementation.
  *
- * This is a PERMANENT `platform_unsupported` stub per R-03 typed-asymmetry.
- * Branch→SHA resolution on GitLab isn't a pre-condition for the CI wait —
- * GitLab pipelines attach to branch names directly via the `ref=` query on
- * the pipelines endpoint. The GitHub merge-queue pre-flight that needs this
- * resolution doesn't exist on GitLab (merge trains operate differently).
+ * Lifted from the pre-migration `handlers/wave_init.ts`'s local `getMainHeadSha`
+ * helper per Story 2.22 (#316) — the original Story 2.19 (#313) landed this
+ * method as a permanent `platform_unsupported` stub because `ci_wait_run`
+ * doesn't need the resolution on GitLab (pipelines attach to branch names
+ * directly). `wave_init`'s KAHUNA bootstrap, however, needs the HEAD SHA of
+ * the plan's base branch to feed into `createBranch`, so this adapter gets a
+ * real body.
  *
- * Returning `platform_unsupported` (rather than throwing or returning
- * `{ok: true, data: null}`) is the point of R-03: callers that hit this on
- * a GitLab repo get a TYPED signal that the concept doesn't map, not a
- * fake-success `null` that might be mistaken for "branch doesn't exist".
+ * `ci-wait-run-poll.ts` treats `platform_unsupported` and `{data: null}` the
+ * same way (soft-fail to null), so returning a real sha here stays backward
+ * compatible with that consumer.
+ *
+ * Argv: `glab api projects/:id/repository/branches/<branch>` →
+ * `{ commit: { id: <sha> } }`. The `:id` slug is `%2F`-encoded from
+ * `owner/repo`.
+ *
+ * Returns `{sha}` on success; `null` when resolution fails for any reason
+ * (missing repo slug, deleted branch, unauthenticated `glab`) — same
+ * soft-fail contract as the GitHub adapter so the polling loop can collapse
+ * both into "no SHA match".
  */
 
+import { execSync } from 'child_process';
+import { runArgv } from '../shared/error-norm.js';
 import type {
   AdapterResult,
   ResolveBranchShaArgs,
   ResolveBranchShaResponse,
 } from './types.js';
 
-export async function resolveBranchShaGitlab(
-  _args: ResolveBranchShaArgs,
-): Promise<AdapterResult<ResolveBranchShaResponse | null>> {
-  return {
-    platform_unsupported: true,
-    hint:
-      'branch→SHA not needed — GitLab CI pipelines attach to branch names directly',
-  };
+const GITLAB_REPO_SLUG = /^[A-Za-z0-9._-]+(\/[A-Za-z0-9._-]+)+$/;
+const BRANCH_CHARSET = /^[A-Za-z0-9._\-/]+$/;
+const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
 }
+
+export async function resolveBranchShaGitlab(
+  args: ResolveBranchShaArgs,
+): Promise<AdapterResult<ResolveBranchShaResponse | null>> {
+  try {
+    if (!BRANCH_CHARSET.test(args.branch)) {
+      return {
+        ok: false,
+        code: 'invalid_branch',
+        error: `resolveBranchShaGitlab: invalid branch ${JSON.stringify(args.branch)}`,
+      };
+    }
+    if (args.repo !== undefined && !GITLAB_REPO_SLUG.test(args.repo)) {
+      return {
+        ok: false,
+        code: 'invalid_repo',
+        error: `resolveBranchShaGitlab: invalid repo slug ${JSON.stringify(args.repo)}`,
+      };
+    }
+
+    const slug = args.repo;
+    if (slug === undefined) {
+      // No slug resolution is available at this layer — callers pass an
+      // explicit slug (or resolve cwd via `parseRepoSlug()` upstream).
+      return { ok: true, data: null };
+    }
+
+    const encoded = slug.replace(/\//g, '%2F');
+    const cmd = [
+      'glab',
+      'api',
+      `projects/${encoded}/repository/branches/${args.branch}`,
+    ];
+    const result = runArgv(cmd, projectDir());
+    if (result.exitCode !== 0) {
+      // Soft-fail to null — mirrors the GitHub adapter contract.
+      return { ok: true, data: null };
+    }
+
+    try {
+      const parsed = JSON.parse(result.stdout) as { commit?: { id?: string } };
+      const sha = parsed.commit?.id;
+      if (typeof sha !== 'string' || !SHA_PATTERN.test(sha)) {
+        return { ok: true, data: null };
+      }
+      return { ok: true, data: { sha } };
+    } catch {
+      return { ok: true, data: null };
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'unexpected_error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// `execSync` is intentionally re-imported above so that adapter-level test
+// files can `mock.module('child_process', ...)` and intercept this module's
+// subprocess calls.
+void execSync;

--- a/lib/adapters/types.test.ts
+++ b/lib/adapters/types.test.ts
@@ -69,6 +69,12 @@ describe('PlatformAdapter contract', () => {
   //                    `queryGithubMergedPrs` / `queryGitlabMergedMrs` helpers;
   //                    also closes #282 by exposing a configurable `limit`
   //                    instead of the pre-migration hardcoded 50).
+  // Story 2.22 (#316): wave_init hybrid migration (+ createBranch — the
+  //                    KAHUNA branch-creation sub-call lifted from the
+  //                    handler-local `createKahunaBranch` helper; also
+  //                    promotes `resolveBranchShaGitlab` from a permanent
+  //                    `platform_unsupported` stub to a real implementation
+  //                    so GitLab can resolve the base-branch HEAD SHA).
   const MIGRATED_METHODS = new Set<string>([
     'prCreate',
     'prDiff',
@@ -93,6 +99,7 @@ describe('PlatformAdapter contract', () => {
     'labelList',
     'resolveBranchSha',
     'workItem',
+    'createBranch',
   ]);
 
   test('still-stubbed methods return platform_unsupported', async () => {

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -695,6 +695,29 @@ export interface IssueClosureInfo {
 }
 
 /**
+ * Hybrid sub-call (Story 2.22, #316). `createBranch` is the KAHUNA bootstrap
+ * sub-call lifted from `handlers/wave_init.ts`'s local `createKahunaBranch`
+ * helper. Creates a branch pointing at an explicit SHA.
+ *
+ * Two-step dispatch diverges per platform:
+ * - GitHub: `gh api repos/:owner/:repo/git/refs -X POST -f ref=refs/heads/<name>
+ *   -f sha=<sha>`. `gh api` resolves repo context from the URL path — no
+ *   `--repo` flag (that belongs to porcelain subcommands like `gh pr …`).
+ * - GitLab: `glab api projects/:id/repository/branches -X POST -f branch=<name>
+ *   -f ref=<sha>`. The `:id` slug is `%2F`-encoded from `owner/repo`.
+ *
+ * Returns `void` on success (the response body is just an echo of the ref
+ * with no fields the handler needs). On failure returns `{ok: false, …}`;
+ * there's no "already exists" idempotent path — the handler's state/remote
+ * pre-check catches that case before we get here.
+ */
+export interface CreateBranchArgs {
+  branch: string;
+  sha: string;
+  repo?: string;
+}
+
+/**
  * Hybrid sub-call (Story 2.21, #315). `findMergedPrForBranchPrefix` collapses
  * the handler-local `queryGithubMergedPrs` / `queryGitlabMergedMrs` helpers
  * lifted from the pre-migration `wave_reconcile_mrs` handler. Returns the
@@ -780,6 +803,7 @@ export interface PlatformAdapter {
   resolveBranchSha(
     args: ResolveBranchShaArgs,
   ): Promise<AdapterResult<ResolveBranchShaResponse | null>>;
+  createBranch(args: CreateBranchArgs): Promise<AdapterResult<void>>;
 }
 
 // ---------------------------------------------------------------------------
@@ -822,6 +846,7 @@ export const PLATFORM_ADAPTER_METHODS = [
   'findMergedPrForBranchPrefix',
   'ciListRuns',
   'resolveBranchSha',
+  'createBranch',
 ] as const;
 
 export type PlatformAdapterMethod = (typeof PLATFORM_ADAPTER_METHODS)[number];

--- a/lib/shared/git-remote.ts
+++ b/lib/shared/git-remote.ts
@@ -1,0 +1,24 @@
+/**
+ * Git-remote helpers — platform-agnostic `git` subprocess probes that don't
+ * belong inside the platform adapter (they're local git operations, not
+ * GitHub/GitLab API calls).
+ *
+ * Extracted from the handler-local helpers in `wave_init.ts` /
+ * `wave_finalize.ts` per Story 2.22 (#316) so future consumers share one
+ * implementation.
+ */
+
+import { runArgv } from './error-norm.js';
+
+/**
+ * Returns true when `<branch>` is present on the `origin` remote. Uses
+ * `git ls-remote --heads origin <branch>` — an exit 0 with non-empty stdout
+ * means the ref exists. Any other condition (non-zero exit, empty stdout,
+ * network error) collapses to `false`; callers treat that as "not present"
+ * and can recover.
+ */
+export function branchExistsOnRemote(cwd: string, branch: string): boolean {
+  const result = runArgv(['git', 'ls-remote', '--heads', 'origin', branch], cwd);
+  if (result.exitCode !== 0) return false;
+  return result.stdout.trim().length > 0;
+}

--- a/lib/wave_init_plan.ts
+++ b/lib/wave_init_plan.ts
@@ -1,0 +1,270 @@
+// Wave-init plan/state helpers — platform-agnostic parsing, fixture I/O, and
+// KAHUNA bootstrap orchestration. Extracted from `handlers/wave_init.ts` per
+// Story 2.22 (#316) so the handler shell stays ≤80 lines and contains no
+// platform branching or direct subprocess invocation.
+
+import { writeFileSync } from 'fs';
+import { join } from 'path';
+
+import type { PlatformAdapter, AdapterResult } from './adapters/index.js';
+import { branchExistsOnRemote } from './shared/git-remote.js';
+
+export interface PlanWave {
+  id?: string;
+  issues?: unknown[];
+}
+
+export interface PlanPhase {
+  waves?: PlanWave[];
+}
+
+export interface PlanData {
+  phases?: PlanPhase[];
+  base_branch?: string;
+}
+
+export interface StateData {
+  waves?: Record<string, unknown>;
+  kahuna_branch?: string | null;
+}
+
+export interface PhasesWavesData {
+  phases?: Array<{ waves?: unknown[] }>;
+}
+
+export function projectDir(override?: string): string {
+  if (override !== undefined && override.length > 0) return override;
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+export function writePlanFile(planJson: string): string {
+  const path = `/tmp/wave-init-plan-${Date.now()}-${Math.floor(Math.random() * 1e6)}.json`;
+  writeFileSync(path, planJson);
+  return path;
+}
+
+export async function fileExists(path: string): Promise<boolean> {
+  return await Bun.file(path).exists();
+}
+
+export async function readJson(path: string): Promise<unknown> {
+  return await Bun.file(path).json();
+}
+
+export async function statusDir(root: string): Promise<string> {
+  // Prefer .sdlc/waves/ if .sdlc/ exists; otherwise fall back to .claude/status/.
+  const sdlc = join(root, '.sdlc');
+  if (await fileExists(sdlc)) return join(sdlc, 'waves');
+  return join(root, '.claude', 'status');
+}
+
+export function countIssuesFromPlan(plan: PlanData): {
+  phases_added: number;
+  waves_added: number;
+  issues_added: number;
+} {
+  const phases = plan.phases ?? [];
+  let waves_added = 0;
+  let issues_added = 0;
+  for (const phase of phases) {
+    for (const wave of phase.waves ?? []) {
+      waves_added += 1;
+      issues_added += (wave.issues ?? []).length;
+    }
+  }
+  return {
+    phases_added: phases.length,
+    waves_added,
+    issues_added,
+  };
+}
+
+export function extractPlanWaveIds(plan: PlanData): string[] {
+  const ids: string[] = [];
+  for (const phase of plan.phases ?? []) {
+    for (const wave of phase.waves ?? []) {
+      if (typeof wave.id === 'string' && wave.id.length > 0) {
+        ids.push(wave.id);
+      }
+    }
+  }
+  return ids;
+}
+
+/**
+ * Pre-scan the extend-mode plan against on-disk state to detect wave-ID
+ * collisions BEFORE shelling out to the `wave-status` CLI. Returns
+ * `{ok:false, error}` when state is missing or a collision is found, else
+ * `{ok:true}` to signal "proceed". The CLI has its own collision guard;
+ * this is defense-in-depth + clearer error envelope.
+ */
+export async function extendModePrescan(
+  planJson: string,
+  root: string,
+): Promise<
+  | { ok: true }
+  | { ok: false; error: string; colliding_ids?: string[] }
+> {
+  let plan: PlanData;
+  try {
+    plan = JSON.parse(planJson) as PlanData;
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: `plan_json is not valid JSON: ${detail}` };
+  }
+
+  const dir = await statusDir(root);
+  const statePath = join(dir, 'state.json');
+  if (!(await fileExists(statePath))) {
+    return { ok: false, error: 'no existing plan found' };
+  }
+
+  const state = (await readJson(statePath)) as StateData;
+  const existingIds = new Set(Object.keys(state.waves ?? {}));
+  const incomingIds = extractPlanWaveIds(plan);
+  const colliding = incomingIds.filter((id) => existingIds.has(id));
+  if (colliding.length > 0) {
+    return {
+      ok: false,
+      error: `wave ID collision: ${colliding.join(', ')} already exist`,
+      colliding_ids: colliding,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * After the wave-status CLI has written `phases-waves.json`, read it back
+ * so the handler can report project totals. Returns `{0,0}` rather than
+ * failing the whole call if the file is missing or malformed — the CLI
+ * already succeeded at writing state.
+ */
+export async function readPhasesWavesTotals(
+  root: string,
+): Promise<{ total_phases: number; total_waves: number }> {
+  try {
+    const dir = await statusDir(root);
+    const phasesPath = join(dir, 'phases-waves.json');
+    if (!(await fileExists(phasesPath))) return { total_phases: 0, total_waves: 0 };
+    const data = (await readJson(phasesPath)) as PhasesWavesData;
+    const phases = data.phases ?? [];
+    let total_waves = 0;
+    for (const p of phases) total_waves += (p.waves ?? []).length;
+    return { total_phases: phases.length, total_waves };
+  } catch {
+    return { total_phases: 0, total_waves: 0 };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// KAHUNA bootstrap — platform-facing calls go through the `PlatformAdapter`
+// so the handler remains free of platform branching (R-09).
+// ---------------------------------------------------------------------------
+
+export interface KahunaBootstrapResult {
+  ok: true;
+  kahuna_branch: string;
+  created: boolean;
+}
+export interface KahunaBootstrapError {
+  ok: false;
+  error: string;
+}
+
+export interface KahunaBootstrapDeps {
+  adapter: Pick<PlatformAdapter, 'resolveBranchSha' | 'createBranch'>;
+  /** CLI shell-out — `wave-status set-kahuna-branch <name>`. Injectable for testing. */
+  recordKahunaBranch: (branch: string) => void;
+  /** `git ls-remote` probe — local git, not a platform API. Injectable for testing. */
+  branchPresentOnRemote: (branch: string) => boolean;
+  slug: string | undefined;
+}
+
+export async function bootstrapKahunaBranch(
+  cwd: string,
+  kahuna: { epic_id: number; slug: string },
+  baseBranch: string,
+  readState: () => Promise<{ kahuna_branch?: string | null }>,
+  deps: KahunaBootstrapDeps,
+): Promise<KahunaBootstrapResult | KahunaBootstrapError> {
+  void cwd;
+  const desired = `kahuna/${kahuna.epic_id}-${kahuna.slug}`;
+  const state = await readState();
+  const recorded = state.kahuna_branch ?? null;
+
+  if (recorded === desired) {
+    if (deps.branchPresentOnRemote(desired)) {
+      return { ok: true, kahuna_branch: desired, created: false };
+    }
+    return {
+      ok: false,
+      error: `kahuna_branch ${desired} is recorded in state but missing from remote — manual triage required`,
+    };
+  }
+  if (recorded !== null && recorded !== desired) {
+    return {
+      ok: false,
+      error: `wave state already records kahuna_branch '${recorded}' which does not match requested '${desired}'`,
+    };
+  }
+
+  // recorded === null: state unset. Check the remote for an orphan.
+  if (deps.branchPresentOnRemote(desired)) {
+    return {
+      ok: false,
+      error: `orphan kahuna branch ${desired} exists on remote but is not recorded in state — manual triage required`,
+    };
+  }
+
+  // Fresh creation path — adapter reads main HEAD SHA + creates the branch.
+  const shaResult = await deps.adapter.resolveBranchSha({ branch: baseBranch, repo: deps.slug });
+  const sha = extractSha(shaResult);
+  if (sha === null) {
+    return { ok: false, error: shaErrorMessage(baseBranch, shaResult) };
+  }
+  if (!/^[0-9a-f]{40}$/i.test(sha)) {
+    return { ok: false, error: `unexpected SHA from resolveBranchSha: ${sha.slice(0, 80)}` };
+  }
+  const createResult = await deps.adapter.createBranch({ branch: desired, sha, repo: deps.slug });
+  if ('platform_unsupported' in createResult) {
+    return { ok: false, error: `createBranch platform_unsupported: ${createResult.hint}` };
+  }
+  if (!createResult.ok) {
+    return { ok: false, error: createResult.error };
+  }
+
+  try {
+    deps.recordKahunaBranch(desired);
+  } catch (err) {
+    return {
+      ok: false,
+      error: `wave-status set-kahuna-branch failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  return { ok: true, kahuna_branch: desired, created: true };
+}
+
+function extractSha(
+  result: AdapterResult<{ sha: string } | null>,
+): string | null {
+  if ('platform_unsupported' in result) return null;
+  if (!result.ok) return null;
+  if (result.data === null) return null;
+  return result.data.sha;
+}
+
+function shaErrorMessage(
+  baseBranch: string,
+  result: AdapterResult<{ sha: string } | null>,
+): string {
+  if ('platform_unsupported' in result) {
+    return `failed to read ${baseBranch} HEAD SHA: ${result.hint}`;
+  }
+  if (!result.ok) {
+    return `failed to read ${baseBranch} HEAD SHA: ${result.error}`;
+  }
+  return `failed to read ${baseBranch} HEAD SHA: branch not found`;
+}
+
+// Re-export the shared git-remote helper for the handler's injection.
+export { branchExistsOnRemote };

--- a/scripts/ci/migration-allowlist.txt
+++ b/scripts/ci/migration-allowlist.txt
@@ -11,4 +11,3 @@
 # Format: one basename per line. Comments (#) and blank lines ignored.
 wave_ci_trust_level.ts
 wave_finalize.ts
-wave_init.ts

--- a/tests/wave_init.test.ts
+++ b/tests/wave_init.test.ts
@@ -12,7 +12,18 @@ const mockExecSync = mock((cmd: string, _opts?: unknown) => {
 const mockWriteFileSync = mock((_path: unknown, _data: unknown) => undefined);
 
 mock.module('child_process', () => ({ execSync: mockExecSync }));
-mock.module('fs', () => ({ writeFileSync: mockWriteFileSync }));
+// Story 2.22 (#316): the handler now imports `getAdapter()` which transitively
+// pulls in `logger.ts` → `node:fs`. Bun aliases `'fs'` mocks to `'node:fs'`,
+// so the mock surface must include every export `logger.ts` reaches for —
+// otherwise `node:fs` resolves to a stub-less stand-in and the import fails
+// with `Export named 'mkdirSync' not found`. Real fs calls are not expected
+// during tests; these stubs are silently-noop defaults.
+mock.module('fs', () => ({
+  writeFileSync: mockWriteFileSync,
+  appendFileSync: () => undefined,
+  mkdirSync: () => undefined,
+  existsSync: () => true,
+}));
 
 const { default: handler } = await import('../handlers/wave_init.ts');
 
@@ -263,11 +274,22 @@ describe('wave_init handler', () => {
    * Tests register a map of {substring → response or thrower}; unmatched
    * commands fall through to the default `wave plan initialized` response so
    * the existing wave-status init call keeps working.
+   *
+   * Story 2.22 (#316): matches against both the raw cmd AND a single-quote
+   * stripped version so route expressions written for the legacy non-escaped
+   * handler form also match the adapter's `runArgv`-produced per-token quoted
+   * form (`'git' 'ls-remote' ...`). The handler-owned execSync calls
+   * (`wave-status ...`, `parseRepoSlug`'s `git remote get-url`) still use the
+   * legacy format; adapter calls now go through `runArgv`.
    */
+  function unquote(cmd: string): string {
+    return cmd.replace(/'([^']*)'/g, '$1');
+  }
   function setExecRoutes(routes: Array<{ match: string; respond: string | (() => string) }>): void {
     execMockFn = (cmd: string) => {
+      const flat = unquote(cmd);
       for (const r of routes) {
-        if (cmd.includes(r.match)) {
+        if (cmd.includes(r.match) || flat.includes(r.match)) {
           return typeof r.respond === 'function' ? r.respond() : r.respond;
         }
       }
@@ -280,8 +302,9 @@ describe('wave_init handler', () => {
     setExecRoutes([
       { match: 'git remote get-url', respond: 'git@github.com:Wave-Engineering/mcp-server-sdlc.git' },
       { match: 'git ls-remote --heads origin', respond: '' }, // branch absent
-      { match: "gh api repos/Wave-Engineering/mcp-server-sdlc/branches/'main'", respond: '0000000000000000000000000000000000000abc' },
-      { match: 'gh api repos/Wave-Engineering/mcp-server-sdlc/git/refs', respond: '' },
+      // Story 2.22 (#316): adapter uses `gh api repos/<slug>/git/refs/heads/<branch> --jq .object.sha`.
+      { match: 'gh api repos/Wave-Engineering/mcp-server-sdlc/git/refs/heads/main', respond: '0000000000000000000000000000000000000abc' },
+      { match: 'gh api repos/Wave-Engineering/mcp-server-sdlc/git/refs -X POST', respond: '' },
       { match: 'wave-status set-kahuna-branch', respond: '' },
     ]);
 
@@ -295,13 +318,17 @@ describe('wave_init handler', () => {
     expect(parsed.kahuna_branch).toBe('kahuna/42-wave-status-cli');
     expect(parsed.kahuna_created).toBe(true);
 
-    // The platform API was actually called to create the branch
-    const calls = mockExecSync.mock.calls.map(c => c[0] as string);
+    // The platform API was actually called to create the branch. Adapter
+    // argv is per-token shell-escaped (`'gh' 'api' 'repos/…' …`), so match
+    // against an unquoted view of each recorded call.
+    const calls = mockExecSync.mock.calls.map(c => unquote(c[0] as string));
     expect(calls.some(c => c.includes('gh api repos/Wave-Engineering/mcp-server-sdlc/git/refs -X POST'))).toBe(true);
-    expect(calls.some(c => c.includes("ref='refs/heads/kahuna/42-wave-status-cli'"))).toBe(true);
-    expect(calls.some(c => c.includes("sha='0000000000000000000000000000000000000abc'"))).toBe(true);
-    // And state was updated via the new CLI subcommand
-    expect(calls.some(c => c.includes("wave-status set-kahuna-branch 'kahuna/42-wave-status-cli'"))).toBe(true);
+    expect(calls.some(c => c.includes('ref=refs/heads/kahuna/42-wave-status-cli'))).toBe(true);
+    expect(calls.some(c => c.includes('sha=0000000000000000000000000000000000000abc'))).toBe(true);
+    // And state was updated via the new CLI subcommand (handler's own
+    // execSync, still in legacy quoted form).
+    const rawCalls = mockExecSync.mock.calls.map(c => c[0] as string);
+    expect(rawCalls.some(c => c.includes("wave-status set-kahuna-branch 'kahuna/42-wave-status-cli'"))).toBe(true);
   });
 
   test('kahuna bootstrap — idempotent reuse: state matches and branch exists on remote → no creation', async () => {
@@ -415,7 +442,10 @@ describe('wave_init handler', () => {
     setExecRoutes([
       { match: 'git remote get-url', respond: 'git@gitlab.com:my-group/my-repo.git' },
       { match: 'git ls-remote --heads origin', respond: '' },
-      { match: "glab api projects/my-group%2Fmy-repo/repository/branches/'main'", respond: JSON.stringify({ commit: { id: '3333333333333333333333333333333333333333' } }) },
+      // Story 2.22 (#316): adapter's GitLab resolveBranchSha uses
+      // `glab api projects/<encoded>/repository/branches/<branch>` with no
+      // trailing `--jq` (parses JSON client-side).
+      { match: 'glab api projects/my-group%2Fmy-repo/repository/branches/main', respond: JSON.stringify({ commit: { id: '3333333333333333333333333333333333333333' } }) },
       { match: 'glab api projects/my-group%2Fmy-repo/repository/branches -X POST', respond: '' },
       { match: 'wave-status set-kahuna-branch', respond: '' },
     ]);
@@ -428,10 +458,10 @@ describe('wave_init handler', () => {
 
     expect(parsed.ok).toBe(true);
     expect(parsed.kahuna_branch).toBe('kahuna/7-feature-x');
-    const calls = mockExecSync.mock.calls.map(c => c[0] as string);
+    const calls = mockExecSync.mock.calls.map(c => unquote(c[0] as string));
     expect(calls.some(c => c.includes('glab api projects/my-group%2Fmy-repo/repository/branches -X POST'))).toBe(true);
-    expect(calls.some(c => c.includes("branch='kahuna/7-feature-x'"))).toBe(true);
-    expect(calls.some(c => c.includes("ref='3333333333333333333333333333333333333333'"))).toBe(true);
+    expect(calls.some(c => c.includes('branch=kahuna/7-feature-x'))).toBe(true);
+    expect(calls.some(c => c.includes('ref=3333333333333333333333333333333333333333'))).toBe(true);
   });
 
   test('kahuna bootstrap — uses plan.base_branch when provided (default main)', async () => {
@@ -439,8 +469,9 @@ describe('wave_init handler', () => {
     setExecRoutes([
       { match: 'git remote get-url', respond: 'git@github.com:org/repo.git' },
       { match: 'git ls-remote --heads origin', respond: '' },
-      { match: "gh api repos/org/repo/branches/'develop'", respond: '1111111111111111111111111111111111111111' },
-      { match: 'gh api repos/org/repo/git/refs', respond: '' },
+      // Adapter URL: `/git/refs/heads/<branch> --jq .object.sha`.
+      { match: 'gh api repos/org/repo/git/refs/heads/develop', respond: '1111111111111111111111111111111111111111' },
+      { match: 'gh api repos/org/repo/git/refs -X POST', respond: '' },
       { match: 'wave-status set-kahuna-branch', respond: '' },
     ]);
 
@@ -451,9 +482,9 @@ describe('wave_init handler', () => {
     const parsed = parseResult(result);
 
     expect(parsed.ok).toBe(true);
-    const calls = mockExecSync.mock.calls.map(c => c[0] as string);
-    expect(calls.some(c => c.includes("branches/'develop'"))).toBe(true);
-    expect(calls.some(c => c.includes("sha='1111111111111111111111111111111111111111'"))).toBe(true);
+    const calls = mockExecSync.mock.calls.map(c => unquote(c[0] as string));
+    expect(calls.some(c => c.includes('git/refs/heads/develop'))).toBe(true);
+    expect(calls.some(c => c.includes('sha=1111111111111111111111111111111111111111'))).toBe(true);
   });
 
   test('kahuna bootstrap — gh api returns non-SHA garbage: defensive validator rejects', async () => {
@@ -462,7 +493,10 @@ describe('wave_init handler', () => {
       { match: 'git remote get-url', respond: 'git@github.com:org/repo.git' },
       { match: 'git ls-remote --heads origin', respond: '' },
       // Could happen if the API shape changes or --jq returns null/empty.
-      { match: "gh api repos/org/repo/branches/'main'", respond: 'null' },
+      // Adapter's SHA-validator soft-fails to null → handler surfaces as
+      // "failed to read main HEAD SHA". Either way the creation path stays
+      // un-entered — same defense as the pre-migration validator.
+      { match: 'gh api repos/org/repo/git/refs/heads/main', respond: 'null' },
     ]);
 
     const result = await handler.execute({
@@ -471,9 +505,9 @@ describe('wave_init handler', () => {
     });
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(false);
-    expect(parsed.error as string).toContain('unexpected SHA');
+    expect(parsed.error as string).toContain('failed to read main HEAD SHA');
     // Critically, no branch creation attempted with the bogus SHA
-    const calls = mockExecSync.mock.calls.map(c => c[0] as string);
+    const calls = mockExecSync.mock.calls.map(c => unquote(c[0] as string));
     expect(calls.some(c => c.includes('git/refs -X POST'))).toBe(false);
   });
 
@@ -482,8 +516,8 @@ describe('wave_init handler', () => {
     setExecRoutes([
       { match: 'git remote get-url', respond: 'git@github.com:org/repo.git' },
       { match: 'git ls-remote --heads origin', respond: '' },
-      { match: "gh api repos/org/repo/branches/'main'", respond: '4444444444444444444444444444444444444444' },
-      { match: 'gh api repos/org/repo/git/refs', respond: '' },
+      { match: 'gh api repos/org/repo/git/refs/heads/main', respond: '4444444444444444444444444444444444444444' },
+      { match: 'gh api repos/org/repo/git/refs -X POST', respond: '' },
       { match: 'wave-status set-kahuna-branch', respond: '' },
     ]);
 
@@ -500,28 +534,26 @@ describe('wave_init handler', () => {
     }
   });
 
-  test('kahuna bootstrap — base_branch is shell-escaped in the URL path', async () => {
+  test('kahuna bootstrap — base_branch with shell metacharacters is rejected by adapter validator', async () => {
+    // Story 2.22 (#316): pre-migration shell-escaped malicious branch names
+    // into the URL path. The adapter's validator is STRONGER — it rejects
+    // branches outside `[A-Za-z0-9._\\-/]+` up front, so no subprocess is
+    // invoked with the malicious value at all.
     await setupStatusFixture({ kahuna_branch: null });
-    let capturedBaseCmd = '';
     setExecRoutes([
       { match: 'git remote get-url', respond: 'git@github.com:org/repo.git' },
       { match: 'git ls-remote --heads origin', respond: '' },
-      // Match a benign substring; the test asserts the call shape after.
-      { match: 'gh api repos/org/repo/branches/', respond: () => {
-        capturedBaseCmd = mockExecSync.mock.calls[mockExecSync.mock.calls.length - 1][0] as string;
-        return '5555555555555555555555555555555555555555';
-      } },
-      { match: 'gh api repos/org/repo/git/refs', respond: '' },
-      { match: 'wave-status set-kahuna-branch', respond: '' },
     ]);
 
-    await handler.execute({
-      plan_json: JSON.stringify({ phases: [], base_branch: "weird; rm -rf /" }),
+    const result = await handler.execute({
+      plan_json: JSON.stringify({ phases: [], base_branch: 'weird; rm -rf /' }),
       kahuna: { epic_id: 1, slug: 'foo' },
     });
-
-    // The malicious value must be wrapped in single quotes — proves shell escaping fires
-    expect(capturedBaseCmd).toContain(`'weird; rm -rf /'`);
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(false);
+    // No gh/glab api call made with the malicious branch — validator fires first.
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string);
+    expect(calls.some(c => c.includes('rm -rf'))).toBe(false);
   });
 
   test('kahuna bootstrap — wave-status set-kahuna-branch failure surfaces as ok:false', async () => {
@@ -529,8 +561,8 @@ describe('wave_init handler', () => {
     setExecRoutes([
       { match: 'git remote get-url', respond: 'git@github.com:org/repo.git' },
       { match: 'git ls-remote --heads origin', respond: '' },
-      { match: "gh api repos/org/repo/branches/'main'", respond: '2222222222222222222222222222222222222222' },
-      { match: 'gh api repos/org/repo/git/refs', respond: '' },
+      { match: 'gh api repos/org/repo/git/refs/heads/main', respond: '2222222222222222222222222222222222222222' },
+      { match: 'gh api repos/org/repo/git/refs -X POST', respond: '' },
       { match: 'wave-status set-kahuna-branch', respond: () => { throw new Error('CLI exploded'); } },
     ]);
 


### PR DESCRIPTION
## Summary

Hybrid migration of `wave_init` per Story 2.22. Lands new `PlatformAdapter.createBranch` method with GitHub/GitLab adapters, promotes GitLab `resolveBranchSha` from stub to real implementation, and shrinks `handlers/wave_init.ts` from 451 to 80 lines with all platform branching routed through `getAdapter()`.

## Changes

- `PlatformAdapter.createBranch({branch, sha, repo?})` added in `lib/adapters/types.ts` (CreateBranchArgs + interface + registry entry).
- New adapters `lib/adapters/create-branch-{github,gitlab}.ts` with per-token shell-escaped `runArgv` and `BRANCH_CHARSET` validation.
- Promoted GitLab `resolveBranchSha` from `platform_unsupported` stub to real `glab api projects/<encoded>/repository/branches/<branch>` implementation.
- `handlers/wave_init.ts` refactored to 80 lines; extracted `branchExistsOnRemote` into `lib/shared/git-remote.ts`; plan/state/kahuna orchestration helpers in `lib/wave_init_plan.ts`.
- Removed `wave_init.ts` from `scripts/ci/migration-allowlist.txt`.
- Colocated tests: 15 for create-branch adapters, 8 for resolve-branch-sha-gitlab; `MIGRATED_METHODS` updated.

## Linked Issues

Closes #316

## Test Plan

- `bun test lib/adapters/create-branch-github.test.ts lib/adapters/create-branch-gitlab.test.ts` — 15/15 pass
- `bun test lib/adapters/resolve-branch-sha-gitlab.test.ts lib/adapters/types.test.ts` — 72/72 pass
- `bun test tests/wave_init.test.ts` — 29/29 pass
- `./scripts/ci/gate-greps.sh` — OK (71 non-allowlisted handlers, no violations)
- `./scripts/ci/validate.sh` — full validation + 1981/1981 tests pass; per-tool assertions 73/73