### PR TITLE
fix(dod_load_manifest): parse H3 manifest headings with section prefix

### DIFF
--- a/lib/dod-manifest-parser.test.ts
+++ b/lib/dod-manifest-parser.test.ts
@@ -106,4 +106,42 @@ more body
       category: 'code',
     });
   });
+
+  test('extractManifestSection — H3 with section number prefix (### 5.A Deliverables Manifest)', () => {
+    const md = `# Dev Spec
+
+## 5. Deliverables & Definition of Done
+
+### 5.A Deliverables Manifest
+
+| ID | Description | Evidence Path | Status | Category |
+|----|-------------|---------------|--------|----------|
+| D-01 | Test deliverable | src/test.ts | pending | code |
+
+### 5.B Test Plan
+
+More content.
+`;
+    const section = extractManifestSection(md);
+    expect(section).not.toBeNull();
+    expect(section).toContain('| D-01 | Test deliverable |');
+    expect(section).not.toContain('5.B Test Plan');
+  });
+
+  test('extractManifestSection — H2 without prefix (backward compatibility)', () => {
+    const md = `# PRD
+
+## Deliverables Manifest
+
+| ID | Description | Evidence Path | Status | Category |
+|----|-------------|---------------|--------|----------|
+| D-01 | handler | handlers/x.ts | done | code |
+
+## Other Section
+`;
+    const section = extractManifestSection(md);
+    expect(section).not.toBeNull();
+    expect(section).toContain('| D-01 | handler |');
+    expect(section).not.toContain('Other Section');
+  });
 });

--- a/lib/dod-manifest-parser.ts
+++ b/lib/dod-manifest-parser.ts
@@ -3,10 +3,14 @@
  * (Story 2.7, #301) so the handler can stay platform-agnostic and under the
  * ≤80-line R-05 budget. Shape parsing is pure string work; no I/O lives here.
  *
- * A PRD body contains a `## Deliverables Manifest` H2 section whose content is
- * a GitHub-flavored markdown table with flexible column ordering (id,
+ * A PRD body contains a Deliverables Manifest section (H2 or H3 heading) whose
+ * content is a GitHub-flavored markdown table with flexible column ordering (id,
  * description, evidence path, status, category). This module extracts that
  * section and parses the table into typed rows.
+ *
+ * Supports both:
+ * - `## Deliverables Manifest` (H2, legacy form)
+ * - `### 5.A Deliverables Manifest` (H3 with section prefix, canonical devspec form)
  */
 
 export interface Deliverable {
@@ -20,8 +24,9 @@ export interface Deliverable {
 /**
  * Extract the "Deliverables Manifest" section from a PRD markdown body.
  *
- * Looks for a heading matching `/^##+\s*deliverables manifest/i`, then
- * captures everything until the next same-or-lower level heading.
+ * Looks for a heading (any level) containing "deliverables manifest"
+ * (case-insensitive), then captures everything until the next same-or-lower
+ * level heading.
  */
 export function extractManifestSection(markdown: string): string | null {
   const lines = markdown.split('\n');
@@ -37,7 +42,7 @@ export function extractManifestSection(markdown: string): string | null {
       if (inSection) {
         if (level <= sectionLevel) break;
       }
-      if (/^deliverables manifest/i.test(title)) {
+      if (/deliverables manifest/i.test(title)) {
         inSection = true;
         sectionLevel = level;
         continue;

--- a/tests/dod_load_manifest.test.ts
+++ b/tests/dod_load_manifest.test.ts
@@ -180,4 +180,27 @@ describe('dod_load_manifest handler', () => {
     const parsed = parseResult(result);
     expect(parsed.ok).toBe(false);
   });
+
+  test('parses_h3_manifest_heading — devspec canonical form (### 5.A Deliverables Manifest)', async () => {
+    const prd = `# Development Specification
+
+## 5. Deliverables & Definition of Done
+
+### 5.A Deliverables Manifest
+
+| ID | Description | Evidence Path | Status | Category |
+|----|-------------|---------------|--------|----------|
+| D-01 | Test handler | handlers/test.ts | pending | code |
+| D-02 | Test suite | tests/test.test.ts | pending | test |
+
+### 5.B Test Plan
+`;
+    const path = await writeTempFile(prd);
+    const result = await handler.execute({ path });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.deliverables.length).toBe(2);
+    expect(parsed.deliverables[0].id).toBe('D-01');
+    expect(parsed.deliverables[1].id).toBe('D-02');
+  });
 });


### PR DESCRIPTION
## Summary

Fixed `dod_load_manifest` parser to recognize H3 Deliverables Manifest headings with section number prefixes (e.g., `### 5.A Deliverables Manifest`), the canonical format emitted by `/devspec create`.

## Changes

- Relaxed heading regex from `/^deliverables manifest/i` to `/deliverables manifest/i` to allow section-prefixed headings
- Updated JSDoc documentation to reflect H2 and H3 support
- Added test coverage for H3 canonical form and H2 backward compatibility in both unit and integration tests

## Linked Issues

Closes #379

## Test Plan

- All existing parser tests pass (backward compatibility verified)
- New test cases cover H3 with section prefix and H2 without prefix
- Handler integration test confirms end-to-end parsing of devspec canonical format
- Full validation suite: 2073 tests pass, 0 fail