### PR TITLE
fix(pr-create-gitlab): replace broken glab mr view -F json with glab api lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixes
 - **ibm**: `BRANCH_PATTERN` now accepts the canonical singular `doc/` and the missing `bug/` and `kahuna/` prefixes. Previous pattern required plural `docs/` and rejected `kahuna/<N>-<slug>` integration branches outright, forcing rename-then-platform-rejection loops. [#381]
 - **gitlab-api**: `execGlab` now surfaces non-zero exit codes with stderr context, and rejects zero-exit-empty-stdout with a named error instead of letting `JSON.parse('')` produce a cryptic `Unexpected EOF`. [#382]
+- **pr_create (gitlab)**: replaced the post-create lookup `glab mr view <head> -F json` with `glab api projects/.../merge_requests?source_branch=<head>&state=opened`. The `-F` flag does not exist on glab 1.36.0, so every successful create was being followed by a failed lookup, the handler reported `glab_mr_view_failed`, and callers fell back into a 409 conflict. The mock-based test suite missed it (same family as `lesson_pr_wait_ci_broken.md`). [#383]
 
 ## v1.0.2 — 2026-04-07
 

--- a/lib/adapters/pr-create-gitlab.test.ts
+++ b/lib/adapters/pr-create-gitlab.test.ts
@@ -70,15 +70,17 @@ describe('prCreateGitlab — subprocess boundary', () => {
   test('glab CLI invocation matches expected argv shape (happy path)', async () => {
     on('git branch --show-current', 'feature/gl\n');
     on('glab mr create', 'https://gitlab.com/o/r/-/merge_requests/9\n');
+    // Post-create lookup goes via `glab api projects/.../merge_requests?source_branch=...`
+    // (#383 — `glab mr view -F json` does not exist on glab 1.36.0).
     on(
-      'glab mr view',
-      JSON.stringify({
+      'merge_requests?source_branch',
+      JSON.stringify([{
         iid: 9,
         web_url: 'https://gitlab.com/o/r/-/merge_requests/9',
         state: 'opened',
         source_branch: 'feature/gl',
         target_branch: 'main',
-      }),
+      }]),
     );
 
     const result = await prCreateGitlab({
@@ -102,20 +104,23 @@ describe('prCreateGitlab — subprocess boundary', () => {
     // --yes is the load-bearing non-interactive flag for glab.
     expect(createCall).toContain('--yes');
     expect(createCall).not.toContain('--draft');
+    // Regression guard for #383: post-create lookup MUST NOT use
+    // `glab mr view -F json` (the broken pre-#383 form).
+    expect(execCalls.some((c) => c.includes('mr view') && c.includes('-F'))).toBe(false);
   });
 
-  test('parses glab mr view response into PrCreateResponse', async () => {
+  test('parses post-create MR lookup response into PrCreateResponse', async () => {
     on('git branch --show-current', 'feature/y\n');
     on('glab mr create', 'created\n');
     on(
-      'glab mr view',
-      JSON.stringify({
+      'merge_requests?source_branch',
+      JSON.stringify([{
         iid: 12,
         web_url: 'https://gitlab.com/o/r/-/merge_requests/12',
         state: 'opened',
         source_branch: 'feature/y',
         target_branch: 'develop',
-      }),
+      }]),
     );
 
     const result = await prCreateGitlab({ title: 't', body: 'b', base: 'develop' });
@@ -154,14 +159,14 @@ describe('prCreateGitlab — subprocess boundary', () => {
       throw err;
     });
     on(
-      'glab mr view',
-      JSON.stringify({
+      'merge_requests?source_branch',
+      JSON.stringify([{
         iid: 77,
         web_url: 'https://gitlab.com/o/r/-/merge_requests/77',
         state: 'opened',
         source_branch: 'feature/dup',
         target_branch: 'main',
-      }),
+      }]),
     );
 
     const result = await prCreateGitlab({ title: 't', body: 'b', base: 'main' });
@@ -170,46 +175,50 @@ describe('prCreateGitlab — subprocess boundary', () => {
     expect(result.data.created).toBe(false);
   });
 
-  test('-R flag forwarded when args.repo provided (GitLab uses -R, not --repo)', async () => {
+  test('-R flag forwarded on create when args.repo provided; lookup uses URL-encoded slug', async () => {
     on('git branch --show-current', 'feature/cross\n');
     on('glab mr create', 'created\n');
     on(
-      'glab mr view',
-      JSON.stringify({
+      'merge_requests?source_branch',
+      JSON.stringify([{
         iid: 5,
         web_url: 'https://gitlab.com/Org/Other/-/merge_requests/5',
         state: 'opened',
         source_branch: 'feature/cross',
         target_branch: 'main',
-      }),
+      }]),
     );
 
     await prCreateGitlab({ title: 't', body: 'b', base: 'main', repo: 'Org/Other' });
     const create = findCall('glab mr create');
     expect(create).toContain('-R');
     expect(create).toContain('Org/Other');
-    const view = findCall('glab mr view');
-    expect(view).toContain('-R');
-    expect(view).toContain('Org/Other');
+    // Post-create lookup uses `glab api projects/<encoded>/merge_requests?...`
+    // — URL-encoded slug, no `-R` flag (the API path carries the project).
+    const apiLookup = findCall('merge_requests?source_branch');
+    expect(apiLookup).toContain('Org%2FOther');
+    expect(apiLookup).toContain('source_branch=feature%2Fcross');
   });
 
   test('default-branch resolution via glab api projects/<encoded> when args.base undefined', async () => {
     on('git branch --show-current', 'feature/no-base\n');
+    // Post-create lookup match — registered FIRST so the MR-listing call
+    // doesn't fall through to the default-branch matcher.
     on(
-      'glab api projects/',
-      JSON.stringify({ default_branch: 'main' }),
-    );
-    on('glab mr create', 'created\n');
-    on(
-      'glab mr view',
-      JSON.stringify({
+      'merge_requests?source_branch',
+      JSON.stringify([{
         iid: 33,
         web_url: 'https://gitlab.com/Org/Repo/-/merge_requests/33',
         state: 'opened',
         source_branch: 'feature/no-base',
         target_branch: 'main',
-      }),
+      }]),
     );
+    on(
+      'glab api projects/',
+      JSON.stringify({ default_branch: 'main' }),
+    );
+    on('glab mr create', 'created\n');
 
     const result = await prCreateGitlab({ title: 't', body: 'b', repo: 'Org/Repo' });
     expectOk(result);
@@ -219,5 +228,18 @@ describe('prCreateGitlab — subprocess boundary', () => {
     expect(probe).toContain('Org%2FRepo');
     // Confirm resolved branch flowed into create.
     expect(findCall('glab mr create')).toContain('main');
+  });
+
+  test('post-create lookup failure surfaces glab_mr_view_failed (regression guard for soft-fallback)', async () => {
+    on('git branch --show-current', 'feature/orphan\n');
+    on('glab mr create', 'created\n');
+    // Lookup returns empty array — no opened MR found despite create succeeding
+    on('merge_requests?source_branch', JSON.stringify([]));
+
+    const result = await prCreateGitlab({ title: 't', body: 'b', base: 'main' });
+    expectErr(result);
+    expect(result.code).toBe('glab_mr_view_failed');
+    expect(result.error).toContain('source_branch=feature/orphan');
+    expect(result.error).toContain('verify in the GitLab UI');
   });
 });

--- a/lib/adapters/pr-create-gitlab.ts
+++ b/lib/adapters/pr-create-gitlab.ts
@@ -7,7 +7,10 @@
  * GitLab divergences from the GitHub flow:
  * - `glab mr create --yes` (non-interactive); `gh pr create` doesn't need it.
  * - `glab mr create` doesn't print a parseable URL on stdout — re-fetch via
- *   `glab mr view <head> -F json` to get the canonical IID + web_url.
+ *   `glab api projects/<encoded>/merge_requests?source_branch=<head>` to get the
+ *   canonical IID + web_url. (Was `glab mr view <head> -F json` until #383, but
+ *   `-F` is not a valid flag on any glab subcommand in 1.36.0; see the
+ *   `lib/gitlab-api.ts` header comment for the broader rationale.)
  * - `glab api projects/<encoded>` for default branch (no `--jq` flag — parse
  *   the JSON in-process).
  */
@@ -52,35 +55,51 @@ function getDefaultBranch(repo: string | undefined, cwd: string): string {
   return parsed.default_branch;
 }
 
-function lookupGitlabMr(
+function projectSlugEncoded(repo: string | undefined): string {
+  return repo !== undefined ? repo.replace(/\//g, '%2F') : ':id';
+}
+
+function fetchOpenedMrBySourceBranch(
   head: string,
   cwd: string,
   repo: string | undefined,
 ): PrCreateResponse | null {
-  const cmd = ['glab', 'mr', 'view', head, '-F', 'json'];
-  if (repo !== undefined) cmd.push('-R', repo);
-  const view = runArgv(cmd, cwd);
-  if (view.exitCode !== 0) return null;
+  // `glab api projects/.../merge_requests?source_branch=<head>&state=opened`
+  // — the only reliable way to get JSON for an MR by source branch in
+  // glab 1.36.0. Replaces the broken `glab mr view <head> -F json` (#383).
+  const project = projectSlugEncoded(repo);
+  const query = `source_branch=${encodeURIComponent(head)}&state=opened`;
+  const result = runArgv(['glab', 'api', `projects/${project}/merge_requests?${query}`], cwd);
+  if (result.exitCode !== 0 || result.stdout.trim().length === 0) return null;
   try {
-    const parsed = JSON.parse(view.stdout) as {
+    const arr = JSON.parse(result.stdout) as Array<{
       iid: number;
       web_url: string;
       state: string;
       source_branch: string;
       target_branch: string;
-    };
-    if (parsed.state !== 'opened') return null;
+    }>;
+    const mr = arr.find((m) => m.state === 'opened');
+    if (!mr) return null;
     return {
-      number: parsed.iid,
-      url: parsed.web_url,
+      number: mr.iid,
+      url: mr.web_url,
       state: 'open',
-      head: parsed.source_branch,
-      base: parsed.target_branch,
+      head: mr.source_branch,
+      base: mr.target_branch,
       created: false,
     };
   } catch {
     return null;
   }
+}
+
+function lookupGitlabMr(
+  head: string,
+  cwd: string,
+  repo: string | undefined,
+): PrCreateResponse | null {
+  return fetchOpenedMrBySourceBranch(head, cwd, repo);
 }
 
 export async function prCreateGitlab(
@@ -125,34 +144,22 @@ export async function prCreateGitlab(
       };
     }
 
-    // `glab mr create` doesn't print a URL on stdout. Re-fetch by source-branch.
-    const viewCmd = ['glab', 'mr', 'view', head, '-F', 'json'];
-    if (args.repo !== undefined) viewCmd.push('-R', args.repo);
-    const view = runArgv(viewCmd, cwd);
-    if (view.exitCode !== 0) {
+    // `glab mr create` doesn't print a URL on stdout. Re-fetch by
+    // source-branch via `glab api` (#383: the previous `glab mr view -F json`
+    // form rejected with "unknown shorthand flag" on every call, causing
+    // pr_create to report failure even when the MR was created — callers then
+    // fell back to a second `glab mr create` and hit a 409 conflict).
+    const found = fetchOpenedMrBySourceBranch(head, cwd, args.repo);
+    if (found === null) {
       return {
         ok: false,
         code: 'glab_mr_view_failed',
-        error: `glab mr view failed: ${view.stderr.trim() || view.stdout.trim()}`,
+        error: `glab api lookup of MR for source_branch=${head} returned no opened MR after create; the create may have succeeded — verify in the GitLab UI`,
       };
     }
-    const parsed = JSON.parse(view.stdout) as {
-      iid: number;
-      web_url: string;
-      state: string;
-      source_branch: string;
-      target_branch: string;
-    };
     return {
       ok: true,
-      data: {
-        number: parsed.iid,
-        url: parsed.web_url,
-        state: 'open',
-        head: parsed.source_branch,
-        base: parsed.target_branch,
-        created: true,
-      },
+      data: { ...found, created: true },
     };
   } catch (err) {
     return {

--- a/tests/pr_create.test.ts
+++ b/tests/pr_create.test.ts
@@ -121,15 +121,16 @@ describe('pr_create handler', () => {
     onExec('git remote get-url origin', 'git@gitlab.com:org/repo.git\n');
     onExec('git branch --show-current', 'feature/76-pr-create\n');
     onExec('glab mr create', 'https://gitlab.com/org/repo/-/merge_requests/7\n');
+    // Post-create lookup uses `glab api projects/.../merge_requests?source_branch=...` (#383)
     onExec(
-      'glab mr view',
-      JSON.stringify({
+      'merge_requests?source_branch',
+      JSON.stringify([{
         iid: 7,
         web_url: 'https://gitlab.com/org/repo/-/merge_requests/7',
         state: 'opened',
         source_branch: 'feature/76-pr-create',
         target_branch: 'main',
-      }),
+      }]),
     );
 
     const result = await handler.execute({
@@ -181,14 +182,14 @@ describe('pr_create handler', () => {
     onExec('git branch --show-current', 'feature/76-pr-create\n');
     onExec('glab mr create', 'https://gitlab.com/org/repo/-/merge_requests/8\n');
     onExec(
-      'glab mr view',
-      JSON.stringify({
+      'merge_requests?source_branch',
+      JSON.stringify([{
         iid: 8,
         web_url: 'https://gitlab.com/org/repo/-/merge_requests/8',
         state: 'opened',
         source_branch: 'feature/76-pr-create',
         target_branch: 'main',
-      }),
+      }]),
     );
 
     const result = await handler.execute({
@@ -255,6 +256,18 @@ describe('pr_create handler', () => {
   test('default_branch_resolution_gitlab — base omitted resolves via glab api', async () => {
     onExec('git remote get-url origin', 'git@gitlab.com:org/repo.git\n');
     onExec('git branch --show-current', 'feature/159-default-branch\n');
+    // Post-create lookup match — registered FIRST so the merge_requests
+    // listing call doesn't fall through to the broader `glab api` mock below.
+    onExec(
+      'merge_requests?source_branch',
+      JSON.stringify([{
+        iid: 7,
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/7',
+        state: 'opened',
+        source_branch: 'feature/159-default-branch',
+        target_branch: 'develop',
+      }]),
+    );
     // glab api projects/:id — no --jq flag (handler parses JSON in-process).
     onExec('glab api', () => {
       // Faithful to the real glab binary — fail loudly if the handler ever
@@ -274,16 +287,6 @@ describe('pr_create handler', () => {
       });
     });
     onExec('glab mr create', 'https://gitlab.com/org/repo/-/merge_requests/7\n');
-    onExec(
-      'glab mr view',
-      JSON.stringify({
-        iid: 7,
-        web_url: 'https://gitlab.com/org/repo/-/merge_requests/7',
-        state: 'opened',
-        source_branch: 'feature/159-default-branch',
-        target_branch: 'develop',
-      }),
-    );
 
     const result = await handler.execute({
       title: 'feat: default branch',
@@ -431,14 +434,14 @@ describe('pr_create handler', () => {
       'Another open merge request already exists for this source branch',
     );
     onExec(
-      'glab mr view',
-      JSON.stringify({
+      'merge_requests?source_branch',
+      JSON.stringify([{
         iid: 7,
         web_url: 'https://gitlab.com/org/repo/-/merge_requests/7',
         state: 'opened',
         source_branch: 'feature/76-pr-create',
         target_branch: 'main',
-      }),
+      }]),
     );
 
     const result = await handler.execute({
@@ -491,7 +494,7 @@ describe('pr_create handler', () => {
     expect(viewCall).toContain('Wave-Engineering/mcp-server-sdlc');
   });
 
-  test('route_with_repo_gitlab — appends -R to glab mr create/view when repo provided', async () => {
+  test('route_with_repo_gitlab — appends -R to glab mr create when repo provided; lookup uses URL-encoded slug', async () => {
     onExec('git remote get-url origin', 'git@gitlab.com:cwd-org/cwd-repo.git\n');
     onExec('git branch --show-current', 'feature/196-cross-repo\n');
     onExec(
@@ -499,14 +502,14 @@ describe('pr_create handler', () => {
       'https://gitlab.com/target-org/target-repo/-/merge_requests/8\n',
     );
     onExec(
-      'glab mr view',
-      JSON.stringify({
+      'merge_requests?source_branch',
+      JSON.stringify([{
         iid: 8,
         web_url: 'https://gitlab.com/target-org/target-repo/-/merge_requests/8',
         state: 'opened',
         source_branch: 'feature/196-cross-repo',
         target_branch: 'main',
-      }),
+      }]),
     );
 
     const result = await handler.execute({
@@ -522,9 +525,11 @@ describe('pr_create handler', () => {
     const createCall = findCall('glab mr create');
     expect(createCall).toContain('-R');
     expect(createCall).toContain('target-org/target-repo');
-    const viewCall = findCall('glab mr view');
-    expect(viewCall).toContain('-R');
-    expect(viewCall).toContain('target-org/target-repo');
+    // Post-create lookup uses `glab api projects/<encoded>/merge_requests?...`
+    // — URL-encoded slug in the path, no `-R` flag (#383).
+    const apiCall = findCall('merge_requests?source_branch');
+    expect(apiCall).toContain('target-org%2Ftarget-repo');
+    expect(apiCall).toContain('source_branch=feature%2F196-cross-repo');
   });
 
   test('regression_without_repo — gh pr create argv has no --repo flag', async () => {
@@ -576,14 +581,14 @@ describe('pr_create handler', () => {
     onExec('git branch --show-current', 'feature/76-pr-create\n');
     onExec('glab mr create', 'https://gitlab.com/org/repo/-/merge_requests/11\n');
     onExec(
-      'glab mr view',
-      JSON.stringify({
+      'merge_requests?source_branch',
+      JSON.stringify([{
         iid: 11,
         web_url: 'https://gitlab.com/org/repo/-/merge_requests/11',
         state: 'opened',
         source_branch: 'feature/76-pr-create',
         target_branch: 'main',
-      }),
+      }]),
     );
 
     const result = await handler.execute({

--- a/tests/wave_finalize.test.ts
+++ b/tests/wave_finalize.test.ts
@@ -409,15 +409,22 @@ describe('wave_finalize handler', () => {
     await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md',
       'Done.\nMR: https://gitlab.com/o/r/-/merge_requests/100\n');
 
+    // Post-create lookup match — registered FIRST so prCreateGitlab's
+    // `glab api projects/.../merge_requests?source_branch=...` call doesn't
+    // fall through to the broader pre-create idempotency mock below (#383).
+    onExec(
+      'source_branch=kahuna%2F42-foo&state=opened',
+      JSON.stringify([{
+        iid: 555,
+        web_url: 'https://gitlab.com/o/r/-/merge_requests/555',
+        state: 'opened',
+        source_branch: 'kahuna/42-foo',
+        target_branch: 'main',
+      }]),
+    );
+    // Pre-create idempotency check (findExistingPr) — empty array.
     onExec('glab api projects/o%2Fr/merge_requests', JSON.stringify([]));
     onExec("'mr' 'create'", '');
-    onExec("'mr' 'view'", JSON.stringify({
-      iid: 555,
-      web_url: 'https://gitlab.com/o/r/-/merge_requests/555',
-      state: 'opened',
-      source_branch: 'kahuna/42-foo',
-      target_branch: 'main',
-    }));
     onExec('ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
 
     const result = await handler.execute({


### PR DESCRIPTION
## Summary

`pr_create` reported failure to callers even when MR creation succeeded. Root cause: the post-create lookup issued `glab mr view <head> -F json`, but `-F` does not exist on `glab mr view` (or any glab subcommand) in 1.36.0. Mock-based tests fed canned JSON to the broken command shape, so the regression never surfaced in CI. Reported by polyjuice 🧪 (perkollate) in `#agent-ops` 2026-05-04.

## Changes

- `lib/adapters/pr-create-gitlab.ts` — both the post-create and idempotent-recovery paths now call `glab api projects/<encoded>/merge_requests?source_branch=<head>&state=opened`, take the first opened MR, and normalize into `PrCreateResponse`. New `fetchOpenedMrBySourceBranch` helper extracts the shared logic. Module-level docstring updated to call out the historical reason.
- `lib/adapters/pr-create-gitlab.test.ts` — six existing tests rewritten for the new mock shape; new soft-fail regression test (`post-create lookup failure surfaces glab_mr_view_failed`).
- `tests/pr_create.test.ts` — six existing tests rewritten; the `default_branch_resolution_gitlab` mock-registration order swapped to register the new `merge_requests?source_branch` matcher BEFORE the broader `glab api` mock. The `route_with_repo_gitlab` test now asserts URL-encoded slug in the lookup path instead of `-R`.
- `tests/wave_finalize.test.ts` — gitlab happy-path mock updated for the new lookup shape.
- `CHANGELOG.md` — entry under Unreleased / ### Fixes citing the lineage with `lesson_pr_wait_ci_broken.md`.

## Linked Issues

Closes #383

## Test Plan

- [x] `bun test tests/pr_create.test.ts lib/adapters/pr-create-gitlab.test.ts tests/wave_finalize.test.ts` — 54/54 pass
- [x] `./scripts/ci/validate.sh` — 74/74 per-tool assertions, 2066 tests across 147 files green

🤖 Generated with [Claude Code](https://claude.com/claude-code)