### PR TITLE
chore(glab): delete lib/glab.ts — all helpers migrated to adapters (#320)

### DIFF
--- a/lib/adapters/ci-list-runs-gitlab.test.ts
+++ b/lib/adapters/ci-list-runs-gitlab.test.ts
@@ -6,10 +6,9 @@ import type { AdapterResult, CiListRunsResponse } from './types.ts';
 // owns the argv-shape and normalization assertions.
 //
 // The adapter routes its subprocess through `gitlabApiCiList` in
-// `lib/glab.ts` today (per Story 2.19 spec — `lib/glab.ts` deletion is
-// deferred to Phase 3 Story 3.1). So we mock `child_process.execSync`
-// directly AND stub `parseRepoSlug` so `gitlabApiCiList`'s `git remote`
-// peek doesn't need a real repo.
+// `lib/gitlab-api.ts`. So we mock `child_process.execSync` directly AND stub
+// `parseRepoSlug` so `gitlabApiCiList`'s `git remote` peek doesn't need a
+// real repo.
 
 interface ThrowableError extends Error {
   stderr?: string;

--- a/lib/adapters/ci-list-runs-gitlab.ts
+++ b/lib/adapters/ci-list-runs-gitlab.ts
@@ -17,13 +17,12 @@
  * - `expected_sha` threads through as the `?sha=` query param on the GitLab
  *   REST endpoint; `gitlabApiCiList` handles the encoding.
  *
- * `gitlabApiCiList` lives in `lib/glab.ts` today and is shared across the
- * CI family. Phase 3 Story 3.1 deletes `lib/glab.ts` wholesale; this adapter
- * will in-line the `glab api` invocation at that time.
+ * `gitlabApiCiList` lives in `lib/gitlab-api.ts` and is shared across the
+ * CI family (`ci_wait_run`, `ci_run_status`, `ci_runs_for_branch`).
  */
 
 import { execSync } from 'child_process';
-import { gitlabApiCiList, type GitlabPipeline } from '../glab.js';
+import { gitlabApiCiList, type GitlabPipeline } from '../gitlab-api.js';
 import type {
   AdapterResult,
   CiListRunsArgs,

--- a/lib/adapters/ci-run-status-gitlab.test.ts
+++ b/lib/adapters/ci-run-status-gitlab.test.ts
@@ -7,10 +7,9 @@ import type { AdapterResult, CiRunStatusResponse } from './types.ts';
 // enum-normalization assertions.
 //
 // The adapter routes its subprocess through `gitlabApiCiList` in
-// `lib/glab.ts` (per Story 2.13 spec note — `lib/glab.ts` deletion is
-// deferred to Phase 3 Story 3.1). That means we mock `child_process.execSync`
-// directly AND stub `parseRepoSlug` so `gitlabApiCiList`'s `git remote` peek
-// doesn't need a real repo.
+// `lib/gitlab-api.ts`. That means we mock `child_process.execSync` directly
+// AND stub `parseRepoSlug` so `gitlabApiCiList`'s `git remote` peek doesn't
+// need a real repo.
 
 interface ThrowableError extends Error {
   stderr?: string;

--- a/lib/adapters/ci-run-status-gitlab.ts
+++ b/lib/adapters/ci-run-status-gitlab.ts
@@ -12,9 +12,8 @@
  *   best-effort matching. When `workflow_name` is set we fetch a deeper
  *   window (20) so the filter has something to chew on; otherwise just 1.
  * - `gitlabApiCiList` (the `glab api projects/.../pipelines` wrapper) lives
- *   in `lib/glab.ts` today and is shared with `ci_wait_run` +
- *   `ci_runs_for_branch`. Per Story 2.13's spec note, THIS adapter owns the
- *   call-site; `lib/glab.ts` is deleted wholesale in Phase 3 Story 3.1.
+ *   in `lib/gitlab-api.ts` and is shared with `ci_wait_run` +
+ *   `ci_runs_for_branch`.
  * - Status enum mapping diverges: GitLab statuses (`created`, `pending`,
  *   `running`, `success`, `failed`, `canceled`, `skipped`, …) normalize
  *   differently than GitHub's, so `normalizeGl*` lives here next to the
@@ -22,7 +21,7 @@
  */
 
 import { execSync } from 'child_process';
-import { gitlabApiCiList, type GitlabPipeline } from '../glab.js';
+import { gitlabApiCiList, type GitlabPipeline } from '../gitlab-api.js';
 import type {
   AdapterResult,
   CiRunConclusion,

--- a/lib/adapters/ci-runs-for-branch-gitlab.test.ts
+++ b/lib/adapters/ci-runs-for-branch-gitlab.test.ts
@@ -7,8 +7,7 @@ import type { AdapterResult, CiRunsForBranchResponse } from './types.ts';
 // and response-normalization assertions.
 //
 // The adapter routes its subprocess through `gitlabApiCiList` in
-// `lib/glab.ts` (per dev spec §5 — `lib/glab.ts` deletion is deferred to
-// Phase 3 Story 3.1). We mock `child_process.execSync` directly and register
+// `lib/gitlab-api.ts`. We mock `child_process.execSync` directly and register
 // the `git remote get-url origin` response in the same registry so
 // `parseRepoSlug`'s call lands on our mock. Avoiding `mock.module` on
 // `../shared/parse-repo-slug.js` keeps the process-global mock registry

--- a/lib/adapters/ci-runs-for-branch-gitlab.ts
+++ b/lib/adapters/ci-runs-for-branch-gitlab.ts
@@ -13,8 +13,7 @@
  *   in_progress | all`) to the GitLab-native vocabulary (`success | failed |
  *   running`). This lives next to the query that produces the raw values.
  * - `gitlabApiCiList` (the `glab api projects/.../pipelines` wrapper) lives
- *   in `lib/glab.ts` today and is shared with `ci_wait_run` + `ci_run_status`.
- *   Per dev spec §5, `lib/glab.ts` is deleted wholesale in Phase 3 Story 3.1.
+ *   in `lib/gitlab-api.ts` and is shared with `ci_wait_run` + `ci_run_status`.
  * - `workflow_name` falls back to the pipeline `source` field (push,
  *   merge_request_event, schedule, …); GitLab pipelines don't carry a
  *   separate workflow name the way GitHub runs do.
@@ -23,7 +22,7 @@
  */
 
 import { execSync } from 'child_process';
-import { gitlabApiCiList } from '../glab.js';
+import { gitlabApiCiList } from '../gitlab-api.js';
 import type {
   AdapterResult,
   CiRunsForBranchArgs,

--- a/lib/adapters/fetch-ci-trust-signal-gitlab.ts
+++ b/lib/adapters/fetch-ci-trust-signal-gitlab.ts
@@ -7,11 +7,10 @@
  * GitLab — merge pipelines alone are not sufficient (they still allow merge
  * before CI completes).
  *
- * Uses the typed `gitlabApiRepo` wrapper from `lib/glab.ts` (the supported
- * path until Phase-3 Story 3.1 deletes `lib/glab.ts`).
+ * Uses the typed `gitlabApiRepo` wrapper from `lib/gitlab-api.ts`.
  */
 
-import { gitlabApiRepo } from '../glab.js';
+import { gitlabApiRepo } from '../gitlab-api.js';
 import type {
   AdapterResult,
   CiTrustSignal,

--- a/lib/adapters/fetch-issue-closure-gitlab.ts
+++ b/lib/adapters/fetch-issue-closure-gitlab.ts
@@ -10,11 +10,10 @@
  * separate feature — keeping the code path untouched avoids a cross-platform
  * regression.
  *
- * Uses the typed `gitlabApiIssue` wrapper from `lib/glab.ts` (the supported
- * path until Phase-3 Story 3.1 deletes `lib/glab.ts`).
+ * Uses the typed `gitlabApiIssue` wrapper from `lib/gitlab-api.ts`.
  */
 
-import { gitlabApiIssue } from '../glab.js';
+import { gitlabApiIssue } from '../gitlab-api.js';
 import type {
   AdapterResult,
   FetchIssueClosureArgs,

--- a/lib/adapters/fetch-issue-gitlab.ts
+++ b/lib/adapters/fetch-issue-gitlab.ts
@@ -2,9 +2,8 @@
  * GitLab `fetchIssue` adapter implementation — the Phase-2 keystone hybrid
  * sub-call (Story 2.1, #295).
  *
- * Uses the typed `gitlabApiIssue` wrapper from `lib/glab.ts` (the supported
- * path until Phase-3 Story 3.1 deletes `lib/glab.ts` as part of the final
- * consumer migration). Normalizes GitLab's `state` vocabulary (`opened` /
+ * Uses the typed `gitlabApiIssue` wrapper from `lib/gitlab-api.ts`.
+ * Normalizes GitLab's `state` vocabulary (`opened` /
  * `closed`) into the adapter-level `IssueState` (`OPEN` / `CLOSED`), and
  * coerces GitLab's nullable `description` to a body string.
  *
@@ -12,7 +11,7 @@
  * we surface it as `number` to match the normalized `AdapterIssue` shape.
  */
 
-import { gitlabApiIssue } from '../glab.js';
+import { gitlabApiIssue } from '../gitlab-api.js';
 import type {
   AdapterIssue,
   AdapterResult,

--- a/lib/adapters/fetch-pr-for-branch-gitlab.ts
+++ b/lib/adapters/fetch-pr-for-branch-gitlab.ts
@@ -4,17 +4,17 @@
  *
  * Lifted from `handlers/ibm.ts`'s local `getGitlabMrUrl` helper. Returns
  * `{url, number}` (or `null` when no MR matches the source branch). Uses
- * the typed `gitlabApiMrList` wrapper from `lib/glab.ts` rather than
+ * the typed `gitlabApiMrList` wrapper from `lib/gitlab-api.ts` rather than
  * calling `execSync('glab api ...')` directly — same pattern as
  * `fetch-pr-state-gitlab.ts` and the rest of the GitLab adapter family.
  *
  * State vocabulary is the caller-facing enum
  * (`'open' | 'closed' | 'merged' | 'all'`) — `gitlabApiMrList` internally
  * translates `'open' → 'opened'` and omits the query param entirely for
- * `'all'`. See `lib/glab.ts` §214 for the mapping table.
+ * `'all'`. See `lib/gitlab-api.ts` §214 for the mapping table.
  */
 
-import { gitlabApiMrList } from '../glab.js';
+import { gitlabApiMrList } from '../gitlab-api.js';
 import type {
   AdapterResult,
   FetchPrForBranchArgs,

--- a/lib/adapters/fetch-pr-state-gitlab.ts
+++ b/lib/adapters/fetch-pr-state-gitlab.ts
@@ -7,12 +7,12 @@
  *   - `prMergeWait` for "block until merged" polling
  *   - `prMerge` (both platforms) for post-merge URL/sha lookup
  *
- * Uses the typed `gitlabApiMr` wrapper from `lib/glab.ts` rather than calling
+ * Uses the typed `gitlabApiMr` wrapper from `lib/gitlab-api.ts` rather than calling
  * `execSync('glab api ...')` directly — same pattern as `prMergeGitlab` and
  * the rest of the GitLab adapter family.
  */
 
-import { gitlabApiMr } from '../glab.js';
+import { gitlabApiMr } from '../gitlab-api.js';
 import type {
   AdapterResult,
   FetchPrStateArgs,

--- a/lib/adapters/find-existing-pr-gitlab.ts
+++ b/lib/adapters/find-existing-pr-gitlab.ts
@@ -5,7 +5,7 @@
  * Lifted from `handlers/wave_finalize.ts`'s local `findExistingGitlabMr`
  * helper. Returns the first MR matching `(head, base, state)` normalized to
  * the adapter's `NormalizedPr` shape, or `null` when no match exists. Uses
- * the typed `gitlabApiMrList` wrapper from `lib/glab.ts` — same pattern as
+ * the typed `gitlabApiMrList` wrapper from `lib/gitlab-api.ts` — same pattern as
  * the sibling `fetch-pr-for-branch-gitlab.ts`.
  *
  * State vocabulary is the caller-facing enum (`'open' | 'closed' | 'merged'`)
@@ -16,7 +16,7 @@
  * normalized `'open' | ...` form should post-process.
  */
 
-import { gitlabApiMrList } from '../glab.js';
+import { gitlabApiMrList } from '../gitlab-api.js';
 import type {
   AdapterResult,
   FindExistingPrArgs,

--- a/lib/adapters/find-merged-pr-for-branch-prefix-gitlab.ts
+++ b/lib/adapters/find-merged-pr-for-branch-prefix-gitlab.ts
@@ -14,11 +14,10 @@
  * direct adapter users see the widened behavior too. GitLab's REST API uses
  * `per_page` — `gitlabApiMrList` forwards the caller's `limit` unchanged.
  *
- * Uses the typed `gitlabApiMrList` wrapper from `lib/glab.ts` (the supported
- * path until Phase-3 Story 3.1 deletes `lib/glab.ts`).
+ * Uses the typed `gitlabApiMrList` wrapper from `lib/gitlab-api.ts`.
  */
 
-import { gitlabApiMrList } from '../glab.js';
+import { gitlabApiMrList } from '../gitlab-api.js';
 import type {
   AdapterResult,
   FindMergedPrForBranchPrefixArgs,

--- a/lib/adapters/pr-diff-gitlab.ts
+++ b/lib/adapters/pr-diff-gitlab.ts
@@ -6,7 +6,7 @@
  *
  * GitLab divergences from the GitHub flow:
  * - `glab mr diff <iid>` for the unified diff (no `--json` mode needed).
- * - URL is fetched via `gitlabApiMr` (per Dev Spec §5.3 — the `lib/glab.ts`
+ * - URL is fetched via `gitlabApiMr` (per Dev Spec §5.3 — the `lib/gitlab-api.ts`
  *   wrapper stays). `glab mr view --output json` is unsupported in glab 1.36;
  *   the API path returns the canonical `web_url` directly.
  *
@@ -15,7 +15,7 @@
 
 import { execSync } from 'child_process';
 import { runArgv } from '../shared/error-norm.js';
-import { gitlabApiMr } from '../glab.js';
+import { gitlabApiMr } from '../gitlab-api.js';
 import type {
   AdapterResult,
   PrDiffArgs,
@@ -101,7 +101,7 @@ export async function prDiffGitlab(
     const rawDiff = diffResult.stdout;
 
     // Fetch the canonical MR URL via the typed `gitlabApiMr` wrapper. Per
-    // Dev Spec §5.3, `lib/glab.ts` stays as the shared GitLab REST client;
+    // Dev Spec §5.3, `lib/gitlab-api.ts` stays as the shared GitLab REST client;
     // adapters layer on top rather than reimplementing it.
     const mr = gitlabApiMr(args.number, parseSlugOpts(args.repo));
     const url = mr.web_url;

--- a/lib/adapters/pr-files-gitlab.ts
+++ b/lib/adapters/pr-files-gitlab.ts
@@ -6,7 +6,7 @@
  *
  * GitLab divergences from the GitHub flow:
  * - There is no `glab` CLI subcommand that returns per-file additions/deletions.
- *   We fetch the MR via `gitlabApiMr` (per Dev Spec §5.3 — `lib/glab.ts` stays
+ *   We fetch the MR via `gitlabApiMr` (per Dev Spec §5.3 — `lib/gitlab-api.ts` stays
  *   as the shared GitLab REST client) and parse hunk stats from each
  *   change's unified `diff` field.
  * - File status (added/modified/removed/renamed) is derived from the boolean
@@ -20,7 +20,7 @@
  */
 
 import { execSync } from 'child_process';
-import { gitlabApiMr } from '../glab.js';
+import { gitlabApiMr } from '../gitlab-api.js';
 import type {
   AdapterResult,
   PrFilesArgs,

--- a/lib/adapters/pr-list-gitlab.ts
+++ b/lib/adapters/pr-list-gitlab.ts
@@ -6,8 +6,8 @@
  *
  * GitLab divergences from the GitHub flow:
  * - There is no `glab pr list` equivalent that returns the JSON shape we need;
- *   we delegate to `gitlabApiMrList` (from `lib/glab.ts`) which speaks the
- *   GitLab REST API directly. Per Dev Spec §5.3, `lib/glab.ts` stays as the
+ *   we delegate to `gitlabApiMrList` (from `lib/gitlab-api.ts`) which speaks the
+ *   GitLab REST API directly. Per Dev Spec §5.3, `lib/gitlab-api.ts` stays as the
  *   shared GitLab REST client during the retrofit.
  * - State translation (`open` → `opened`, etc.) and per_page mapping live
  *   inside `gitlabApiMrList`; this adapter is just a thin call site.
@@ -17,7 +17,7 @@
  */
 
 import { execSync } from 'child_process';
-import { gitlabApiMrList } from '../glab.js';
+import { gitlabApiMrList } from '../gitlab-api.js';
 import type {
   AdapterResult,
   NormalizedPr,

--- a/lib/adapters/pr-status-gitlab.ts
+++ b/lib/adapters/pr-status-gitlab.ts
@@ -7,8 +7,8 @@
  * GitLab divergences from the GitHub flow:
  * - There is no `glab pr status` equivalent that returns the full state +
  *   detailed_merge_status + pipeline shape we need; we delegate to
- *   `gitlabApiMr` (from `lib/glab.ts`) which speaks the GitLab REST API
- *   directly. Per Dev Spec §5.3, `lib/glab.ts` stays as the shared GitLab
+ *   `gitlabApiMr` (from `lib/gitlab-api.ts`) which speaks the GitLab REST API
+ *   directly. Per Dev Spec §5.3, `lib/gitlab-api.ts` stays as the shared GitLab
  *   REST client during the retrofit.
  *
  * **Story 1.7 (#244) — explicit pipeline-status fallthrough.**
@@ -31,7 +31,7 @@
  */
 
 import { execSync } from 'child_process';
-import { gitlabApiMr } from '../glab.js';
+import { gitlabApiMr } from '../gitlab-api.js';
 import type {
   AdapterResult,
   PrStatusArgs,

--- a/lib/adapters/pr-wait-ci-gitlab.ts
+++ b/lib/adapters/pr-wait-ci-gitlab.ts
@@ -19,7 +19,7 @@
  */
 
 import { execSync } from 'child_process';
-import { gitlabApiMr } from '../glab.js';
+import { gitlabApiMr } from '../gitlab-api.js';
 import {
   defaultDeps,
   runPollLoop,

--- a/lib/adapters/types.test.ts
+++ b/lib/adapters/types.test.ts
@@ -85,7 +85,7 @@ describe('PlatformAdapter contract', () => {
   //                    `checkGitlabTrust` helpers). FINAL Phase 2 migration:
   //                    after this lands the `handlers/` tree has zero
   //                    `gitlabApi*` importers, unblocking Phase 3 Story 3.1
-  //                    (delete `lib/glab.ts`).
+  //                    (delete the pre-retrofit GitLab helper module).
   const MIGRATED_METHODS = new Set<string>([
     'prCreate',
     'prDiff',

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -784,10 +784,10 @@ export interface FindMergedPrForBranchPrefixArgs {
  *   lives in a ruleset); on cache miss the adapter falls back to
  *   `gh api repos/<slug>/branches/main/protection` and checks the
  *   `required_status_checks.strict` flag.
- * - GitLab: `glab api projects/<path>` via `gitlabApiRepo()` (the supported
- *   path until Phase-3 Story 3.1 deletes `lib/glab.ts`); `merge_trains_enabled`
- *   is the lone pre-merge-authoritative signal — merge pipelines alone are
- *   not sufficient (they still allow merge before CI completes).
+ * - GitLab: `glab api projects/<path>` via `gitlabApiRepo()` (imported from
+ *   `lib/gitlab-api.ts`); `merge_trains_enabled` is the lone
+ *   pre-merge-authoritative signal — merge pipelines alone are not sufficient
+ *   (they still allow merge before CI completes).
  *
  * Failure modes (subprocess error, JSON parse error, unrecognized platform)
  * collapse to `level: 'unknown'` at the HANDLER level — the adapter itself

--- a/lib/gitlab-api.ts
+++ b/lib/gitlab-api.ts
@@ -1,15 +1,10 @@
 /**
- * Shared GitLab CLI adapter.
+ * Shared GitLab REST API (`glab api`) wrappers used by GitLab platform
+ * adapters in `lib/adapters/*-gitlab.ts`.
  *
- * Consolidates platform detection, repo slug parsing, and typed wrappers
- * around the `glab api` CLI for every GitLab-backed handler.
- *
- * Lives in `lib/` so the handler registry codegen ignores it (same as
- * `lib/dependency_graph.ts` and `lib/spec_parser.ts`).
- *
- * Reference implementation that this adapter generalizes:
- * - `handlers/ci_run_logs.ts:81-108` (fetchGitlab pattern)
- * - `handlers/ci_failed_jobs.ts:96` (glab api projects/.../pipelines/<id>/jobs)
+ * Strictly GitLab-specific: REST response types and typed wrappers around
+ * `glab api projects/...` endpoints. `detectPlatform`, `detectPlatformForRef`,
+ * and `parseRepoSlug` live in `lib/shared/` (Story 1.2, R-17).
  *
  * Why `glab api` and not `glab <sub> view --output json`:
  * `glab 1.36.0` has no `--output` flag on any view or list subcommand
@@ -20,16 +15,6 @@
 import { execSync } from 'child_process';
 import { parseRepoSlug } from './shared/parse-repo-slug.js';
 
-// ---------------------------------------------------------------------------
-// Re-exports — `detectPlatform`, `detectPlatformForRef`, and `parseRepoSlug`
-// moved to `lib/shared/` per Story 1.2 (R-17). These re-exports keep existing
-// importers working during the transition; they are deleted in Phase 3 once
-// every importer is updated to point at the new location directly.
-// ---------------------------------------------------------------------------
-
-export { detectPlatform, detectPlatformForRef, type Platform } from './shared/detect-platform.js';
-export { parseRepoSlug } from './shared/parse-repo-slug.js';
-
 /**
  * URL-encoded project path suitable for `glab api projects/<path>/...`
  * endpoints. GitLab REST API v4 accepts either the numeric project ID or the
@@ -37,9 +22,6 @@ export { parseRepoSlug } from './shared/parse-repo-slug.js';
  *
  * Throws if the origin URL cannot be parsed. Callers that want a graceful
  * fallback should catch the error and fall through to the GitHub code path.
- *
- * Stays in `lib/glab.ts` (not `lib/shared/`) because it's a GitLab-specific
- * helper; it folds into the GitLab adapter during Phase 2 migration.
  */
 export function gitlabProjectPath(): string {
   const slug = parseRepoSlug();

--- a/lib/shared/detect-platform.ts
+++ b/lib/shared/detect-platform.ts
@@ -7,9 +7,9 @@
  * inverted the check (`url.includes('github')`) which gives the wrong answer
  * for self-hosted enterprise deployments.
  *
- * Moved from `lib/glab.ts` per R-17 (Story 1.2). `lib/glab.ts` re-exports
- * these functions during the transition; final deletion of the re-exports
- * happens in Phase 3.
+ * Moved here per R-17 (Story 1.2) — the single source of truth for platform
+ * detection lives in `lib/shared/`, and GitLab-specific REST wrappers live
+ * in `lib/gitlab-api.ts`.
  */
 
 import { execSync } from 'child_process';

--- a/lib/shared/parse-repo-slug.test.ts
+++ b/lib/shared/parse-repo-slug.test.ts
@@ -63,7 +63,8 @@ describe('parseRepoSlug (lib/shared/)', () => {
 
   // Helper-move regression test (per Story 1.2 AC):
   // proves the function still works when imported from its new lib/shared/
-  // location — the goal of the move was to share without coupling to lib/glab.ts.
+  // location — the goal of the move was to share without coupling to the
+  // GitLab-specific REST wrapper module.
   test('helper-move regression: import works from lib/shared/', () => {
     execMockFn = () => 'https://github.com/Wave-Engineering/mcp-server-sdlc.git';
     expect(parseRepoSlug()).toBe('Wave-Engineering/mcp-server-sdlc');

--- a/lib/shared/parse-repo-slug.ts
+++ b/lib/shared/parse-repo-slug.ts
@@ -5,9 +5,9 @@
  * paths. The single source of truth for slug parsing — handlers and adapters
  * import from here rather than rolling local copies.
  *
- * Moved from `lib/glab.ts` per R-17 (Story 1.2). `lib/glab.ts` re-exports
- * these functions during the transition; final deletion of the re-exports
- * happens in Phase 3.
+ * Moved here per R-17 (Story 1.2) — the single source of truth for slug
+ * parsing lives in `lib/shared/`, and GitLab-specific REST wrappers live
+ * in `lib/gitlab-api.ts`.
  */
 
 import { execSync } from 'child_process';

--- a/tests/ci_run_status.test.ts
+++ b/tests/ci_run_status.test.ts
@@ -5,7 +5,7 @@ import { describe, test, expect, mock, beforeEach } from 'bun:test';
 // ci_run_status now dispatches through the platform adapter (Story 2.13 /
 // #307). The GitHub adapter calls subprocess via `runArgv`, which
 // shell-escapes its argv (`'gh' 'run' 'list' '--branch' 'main' …`). The
-// GitLab adapter calls `gitlabApiCiList` in `lib/glab.ts`, which passes a
+// GitLab adapter calls `gitlabApiCiList` in `lib/gitlab-api.ts`, which passes a
 // plain (unquoted) command string to `execSync`. The `unquote` shim strips
 // any shell-quoting so test match-keys can stay as plain
 // `gh run list --branch …` strings — same pattern adopted by

--- a/tests/ci_runs_for_branch.test.ts
+++ b/tests/ci_runs_for_branch.test.ts
@@ -5,7 +5,7 @@ import { describe, test, expect, mock, beforeEach } from 'bun:test';
 // ci_runs_for_branch now dispatches through the platform adapter (Story 2.14
 // / #308). The GitHub adapter calls subprocess via `runArgv`, which
 // shell-escapes its argv (`'gh' 'run' 'list' '--branch' 'main' …`). The
-// GitLab adapter calls `gitlabApiCiList` in `lib/glab.ts`, which passes a
+// GitLab adapter calls `gitlabApiCiList` in `lib/gitlab-api.ts`, which passes a
 // plain (unquoted) command string to `execSync`. The `unquote` shim strips
 // any shell-quoting so test match-keys can stay as plain
 // `gh run list --branch …` strings — same pattern adopted by

--- a/tests/gitlab-api.test.ts
+++ b/tests/gitlab-api.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Tests for `lib/gitlab-api.ts` — the GitLab REST (`glab api`) typed wrappers.
+ *
+ * `detectPlatform` and `parseRepoSlug` coverage lives in
+ * `lib/shared/detect-platform.test.ts` and `lib/shared/parse-repo-slug.test.ts`
+ * respectively.
+ */
+
 import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
 
 interface ExecCall {
@@ -15,15 +23,13 @@ mock.module('child_process', () => ({ execSync: mockExecSync }));
 
 // Import after mocking
 const {
-  detectPlatform,
-  parseRepoSlug,
   gitlabProjectPath,
   gitlabApiIssue,
   gitlabApiMr,
   gitlabApiMrList,
   gitlabApiCiList,
   gitlabApiRepo,
-} = await import('../lib/glab.ts');
+} = await import('../lib/gitlab-api.ts');
 
 function resetMocks() {
   execCalls = [];
@@ -31,164 +37,9 @@ function resetMocks() {
   mockExecSync.mockClear();
 }
 
-describe('glab adapter', () => {
+describe('gitlab-api', () => {
   beforeEach(() => resetMocks());
   afterEach(() => resetMocks());
-
-  describe('detectPlatform', () => {
-    test('returns "gitlab" for gitlab.com URL', () => {
-      execMockFn = (cmd: string) => {
-        if (cmd === 'git remote get-url origin') {
-          return 'https://gitlab.com/owner/repo.git';
-        }
-        return '';
-      };
-      expect(detectPlatform()).toBe('gitlab');
-    });
-
-    test('returns "gitlab" for self-hosted GitLab URL', () => {
-      execMockFn = (cmd: string) => {
-        if (cmd === 'git remote get-url origin') {
-          return 'https://gitlab.company.com/owner/repo.git';
-        }
-        return '';
-      };
-      expect(detectPlatform()).toBe('gitlab');
-    });
-
-    test('returns "gitlab" for SSH GitLab URL', () => {
-      execMockFn = (cmd: string) => {
-        if (cmd === 'git remote get-url origin') {
-          return 'git@gitlab.com:owner/repo.git';
-        }
-        return '';
-      };
-      expect(detectPlatform()).toBe('gitlab');
-    });
-
-    test('returns "github" for github.com URL', () => {
-      execMockFn = (cmd: string) => {
-        if (cmd === 'git remote get-url origin') {
-          return 'https://github.com/owner/repo.git';
-        }
-        return '';
-      };
-      expect(detectPlatform()).toBe('github');
-    });
-
-    test('returns "github" for GitHub Enterprise URL', () => {
-      execMockFn = (cmd: string) => {
-        if (cmd === 'git remote get-url origin') {
-          return 'https://github.company.com/owner/repo.git';
-        }
-        return '';
-      };
-      expect(detectPlatform()).toBe('github');
-    });
-
-    test('falls back to "github" when git remote fails', () => {
-      execMockFn = () => {
-        throw new Error('fatal: not a git repository');
-      };
-      expect(detectPlatform()).toBe('github');
-    });
-
-    test('falls back to "github" when remote is missing', () => {
-      execMockFn = () => {
-        throw new Error('fatal: No such remote');
-      };
-      expect(detectPlatform()).toBe('github');
-    });
-  });
-
-  describe('parseRepoSlug', () => {
-    test('parses HTTPS URL with .git suffix', () => {
-      execMockFn = (cmd: string) => {
-        if (cmd === 'git remote get-url origin') {
-          return 'https://gitlab.com/owner/repo.git';
-        }
-        return '';
-      };
-      expect(parseRepoSlug()).toBe('owner/repo');
-    });
-
-    test('parses HTTPS URL without .git suffix', () => {
-      execMockFn = (cmd: string) => {
-        if (cmd === 'git remote get-url origin') {
-          return 'https://gitlab.com/owner/repo';
-        }
-        return '';
-      };
-      expect(parseRepoSlug()).toBe('owner/repo');
-    });
-
-    test('parses SSH URL with .git suffix', () => {
-      execMockFn = (cmd: string) => {
-        if (cmd === 'git remote get-url origin') {
-          return 'git@gitlab.com:owner/repo.git';
-        }
-        return '';
-      };
-      expect(parseRepoSlug()).toBe('owner/repo');
-    });
-
-    test('parses SSH URL without .git suffix', () => {
-      execMockFn = (cmd: string) => {
-        if (cmd === 'git remote get-url origin') {
-          return 'git@gitlab.com:owner/repo';
-        }
-        return '';
-      };
-      expect(parseRepoSlug()).toBe('owner/repo');
-    });
-
-    test('parses URL with hyphens in owner/repo', () => {
-      execMockFn = (cmd: string) => {
-        if (cmd === 'git remote get-url origin') {
-          return 'https://gitlab.com/my-org/my-repo.git';
-        }
-        return '';
-      };
-      expect(parseRepoSlug()).toBe('my-org/my-repo');
-    });
-
-    test('parses SSH URL with nested GitLab groups', () => {
-      execMockFn = (cmd: string) => {
-        if (cmd === 'git remote get-url origin') {
-          return 'git@gitlab.com:analogicdev/internal/tools/perkollate.git';
-        }
-        return '';
-      };
-      expect(parseRepoSlug()).toBe('analogicdev/internal/tools/perkollate');
-    });
-
-    test('parses HTTPS URL with nested GitLab groups', () => {
-      execMockFn = (cmd: string) => {
-        if (cmd === 'git remote get-url origin') {
-          return 'https://gitlab.com/org/sub/group/repo.git';
-        }
-        return '';
-      };
-      expect(parseRepoSlug()).toBe('org/sub/group/repo');
-    });
-
-    test('returns null when git remote fails', () => {
-      execMockFn = () => {
-        throw new Error('fatal: not a git repository');
-      };
-      expect(parseRepoSlug()).toBeNull();
-    });
-
-    test('returns null for malformed URL', () => {
-      execMockFn = (cmd: string) => {
-        if (cmd === 'git remote get-url origin') {
-          return 'not-a-valid-url';
-        }
-        return '';
-      };
-      expect(parseRepoSlug()).toBeNull();
-    });
-  });
 
   describe('gitlabProjectPath', () => {
     test('returns URL-encoded project path', () => {

--- a/tests/ibm.test.ts
+++ b/tests/ibm.test.ts
@@ -176,7 +176,7 @@ describe('ibm handler', () => {
     const branch = 'feature/5-gitlab-test';
     execRegistry['git branch --show-current'] = branch;
     execRegistry['git remote get-url origin'] = 'https://gitlab.com/org/repo.git';
-    // New API-based calls via lib/glab
+    // New API-based calls via lib/gitlab-api
     execRegistry['glab api projects/org%2Frepo/issues/5'] = JSON.stringify({
       iid: 5,
       state: 'opened',


### PR DESCRIPTION
## Summary

Phase 3 Story 3.1 opener: deletes `lib/glab.ts` now that every helper has been migrated to the permanent GitLab adapter family. GitLab REST wrappers are carved out into `lib/gitlab-api.ts` (owned by the GitLab adapter family), while `detectPlatform` / `parseRepoSlug` remain in `lib/shared/` (landed in Story 1.2, R-17).

## Changes

- Rename `lib/glab.ts` → `lib/gitlab-api.ts` (GitLab REST wrappers only; re-exports of shared helpers dropped)
- Rename `tests/glab.test.ts` → `tests/gitlab-api.test.ts` (GitLab-API sections only; shared-helper coverage stays under `lib/shared/*.test.ts`)
- Rewrite imports in 17 GitLab adapter source files + 3 adapter test files + `lib/adapters/types{.ts,.test.ts}`
- Doc-freshen `lib/shared/detect-platform.ts`, `lib/shared/parse-repo-slug.ts`, `lib/shared/parse-repo-slug.test.ts` + 3 handler-level tests (comment-only touch-ups)
- Net: 28 files changed, +74 / -250

## Linked Issues

Closes #320

## Test Plan

- `./scripts/ci/validate.sh`: PASS — 73/73 per-tool assertions
- `./scripts/ci/gate-greps.sh`: PASS — 73 non-allowlisted handlers verified
- `bunx tsc --noEmit`: PASS (exit 0)
- `bun test`: 2010 pass / 0 fail / 4857 expect() / 141 files / 908 ms
- `grep "lib/glab"` across `*.ts`/`*.js`/`*.json`: 0 hits (remaining matches are in `docs/*.md` narrating the deletion itself, which is intentional history)