### PR TITLE
feat(wave_finalize)!: accept plan_id; title pattern plan(#N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 **BREAKING CHANGE (#362, Story 2.1):** `wave_init` no longer accepts `kahuna: { epic_id, slug }`. Callers must pass `kahuna: { plan_id, slug }` instead. The generated branch name is now `kahuna/<plan_id>-<slug>` and the wave-state schema (`KahunaBranchHistoryEntrySchema` in `lib/wave_state.ts`) renames `epic_id` → `plan_id` on each history entry. No legacy-compat fallback is provided — the legacy shape fails schema validation with a clear error. Part of the Plan/Phase/Epic taxonomy lock (cc-workflow#499): "Plan" is the pipeline's tracking-issue unit; "Epic" is now an optional PM label the pipeline ignores.
 
+**BREAKING CHANGE (#363, Story 2.2):** `wave_finalize` no longer accepts `epic_id`. Callers must pass `plan_id`. The assembled kahuna→target MR title changes from `epic(#N): <slug> — kahuna to <target>` to `plan(#N): <slug> — kahuna to <target>`. No legacy-compat fallback; the old parameter name fails schema validation with a clear error. Part of the Plan/Phase/Epic taxonomy lock (cc-workflow#499).
+
 ## v1.0.2 — 2026-04-07
 
 **Critical fix:** the v1.0.0 / v1.0.1 binaries shipped with a broken handler registry — `index.ts` used `import.meta.glob('./handlers/*.ts', { eager: true })`, which is a Vite-only feature unsupported by Bun. Result: the server crashed at startup whenever a client called `tools/list`. The `work_item` and `ibm` tools existed in the bundle but were never reachable.

--- a/handlers/wave_finalize.ts
+++ b/handlers/wave_finalize.ts
@@ -14,7 +14,7 @@ import {
 
 const inputSchema = z.object({
   root: z.string().optional(),
-  epic_id: z.number().int().positive(),
+  plan_id: z.number().int().positive(),
   kahuna_branch: z.string().min(1),
   target_branch: z.string().min(1).default('main'),
   body_artifacts_dir: z.string().optional(),
@@ -49,13 +49,13 @@ const waveFinalizeHandler: HandlerDef = {
       if (!existing.ok) return envelope({ ok: false, error: existing.error });
       if (existing.data !== null) {
         // body_sha is empty when artifacts are absent — legitimate post-cleanup state.
-        const { body, issueCount } = await assembleBody(resolved.path, args.epic_id, args.kahuna_branch, args.target_branch);
+        const { body, issueCount } = await assembleBody(resolved.path, args.plan_id, args.kahuna_branch, args.target_branch);
         return envelope({ ok: true, number: existing.data.number, url: existing.data.url, state: 'open', created: false, body_sha: issueCount > 0 ? hashBody(body) : '' });
       }
       if (!branchExistsOnRemote(cwd, args.kahuna_branch)) return envelope({ ok: false, error: 'kahuna_branch_not_found' });
-      const { body, issueCount } = await assembleBody(resolved.path, args.epic_id, args.kahuna_branch, args.target_branch);
+      const { body, issueCount } = await assembleBody(resolved.path, args.plan_id, args.kahuna_branch, args.target_branch);
       if (issueCount === 0) return envelope({ ok: false, error: 'no_artifacts' });
-      const title = `epic(#${args.epic_id}): ${epicSlugFromBranch(args.kahuna_branch)} — kahuna to ${args.target_branch}`;
+      const title = `plan(#${args.plan_id}): ${epicSlugFromBranch(args.kahuna_branch)} — kahuna to ${args.target_branch}`;
       const created = await adapter.prCreate({ title, body, base: args.target_branch, head: args.kahuna_branch });
       if ('platform_unsupported' in created) return envelope({ ok: false, error: `prCreate unsupported: ${created.hint}` });
       if (!created.ok) return envelope({ ok: false, error: created.error });

--- a/tests/wave_finalize.plan_id.test.ts
+++ b/tests/wave_finalize.plan_id.test.ts
@@ -1,0 +1,145 @@
+// Story 2.2 (#363) — title-pattern pinning: `wave_finalize` now assembles the
+// kahuna→target MR title as `plan(#<plan_id>): <slug> — kahuna to <target>`.
+//
+// Thin, focused companion to `tests/wave_finalize.test.ts`. The main suite
+// covers the full dispatch matrix (schema, idempotency, GitHub/GitLab happy
+// paths, path containment, body assembly). Here we pin the AC-2 title
+// contract under the new `plan_id` parameter name.
+
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { join } from 'path';
+
+type Responder = string | (() => string);
+
+let execRegistry: Array<{ match: string; respond: Responder }> = [];
+let execCalls: string[] = [];
+
+function mockExec(cmd: string): string {
+  execCalls.push(cmd);
+  for (const { match, respond } of execRegistry) {
+    if (cmd.includes(match)) {
+      return typeof respond === 'function' ? respond() : respond;
+    }
+  }
+  throw new Error(`Unexpected exec call: ${cmd}`);
+}
+
+mock.module('child_process', () => ({
+  execSync: (cmd: string, _opts?: unknown) => mockExec(cmd),
+}));
+
+const { default: handler } = await import('../handlers/wave_finalize.ts');
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text) as Record<string, unknown>;
+}
+
+function onExec(match: string, respond: Responder) {
+  execRegistry.push({ match, respond });
+}
+
+let tmpRoot: string = '';
+
+function makeTmpRoot(): string {
+  return `/tmp/wave-finalize-plan-id-test-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+}
+
+async function writeArtifact(root: string, relPath: string, content: string): Promise<void> {
+  await Bun.write(join(root, relPath), content);
+}
+
+function mockGithubCreate(prNumber: number, headRef: string, baseRef = 'main') {
+  const url = `https://github.com/o/r/pull/${prNumber}`;
+  onExec('gh pr list', '[]');
+  onExec("'pr' 'create'", url);
+  onExec(`'pr' 'view' '${prNumber}'`, JSON.stringify({
+    number: prNumber, url, state: 'OPEN', headRefName: headRef, baseRefName: baseRef,
+  }));
+  onExec('ls-remote', `abc123\trefs/heads/${headRef}`);
+}
+
+beforeEach(() => {
+  execRegistry = [];
+  execCalls = [];
+  tmpRoot = makeTmpRoot();
+  execRegistry.push({
+    match: 'git remote get-url origin',
+    respond: () => 'git@github.com:o/r.git',
+  });
+});
+
+afterEach(() => {
+  execRegistry = [];
+  execCalls = [];
+});
+
+describe('wave_finalize plan_id title pattern', () => {
+  // AC-1: schema accepts plan_id (positive case — the parse succeeds and the
+  // handler proceeds to MR creation).
+  test('accepts plan_id and creates MR with plan(#N): <slug> — kahuna to <target>', async () => {
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
+
+    mockGithubCreate(555, 'kahuna/77-docmancer-portal');
+
+    const result = await handler.execute({
+      plan_id: 77,
+      kahuna_branch: 'kahuna/77-docmancer-portal',
+      body_artifacts_dir: tmpRoot,
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(data.created).toBe(true);
+
+    const createCall = execCalls.find(c => c.includes("'pr' 'create'"));
+    expect(createCall).toBeDefined();
+    expect(createCall).toContain("'--title' 'plan(#77): docmancer-portal — kahuna to main'");
+  });
+
+  // AC-2: title uses explicit target_branch (not hard-coded to 'main') and
+  // the `plan(#N):` prefix is preserved.
+  test('title honors explicit target_branch under the plan(#N) prefix', async () => {
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
+
+    mockGithubCreate(555, 'kahuna/99-foo', 'release/v2');
+
+    await handler.execute({
+      plan_id: 99,
+      kahuna_branch: 'kahuna/99-foo',
+      target_branch: 'release/v2',
+      body_artifacts_dir: tmpRoot,
+    });
+
+    const createCall = execCalls.find(c => c.includes("'pr' 'create'"));
+    expect(createCall).toBeDefined();
+    expect(createCall as string).toContain("'--title' 'plan(#99): foo — kahuna to release/v2'");
+  });
+
+  // AC-4 regression guard: the legacy `epic(#N):` prefix must not be emitted.
+  test('no longer emits the legacy epic(#N) title prefix', async () => {
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
+
+    mockGithubCreate(555, 'kahuna/42-foo');
+
+    await handler.execute({
+      plan_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      body_artifacts_dir: tmpRoot,
+    });
+
+    const createCall = execCalls.find(c => c.includes("'pr' 'create'"));
+    expect(createCall).toBeDefined();
+    expect(createCall as string).not.toContain('epic(#');
+  });
+
+  // AC-4 schema: legacy `epic_id` arg must fail validation cleanly.
+  test('schema rejects legacy epic_id parameter', async () => {
+    const result = await handler.execute({
+      epic_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      body_artifacts_dir: tmpRoot,
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+    expect(data.error as string).toContain('plan_id');
+  });
+});

--- a/tests/wave_finalize.test.ts
+++ b/tests/wave_finalize.test.ts
@@ -97,18 +97,18 @@ describe('wave_finalize handler', () => {
   });
 
   // --- schema validation ---
-  test('schema rejects missing epic_id', async () => {
+  test('schema rejects missing plan_id', async () => {
     const result = await handler.execute({
       kahuna_branch: 'kahuna/42-foo',
     });
     const data = parseResult(result);
     expect(data.ok).toBe(false);
-    expect(data.error as string).toContain('epic_id');
+    expect(data.error as string).toContain('plan_id');
   });
 
-  test('schema rejects non-positive epic_id', async () => {
+  test('schema rejects non-positive plan_id', async () => {
     const result = await handler.execute({
-      epic_id: 0,
+      plan_id: 0,
       kahuna_branch: 'kahuna/42-foo',
     });
     const data = parseResult(result);
@@ -116,7 +116,7 @@ describe('wave_finalize handler', () => {
   });
 
   test('schema rejects missing kahuna_branch', async () => {
-    const result = await handler.execute({ epic_id: 42 });
+    const result = await handler.execute({ plan_id: 42 });
     const data = parseResult(result);
     expect(data.ok).toBe(false);
   });
@@ -129,7 +129,7 @@ describe('wave_finalize handler', () => {
     onExec('ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
 
     const result = await handler.execute({
-      epic_id: 42,
+      plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
       body_artifacts_dir: tmpRoot,
     });
@@ -148,7 +148,7 @@ describe('wave_finalize handler', () => {
     onExec('ls-remote', ''); // branch absent
 
     const result = await handler.execute({
-      epic_id: 42,
+      plan_id: 42,
       kahuna_branch: 'kahuna/42-nonexistent',
       body_artifacts_dir: tmpRoot,
     });
@@ -169,7 +169,7 @@ describe('wave_finalize handler', () => {
     onExec('ls-remote', '');
 
     const result = await handler.execute({
-      epic_id: 42,
+      plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
       body_artifacts_dir: tmpRoot,
     });
@@ -185,7 +185,7 @@ describe('wave_finalize handler', () => {
     onExec('ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
 
     const result = await handler.execute({
-      epic_id: 42,
+      plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
       body_artifacts_dir: tmpRoot, // empty directory
     });
@@ -201,7 +201,7 @@ describe('wave_finalize handler', () => {
     onExec('ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
 
     const result = await handler.execute({
-      epic_id: 42,
+      plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
       body_artifacts_dir: tmpRoot,
     });
@@ -221,7 +221,7 @@ describe('wave_finalize handler', () => {
     }]));
 
     const result = await handler.execute({
-      epic_id: 42,
+      plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
       body_artifacts_dir: tmpRoot,
     });
@@ -243,7 +243,7 @@ describe('wave_finalize handler', () => {
     }]));
 
     await handler.execute({
-      epic_id: 42,
+      plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
       body_artifacts_dir: tmpRoot,
     });
@@ -261,7 +261,7 @@ describe('wave_finalize handler', () => {
     mockGithubCreate(555, 'kahuna/42-wave-status-cli');
 
     const result = await handler.execute({
-      epic_id: 42,
+      plan_id: 42,
       kahuna_branch: 'kahuna/42-wave-status-cli',
       body_artifacts_dir: tmpRoot,
     });
@@ -276,20 +276,20 @@ describe('wave_finalize handler', () => {
     expect((data.body_sha as string).length).toBe(64);
   });
 
-  test('title uses epic(#N): <slug> — kahuna to <target_branch>', async () => {
+  test('title uses plan(#N): <slug> — kahuna to <target_branch>', async () => {
     await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
 
     mockGithubCreate(555, 'kahuna/42-wave-status-cli');
 
     await handler.execute({
-      epic_id: 42,
+      plan_id: 42,
       kahuna_branch: 'kahuna/42-wave-status-cli',
       body_artifacts_dir: tmpRoot,
     });
 
     const createCall = execCalls.find(c => c.includes("'pr' 'create'"));
     expect(createCall).toBeDefined();
-    expect(createCall).toContain("'--title' 'epic(#42): wave-status-cli — kahuna to main'");
+    expect(createCall).toContain("'--title' 'plan(#42): wave-status-cli — kahuna to main'");
   });
 
   test('title uses explicit target_branch when provided', async () => {
@@ -298,7 +298,7 @@ describe('wave_finalize handler', () => {
     mockGithubCreate(555, 'kahuna/42-foo', 'release/v2');
 
     await handler.execute({
-      epic_id: 42,
+      plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
       target_branch: 'release/v2',
       body_artifacts_dir: tmpRoot,
@@ -373,12 +373,12 @@ describe('wave_finalize handler', () => {
     }]));
 
     const r1 = parseResult(await handler.execute({
-      epic_id: 42,
+      plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
       body_artifacts_dir: tmpRoot,
     }));
     const r2 = parseResult(await handler.execute({
-      epic_id: 42,
+      plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
       body_artifacts_dir: tmpRoot,
     }));
@@ -393,7 +393,7 @@ describe('wave_finalize handler', () => {
     onExec('ls-remote', 'abc\trefs/heads/kahuna/42-wave-status-cli');
 
     const result = await handler.execute({
-      epic_id: 42,
+      plan_id: 42,
       kahuna_branch: 'kahuna/42-wave-status-cli',
       // body_artifacts_dir omitted — defaults to /tmp/wavemachine/42-wave-status-cli
     });
@@ -421,7 +421,7 @@ describe('wave_finalize handler', () => {
     onExec('ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
 
     const result = await handler.execute({
-      epic_id: 42,
+      plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
       body_artifacts_dir: tmpRoot,
     });
@@ -449,7 +449,7 @@ describe('wave_finalize handler', () => {
     }]));
 
     const result = await handler.execute({
-      epic_id: 42,
+      plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
       body_artifacts_dir: tmpRoot,
     });
@@ -464,7 +464,7 @@ describe('wave_finalize handler', () => {
   // --- path containment ---
   test('rejects body_artifacts_dir outside /tmp and project directory', async () => {
     const result = await handler.execute({
-      epic_id: 42,
+      plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
       body_artifacts_dir: '/etc',
     });
@@ -478,7 +478,7 @@ describe('wave_finalize handler', () => {
     mockGithubCreate(555, 'kahuna/42-foo');
 
     const result = await handler.execute({
-      epic_id: 42,
+      plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
       body_artifacts_dir: tmpRoot, // /tmp/wave-finalize-test-...
     });
@@ -489,7 +489,7 @@ describe('wave_finalize handler', () => {
   test('rejects body_artifacts_dir with parent-directory escape', async () => {
     // resolve('/tmp/foo/../../etc') === '/etc', which is outside allowed roots.
     const result = await handler.execute({
-      epic_id: 42,
+      plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
       body_artifacts_dir: '/tmp/foo/../../etc',
     });
@@ -506,7 +506,7 @@ describe('wave_finalize handler', () => {
     }]));
 
     const result = await handler.execute({
-      epic_id: 42,
+      plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
       body_artifacts_dir: tmpRoot,
     });


### PR DESCRIPTION
## Summary

Renames `wave_finalize`'s input from `epic_id` to `plan_id` and updates the assembled MR title pattern from `epic(#N): kahuna to <target>` to `plan(#N): kahuna to <target>`. Part of the Plan/Phase/Epic taxonomy lock (cc-workflow#499) — "Plan" is the pipeline's tracking-issue unit; "Epic" is an optional PM label the pipeline ignores.

## Changes

- `handlers/wave_finalize.ts` — schema swap `epic_id` → `plan_id`; assembled MR title emits `plan(#N): kahuna to <target>`
- `tests/wave_finalize.test.ts` — existing fixtures renamed `epic_id` → `plan_id`; title-assertion updated
- `tests/wave_finalize.plan_id.test.ts` (new) — AC-2 title-pattern pin plus AC-4 regression guards (rejects `epic_id`, no legacy `epic(#` prefix). Placed under `tests/` rather than `handlers/` because codegen-handlers.sh globs `handlers/*.ts` and would emit malformed imports for dotted filenames (same gotcha as #362).
- `CHANGELOG.md` — v1.8.2 breaking-change entry

## Linked Issues

Closes Wave-Engineering/mcp-server-sdlc#363

## Test Plan

- [x] `./scripts/ci/validate.sh` — green
- [x] Full suite `bun test` — **2016/2016 pass**
- [x] New `tests/wave_finalize.plan_id.test.ts` — AC-2 title pattern + AC-4 regression guards

## BREAKING CHANGE

Old shape:
```json
{ "epic_id": 42, "target_branch": "main" }
```
→ MR title: `epic(#42): kahuna to main`

New shape:
```json
{ "plan_id": 42, "target_branch": "main" }
```
→ MR title: `plan(#42): kahuna to main`

Schema now rejects `epic_id` (additionalProperties: false).

## Context

Plan #499 Phase 2 Story 2.2 — pipeline tracking unit is the Plan issue, not an Epic. See decision_plan_phase_epic_taxonomy for the full rationale.

Reviewer findings: clean (Orchestrator pre-gate dispatch — no actionable findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>