### PR TITLE
fix(gitlab-api): defensive execGlab — surface non-zero exit + empty-stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixes
 - **ibm**: `BRANCH_PATTERN` now accepts the canonical singular `doc/` and the missing `bug/` and `kahuna/` prefixes. Previous pattern required plural `docs/` and rejected `kahuna/<N>-<slug>` integration branches outright, forcing rename-then-platform-rejection loops. [#381]
+- **gitlab-api**: `execGlab` now surfaces non-zero exit codes with stderr context, and rejects zero-exit-empty-stdout with a named error instead of letting `JSON.parse('')` produce a cryptic `Unexpected EOF`. [#382]
 
 ## v1.0.2 — 2026-04-07
 

--- a/lib/gitlab-api.ts
+++ b/lib/gitlab-api.ts
@@ -125,7 +125,31 @@ export interface GitlabRepo {
 // ---------------------------------------------------------------------------
 
 function execGlab(cmd: string): string {
-  return execSync(cmd, { encoding: 'utf8', maxBuffer: 1024 * 1024 * 64 });
+  let raw: string;
+  try {
+    raw = execSync(cmd, {
+      encoding: 'utf8',
+      maxBuffer: 1024 * 1024 * 64,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    if (err instanceof Error && ('stderr' in err || 'status' in err)) {
+      const stderr = String((err as { stderr?: unknown }).stderr ?? '').trim();
+      const status = (err as { status?: number }).status;
+      const exit = typeof status === 'number' ? status : '?';
+      throw new Error(
+        `glab failed (exit ${exit}): ${cmd}${stderr ? `\nstderr: ${stderr}` : ''}`,
+      );
+    }
+    throw err;
+  }
+  // Zero-exit-empty-stdout: caller would do JSON.parse('') → SyntaxError
+  // ("Unexpected EOF") that loses the underlying cause. Surface a named
+  // error instead so the failure is diagnosable. (#382)
+  if (raw.trim() === '') {
+    throw new Error(`glab returned empty output for: ${cmd}`);
+  }
+  return raw;
 }
 
 /**

--- a/tests/gitlab-api.test.ts
+++ b/tests/gitlab-api.test.ts
@@ -551,4 +551,65 @@ describe('gitlab-api', () => {
       expect(glabCall?.opts?.maxBuffer).toBe(1024 * 1024 * 64);
     });
   });
+
+  // execGlab is internal but its failure-mode behavior is observable through
+  // every wrapper. Test through gitlabApiIssue as the canonical entrypoint
+  // (#382 — empty-stdout produced cryptic "JSON Parse error: Unexpected EOF",
+  // and non-zero exit lost stderr context).
+  describe('execGlab (failure-mode behavior, observed via gitlabApiIssue)', () => {
+    test('non-zero exit with stderr is surfaced as named error including command and stderr', () => {
+      execMockFn = (cmd: string) => {
+        if (cmd === 'git remote get-url origin') {
+          return 'https://gitlab.com/owner/repo.git';
+        }
+        if (cmd.includes('glab api')) {
+          const err = new Error('Command failed') as Error & {
+            stderr?: string;
+            status?: number;
+          };
+          err.stderr = '401 Unauthorized';
+          err.status = 1;
+          throw err;
+        }
+        return '';
+      };
+
+      expect(() => gitlabApiIssue(7)).toThrow(/glab failed \(exit 1\):.*glab api projects/);
+      expect(() => gitlabApiIssue(7)).toThrow(/stderr: 401 Unauthorized/);
+    });
+
+    test('zero-exit empty-stdout throws a named error instead of letting JSON.parse explode', () => {
+      execMockFn = (cmd: string) => {
+        if (cmd === 'git remote get-url origin') {
+          return 'https://gitlab.com/owner/repo.git';
+        }
+        if (cmd.includes('glab api')) {
+          return ''; // the polyjuice failure mode
+        }
+        return '';
+      };
+
+      // Must NOT get "JSON Parse error: Unexpected EOF" — must get the
+      // descriptive "empty output" message that names the failing command.
+      expect(() => gitlabApiIssue(7)).toThrow(/glab returned empty output for: glab api projects/);
+      expect(() => gitlabApiIssue(7)).not.toThrow(/Unexpected EOF/);
+    });
+
+    test('plain Error (no stderr, no status) re-throws unchanged for backward compat', () => {
+      execMockFn = (cmd: string) => {
+        if (cmd === 'git remote get-url origin') {
+          return 'https://gitlab.com/owner/repo.git';
+        }
+        if (cmd.includes('glab api')) {
+          throw new Error('404: Issue not found');
+        }
+        return '';
+      };
+
+      // The existing "propagates errors from glab CLI" test case shape:
+      // a bare Error with neither stderr nor status should pass through
+      // untouched so existing callers expecting verbatim messages still work.
+      expect(() => gitlabApiIssue(999)).toThrow('404: Issue not found');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`mcp__sdlc-server__ibm` (and any handler routing through `lib/gitlab-api.ts`) returned `JSON Parse error: Unexpected EOF` when the underlying `glab` subprocess failed. The actual failure cause (auth missing, project not found, network error, etc.) was silently lost. Reported by polyjuice 🧪 (perkollate) in `#agent-ops` 2026-05-04.

## Changes

- `lib/gitlab-api.ts:127` — `execGlab` wraps `execSync` with explicit stdio capture, re-throws non-zero exits with stderr + exit code in the message, and rejects zero-exit-empty-stdout with a named error.
- `tests/gitlab-api.test.ts` — three new failure-mode tests (non-zero with stderr, zero-with-empty-stdout, plain-Error pass-through for backward compat).
- `CHANGELOG.md` — entry under Unreleased / ### Fixes.

Plain Errors (no `stderr` / `status` fields) still pass through unchanged so the existing "propagates errors from glab CLI" test continues to work.

## Linked Issues

Closes #382

## Test Plan

- [x] `bun test tests/gitlab-api.test.ts` — 30/30 pass
- [x] `./scripts/ci/validate.sh` — 74/74 per-tool assertions, 2066 tests across 147 files green

🤖 Generated with [Claude Code](https://claude.com/claude-code)