### PR TITLE
fix(ibm): accept singular doc/, bug/, kahuna/ branch prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 ### Docs
 - **wave-finalize**: correct stale `<epic_id>` → `<plan_id>` comment at `lib/wave-finalize.ts:70`. [#365, Story 2.4]
 
+### Fixes
+- **ibm**: `BRANCH_PATTERN` now accepts the canonical singular `doc/` and the missing `bug/` and `kahuna/` prefixes. Previous pattern required plural `docs/` and rejected `kahuna/<N>-<slug>` integration branches outright, forcing rename-then-platform-rejection loops. [#381]
+
 ## v1.0.2 — 2026-04-07
 
 **Critical fix:** the v1.0.0 / v1.0.1 binaries shipped with a broken handler registry — `index.ts` used `import.meta.glob('./handlers/*.ts', { eager: true })`, which is a Vite-only feature unsupported by Bun. Result: the server crashed at startup whenever a client called `tools/list`. The `work_item` and `ibm` tools existed in the bundle but were never reachable.

--- a/handlers/ibm.ts
+++ b/handlers/ibm.ts
@@ -11,7 +11,7 @@ import type { HandlerDef } from '../types.js';
 import { getAdapter } from '../lib/adapters/index.js';
 
 const inputSchema = z.object({ branch: z.string().optional() });
-const BRANCH_PATTERN = /^(feature|fix|chore|docs)\/(\d+)-/;
+const BRANCH_PATTERN = /^(feature|fix|chore|doc|bug|kahuna)\/(\d+)-/;
 const PROTECTED_PATTERN = /^(main|release\/.+)$/;
 
 function envelope(payload: unknown) {

--- a/tests/ibm.test.ts
+++ b/tests/ibm.test.ts
@@ -148,9 +148,9 @@ describe('ibm handler', () => {
     expect(data.pr_url).toBe('https://github.com/org/repo/pull/7');
   });
 
-  // --- all 4 type prefixes ---
-  test('branch_types — feature, fix, chore, docs prefixes all parse correctly', async () => {
-    const types = ['feature', 'fix', 'chore', 'docs'];
+  // --- all 6 type prefixes ---
+  test('branch_types — feature, fix, chore, doc, bug, kahuna prefixes all parse correctly', async () => {
+    const types = ['feature', 'fix', 'chore', 'doc', 'bug', 'kahuna'];
 
     for (const type of types) {
       const branch = `${type}/10-something`;
@@ -169,6 +169,17 @@ describe('ibm handler', () => {
       expect(data.ok).toBe(true);
       expect(data.issue_number).toBe(10);
     }
+  });
+
+  // --- plural docs/ rejected (regression guard for #381) ---
+  test('plural_docs_rejected — docs/ (plural) returns no-issue error', async () => {
+    execRegistry['git branch --show-current'] = 'docs/42-some-doc';
+
+    const result = await ibmHandler.execute({});
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(false);
+    expect(data.error).toBe('Branch has no linked issue. Name format: type/NNN-description');
   });
 
   // --- gitlab platform ---


### PR DESCRIPTION
## Summary

`BRANCH_PATTERN` rejected canonical singular `doc/` and entirely missed `bug/` and `kahuna/`, forcing rename loops where the GitLab pre-receive hook accepts singular `doc/`. KAHUNA Flight Agents on `kahuna/<N>-<slug>` branches were also rejected outright. Reported by polyjuice 🧪 (perkollate) in `#agent-ops` 2026-05-04.

## Changes

- `handlers/ibm.ts:14` — `(feature|fix|chore|docs)` → `(feature|fix|chore|doc|bug|kahuna)`
- `tests/ibm.test.ts:152` — `branch_types` test now covers all 6 prefixes
- `tests/ibm.test.ts` — new `plural_docs_rejected` regression test guards against drift back to plural
- `CHANGELOG.md` — entry under Unreleased / ### Fixes

## Linked Issues

Closes #381

## Test Plan

- [x] `bun test tests/ibm.test.ts` — 10/10 pass
- [x] `./scripts/ci/validate.sh` — 74/74 per-tool assertions, 2066 tests across 147 files green

🤖 Generated with [Claude Code](https://claude.com/claude-code)