### PR TITLE
fix(pr_merge): detect gh-pr-merge auto-failure and fall back to GraphQL enqueuePullRequest

### DIFF
--- a/lib/adapters/pr-merge-github.test.ts
+++ b/lib/adapters/pr-merge-github.test.ts
@@ -125,6 +125,7 @@ describe('prMergeGithub — subprocess boundary', () => {
       merge_commit_sha: 'abc123def456',
       warnings: [],
       queue_fallback: false,
+      graphql_fallback: false,
     });
   });
 
@@ -405,5 +406,113 @@ describe('prMergeGithub — subprocess boundary', () => {
       (c) => c.includes('gh pr merge 282') && c.includes('--auto'),
     );
     expect(autoCall).toBeUndefined();
+  });
+
+  // =========================================================================
+  // Bug #284 — GraphQL enqueuePullRequest fallback
+  // =========================================================================
+
+  test('pr-merge-github — merge queue fallback uses GraphQL enqueuePullRequest', async () => {
+    // Regression bug #284: on merge-queue-on / auto-merge-off repos, both
+    // direct merge AND gh pr merge --auto fail. The adapter should fall back
+    // to GraphQL enqueuePullRequest mutation.
+    // Register more specific matcher for enqueuePullRequest BEFORE stubNoQueue
+    on(
+      'enqueuePullRequest',
+      JSON.stringify({
+        data: {
+          enqueuePullRequest: {
+            mergeQueueEntry: { position: 3 },
+          },
+        },
+      }),
+    );
+    stubNoQueue(); // detection returns false-negative
+    on('gh pr merge 284 --squash --delete-branch', () => {
+      throw mergeQueueError();
+    });
+    // --auto ALSO fails with a queue-related error (merge-queue-on but auto-merge-off)
+    on('gh pr merge 284 --squash --delete-branch --auto', () => {
+      const err = new Error('Auto merge is not allowed for this repository') as ThrowableError;
+      err.stderr = 'Auto merge is not allowed for this repository\n';
+      throw err;
+    });
+    // GraphQL node_id fetch
+    on(
+      'gh api repos/org/repo/pulls/284',
+      JSON.stringify({ node_id: 'PR_kwDOAbc123' }),
+    );
+    on(
+      'gh pr view 284 --json state,url,mergeCommit',
+      JSON.stringify({
+        state: 'OPEN',
+        url: 'https://github.com/org/repo/pull/284',
+        mergeCommit: null,
+      }),
+    );
+
+    const result = await prMergeGithub({ number: 284 });
+    expectOk(result);
+    expect(result.data.merge_method).toBe('merge_queue');
+    expect(result.data.enrolled).toBe(true);
+    expect(result.data.merged).toBe(false);
+    expect(result.data.queue_fallback).toBe(true);
+    expect(result.data.graphql_fallback).toBe(true);
+    expect(result.data.queue_position).toBe(3);
+    // Verify both --auto and GraphQL calls were made
+    const autoCall = execCalls.find(
+      (c) => c.includes('gh pr merge 284') && c.includes('--auto'),
+    );
+    expect(autoCall).toBeDefined();
+    const nodeIdCall = execCalls.find((c) => c.includes('gh api repos/org/repo/pulls/284'));
+    expect(nodeIdCall).toBeDefined();
+    const graphqlCall = execCalls.find(
+      (c) => c.includes('gh api graphql') && c.includes('enqueuePullRequest'),
+    );
+    expect(graphqlCall).toBeDefined();
+  });
+
+  test('pr-merge-github — direct merge success has graphql_fallback:false', async () => {
+    // Happy path: direct merge succeeds, no GraphQL fallback needed.
+    stubNoQueue();
+    on('gh pr merge 285 --squash --delete-branch', '');
+    on(
+      'gh pr view 285 --json state,url,mergeCommit',
+      JSON.stringify({
+        state: 'MERGED',
+        url: 'https://github.com/org/repo/pull/285',
+        mergeCommit: { oid: 'abc285' },
+      }),
+    );
+
+    const result = await prMergeGithub({ number: 285 });
+    expectOk(result);
+    expect(result.data.merge_method).toBe('direct_squash');
+    expect(result.data.merged).toBe(true);
+    expect(result.data.queue_fallback).toBe(false);
+    expect(result.data.graphql_fallback).toBe(false);
+    expect(result.data.queue_position).toBeUndefined();
+  });
+
+  test('pr-merge-github — unrelated failure surfaces error, no GraphQL fallback', async () => {
+    // gh fails for a non-queue reason (e.g., CI red, conflicts). The adapter
+    // should NOT invoke GraphQL enqueuePullRequest fallback, just surface the error.
+    stubNoQueue();
+    on('gh pr merge 286 --squash --delete-branch', () => {
+      const err = new Error('Pull request is not mergeable: conflicts') as ThrowableError;
+      err.stderr = 'Pull request is not mergeable: conflicts\n';
+      throw err;
+    });
+
+    const result = await prMergeGithub({ number: 286 });
+    expectErr(result);
+    expect(result.code).toBe('gh_pr_merge_failed');
+    expect(result.error).toContain('conflicts');
+    // Queue detection GraphQL call is expected, but enqueuePullRequest should NOT be called
+    const graphqlEnqueueCall = execCalls.find((c) => c.includes('enqueuePullRequest'));
+    expect(graphqlEnqueueCall).toBeUndefined();
+    // Also should not fetch node_id
+    const nodeIdCall = execCalls.find((c) => c.includes('gh api repos/org/repo/pulls/286'));
+    expect(nodeIdCall).toBeUndefined();
   });
 });

