### PR TITLE
docs(wave-finalize): correct stale epic_id comment

### DIFF
--- a/lib/wave-finalize.ts
+++ b/lib/wave-finalize.ts
@@ -67,7 +67,7 @@ export function resolveArtifactsDir(
   };
 }
 
-/** Extract the free-text slug suffix from `kahuna/<epic_id>-<slug>`. */
+/** Extract the free-text slug suffix from `kahuna/<plan_id>-<slug>`. */
 export function epicSlugFromBranch(kahunaBranch: string): string {
   const m = /^kahuna\/\d+-(.+)$/.exec(kahunaBranch);
   return m !== null ? m[1] : '';


### PR DESCRIPTION
## Summary

One-line docblock comment fix in `wave_finalize`: corrects a stale `epic_id` reference. Most of Story 2.4's scope was superseded by work that landed in P2W1, so this PR carries only the residual docblock correction.

## Changes

- 1 file, 1 line: corrected stale `epic_id` docblock comment in the `wave_finalize` handler.

## Linked Issues

Closes Wave-Engineering/mcp-server-sdlc#365

## Test Plan

- `./scripts/ci/validate.sh` green locally in the worktree.
- Existing `wave_finalize` test suite covers the touched function — no new tests required for a pure docblock change.

## Context

- Plan cc-workflow#499, Phase 2, Story 2.4.
- The originally-scoped helper was omitted per YAGNI: only one call site exists, so extracting a helper would add indirection without reuse.
- Most of Story 2.4's implementation was already delivered in P2W1; this PR carries only the residual docblock correction.

## Note on CHANGELOG

This PR does NOT touch `CHANGELOG.md`. Per the new aggregation pattern (see cc-workflow#524), the wave's changelog entries land in a single aggregation PR at wave end rather than per-story.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
