### PR TITLE
chore(changelog): aggregate P2W3 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 **BREAKING CHANGE (#363, Story 2.2):** `wave_finalize` no longer accepts `epic_id`. Callers must pass `plan_id`. The assembled kahuna→target MR title changes from `epic(#N): <slug> — kahuna to <target>` to `plan(#N): <slug> — kahuna to <target>`. No legacy-compat fallback; the old parameter name fails schema validation with a clear error. Part of the Plan/Phase/Epic taxonomy lock (cc-workflow#499).
 
+### Features
+- **wave_reconcile**: New Prime(post-wave) reconciliation handler emitting canonical `[drift-halt]` comments on Category B drift per Dev Spec §5.4.1. [#366, Story 2.5]
+- **devspec_finalize**: Require `depends_on` field on every Story in `phases-waves.json` (may be empty array); finalization fails with a named list of offenders otherwise. [#367, Story 2.6]
+
 ### Docs
 - **wave-finalize**: correct stale `<epic_id>` → `<plan_id>` comment at `lib/wave-finalize.ts:70`. [#365, Story 2.4]
 


### PR DESCRIPTION
## Summary
Aggregates the 2 CHANGELOG fragments from wave P2W3 flight 1 (issues #366, #367) under the `## Unreleased` → `### Features` subsection.

## Changes
- Appends 2 Feature bullets to `## Unreleased` (issue-number order: 366, 367)
- Creates the `### Features` subsection (Breaking → Features → Docs order maintained)
- Fragments aggregated from `/tmp/wavemachine/mcp-server-sdlc/wave-P2W3/flight-1/issue-{366,367}/CHANGELOG.fragment.md`

## Linked Issues
Aggregation only — no issues closed here. Story issues closed by their individual PRs:
- #366 via #374
- #367 via #375

## Test Plan
- [x] Visual inspection: bullets are correct, in issue-number order, under the right category
- [x] CI green on merge

Pattern: cc-workflow#524 (CHANGELOG fragment aggregation).