--- a/lib/adapters/pr-merge-github.ts
+++ b/lib/adapters/pr-merge-github.ts
@@ -74,6 +74,48 @@ function exec(cmd: string): string {
   return execSync(cmd, { encoding: 'utf8' });
 }
 
+// GraphQL enqueuePullRequest mutation for repos with merge-queue enabled but
+// enablePullRequestAutoMerge disabled. Returns the queue position or null if
+// the position field is unavailable.
+function enqueuePullRequestViaGraphQL(
+  number: number,
+  repo: string | undefined,
+): number | null {
+  // Step 1: fetch the PR's node_id. When repo is undefined, gh uses the
+  // current directory's remote. When repo is provided, we must include it in
+  // both the API path and --repo flag.
+  let nodeIdCmd: string;
+  if (repo !== undefined) {
+    nodeIdCmd = `gh api repos/${repo}/pulls/${number} --repo ${repo} --jq '.node_id'`;
+  } else {
+    // When repo is undefined, resolve via the slug parser (same logic as
+    // detectMergeQueue). If that fails, let gh api infer from cwd.
+    const slug = parseRepoSlug();
+    if (slug !== null) {
+      nodeIdCmd = `gh api repos/${slug}/pulls/${number} --jq '.node_id'`;
+    } else {
+      // Last resort: gh api without explicit repo path — will fail if cwd isn't
+      // a repo, but that's a caller error (same as other gh invocations).
+      nodeIdCmd = `gh pr view ${number} --json id --jq '.id'`;
+    }
+  }
+  const prId = exec(nodeIdCmd).trim();
+
+  // Step 2: invoke the enqueuePullRequest mutation
+  const mutation = `mutation($prId:ID!){enqueuePullRequest(input:{pullRequestId:$prId}){mergeQueueEntry{position}}}`;
+  const repoFlag = repo !== undefined ? `--repo ${repo}` : '';
+  const graphqlCmd = `gh api graphql -f query='${mutation}' -f prId="${prId}" ${repoFlag}`.trim();
+  const response = exec(graphqlCmd);
+
+  // Parse the response to extract the queue position
+  try {
+    const data = JSON.parse(response);
+    return data?.data?.enqueuePullRequest?.mergeQueueEntry?.position ?? null;
+  } catch {
+    return null;
+  }
+}
+
 function shellEscape(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
@@ -143,6 +185,8 @@ function aggregateOk(args: {
   mergeCommitSha?: string;
   warnings: string[];
   queueFallback?: boolean;
+  graphqlFallback?: boolean;
+  queuePosition?: number | null;
 }): PrMergeResponse {
   return {
     number: args.number,
@@ -155,6 +199,8 @@ function aggregateOk(args: {
     merge_commit_sha: args.mergeCommitSha,
     warnings: args.warnings,
     queue_fallback: args.queueFallback === true,
+    graphql_fallback: args.graphqlFallback === true,
+    queue_position: args.queuePosition,
   };
 }
 
@@ -306,35 +352,74 @@ async function mergeGithubDirect(
   }
 
   // Stderr-fallback path: detection thought no queue, but the API rejected
-  // the direct merge with a queue-related error. Promote the queue state so
-  // the response reflects what we just learned. Mark `queue_fallback: true`
-  // so callers can log the silent retry (bug #280 / #294).
+  // the direct merge with a queue-related error. Try --auto first (the original
+  // fallback path from bug #280). If --auto ALSO fails with a queue-related
+  // error, fall back to GraphQL enqueuePullRequest (bug #284 — repos with
+  // merge-queue-on but enablePullRequestAutoMerge off).
   const fallbackQueue: PrMergeQueueState = { enabled: true, position: null, enforced: true };
   const autoCmd = buildGithubMergeCommand(args.number, true, args.squash_message, args.repo);
   try {
     exec(autoCmd);
-  } catch (err) {
+    // --auto succeeded — enrolled via the queue. No GraphQL fallback needed.
+    const info = await fetchPrStateRouted(args.number, args.repo);
     return {
-      ok: false,
-      code: 'gh_pr_merge_auto_fallback_failed',
-      error: `gh pr merge --auto failed after merge-queue fallback: ${extractFailure(err).message}`,
+      ok: true,
+      data: aggregateOk({
+        number: args.number,
+        enrolled: true,
+        merged: info.state === 'merged',
+        method: 'merge_queue',
+        queue: fallbackQueue,
+        url: info.url,
+        mergeCommitSha: info.mergeCommitSha,
+        warnings,
+        queueFallback: true,
+      }),
+    };
+  } catch (autoErr) {
+    const autoFail = extractFailure(autoErr);
+    const autoIndicatesQueue =
+      stderrIndicatesMergeQueue(autoFail.stderr) ||
+      stderrIndicatesMergeQueue(autoFail.message) ||
+      autoFail.message.includes('Auto merge is not allowed');
+    // If --auto failed for a non-queue reason, surface that error.
+    if (!autoIndicatesQueue) {
+      return {
+        ok: false,
+        code: 'gh_pr_merge_auto_fallback_failed',
+        error: `gh pr merge --auto failed after merge-queue fallback: ${autoFail.message}`,
+      };
+    }
+    // --auto failed with a queue-related error (bug #284 — merge-queue-on but
+    // auto-merge-off). Fall back to GraphQL enqueuePullRequest mutation.
+    let queuePosition: number | null = null;
+    try {
+      queuePosition = enqueuePullRequestViaGraphQL(args.number, args.repo);
+    } catch (graphqlErr) {
+      return {
+        ok: false,
+        code: 'gh_pr_enqueue_graphql_failed',
+        error: `GraphQL enqueuePullRequest failed after --auto fallback: ${extractFailure(graphqlErr).message}`,
+      };
+    }
+    const info = await fetchPrStateRouted(args.number, args.repo);
+    return {
+      ok: true,
+      data: aggregateOk({
+        number: args.number,
+        enrolled: true,
+        merged: info.state === 'merged',
+        method: 'merge_queue',
+        queue: fallbackQueue,
+        url: info.url,
+        mergeCommitSha: info.mergeCommitSha,
+        warnings,
+        queueFallback: true,
+        graphqlFallback: true,
+        queuePosition,
+      }),
     };
   }
-  const info = await fetchPrStateRouted(args.number, args.repo);
-  return {
-    ok: true,
-    data: aggregateOk({
-      number: args.number,
-      enrolled: true,
-      merged: info.state === 'merged',
-      method: 'merge_queue',
-      queue: fallbackQueue,
-      url: info.url,
-      mergeCommitSha: info.mergeCommitSha,
-      warnings,
-      queueFallback: true,
-    }),
-  };
 }
 
 export async function prMergeGithub(

--- a/lib/adapters/pr-merge-gitlab.test.ts
+++ b/lib/adapters/pr-merge-gitlab.test.ts
@@ -112,6 +112,7 @@ describe('prMergeGitlab — subprocess boundary', () => {
       merge_commit_sha: 'deadbeef1234',
       warnings: [],
       queue_fallback: false,
+      graphql_fallback: false,
     });
     // No `gh api graphql` call should ever fire on the GitLab path.
     expect(execCalls.find((c) => c.includes('gh api graphql'))).toBeUndefined();

--- a/lib/adapters/pr-merge-gitlab.ts
+++ b/lib/adapters/pr-merge-gitlab.ts
@@ -144,6 +144,9 @@ export async function prMergeGitlab(
         // GitLab has no queue concept — queue_fallback always false. Required
         // by PrMergeResponse since bug #280 / #294 added the field.
         queue_fallback: false,
+        // GitLab has no GraphQL enqueuePullRequest — graphql_fallback always
+        // false. Required by PrMergeResponse since bug #284 added the field.
+        graphql_fallback: false,
       },
     };
   } catch (err) {

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -94,6 +94,17 @@ export interface PrMergeResponse {
    * enforced-queue path where `--auto` was chosen upfront. Bug #280 / #294.
    */
   queue_fallback: boolean;
+  /**
+   * True when the adapter fell back to GraphQL enqueuePullRequest mutation
+   * because gh pr merge --auto failed on a merge-queue-on / auto-merge-off repo.
+   * Defaults to `false` on every other path. Bug #284.
+   */
+  graphql_fallback: boolean;
+  /**
+   * Queue position returned from GraphQL enqueuePullRequest mutation, or null
+   * if unavailable. Only populated when graphql_fallback is true. Bug #284.
+   */
+  queue_position?: number | null;
 }
 export interface PrMergeWaitArgs {
   number: number;


### PR DESCRIPTION
## Summary

Fixes `pr_merge` to handle repos with merge-queue enabled but `enablePullRequestAutoMerge` disabled by implementing a two-level fallback: try `gh pr merge --auto` first (preserving bug #280 behavior), then if that also fails with a queue-related error, invoke the GraphQL `enqueuePullRequest` mutation.

## Changes

- Added `enqueuePullRequestViaGraphQL()` function to `lib/adapters/pr-merge-github.ts`
- Updated `PrMergeResponse` interface to include `graphql_fallback` and `queue_position` fields
- Modified stderr-fallback path in `mergeGithubDirect()` to try `--auto` first, then GraphQL
- Added 3 new unit tests covering the GraphQL fallback scenarios
- Updated GitLab adapter to include the new fields (always false for GitLab)

## Linked Issues

Closes #284

## Test Plan

- All 2073 existing tests pass
- 3 new unit tests added:
  - `pr-merge-github — merge queue fallback uses GraphQL enqueuePullRequest` - verifies two-level fallback
  - `pr-merge-github — direct merge success has graphql_fallback:false` - happy path
  - `pr-merge-github — unrelated failure surfaces error, no GraphQL fallback` - non-queue errors don't trigger fallback
- Validation script passes: TypeScript lint, adapter-retrofit gate-greps, shellcheck, runtime smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)