### PR TITLE
feat(plan-dod): add plan_load_dod MCP tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 **BREAKING CHANGE (#363, Story 2.2):** `wave_finalize` no longer accepts `epic_id`. Callers must pass `plan_id`. The assembled kahuna→target MR title changes from `epic(#N): <slug> — kahuna to <target>` to `plan(#N): <slug> — kahuna to <target>`. No legacy-compat fallback; the old parameter name fails schema validation with a clear error. Part of the Plan/Phase/Epic taxonomy lock (cc-workflow#499).
 
 ### Features
+- **plan_load_dod**: New MCP tool to fetch Plan tracking-issue and extract Definition of Done structure — both Plan-level DoD checkboxes and per-Phase DoD checklists with [R-XX] refs. Returns parsed view including Dev Spec path from References section. Part of the Plan DoD workflow family. [#388]
 - **wave_reconcile**: New Prime(post-wave) reconciliation handler emitting canonical `[drift-halt]` comments on Category B drift per Dev Spec §5.4.1. [#366, Story 2.5]
 - **devspec_finalize**: Require `depends_on` field on every Story in `phases-waves.json` (may be empty array); finalization fails with a named list of offenders otherwise. [#367, Story 2.6]
 

--- a/handlers/plan_load_dod.ts
+++ b/handlers/plan_load_dod.ts
@@ -1,0 +1,86 @@
+/**
+ * `plan_load_dod` handler — fetches a Plan tracking-issue and returns
+ * a parsed view of its Plan-level Definition of Done plus per-Phase DoD
+ * checklists.
+ *
+ * Story #388: Add plan_load_dod MCP tool to extract DoD from Plan-issue body.
+ * Part of the Plan DoD workflow family.
+ */
+
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+import { getAdapter } from '../lib/adapters/index.js';
+import { parsePlanBody, validatePlanBodyStructure } from '../lib/plan-body-parse.js';
+
+const inputSchema = z.object({
+  plan_id: z.number().int().positive(),
+  repo: z.string().optional(),
+});
+
+function envelope(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] };
+}
+
+const planLoadDodHandler: HandlerDef = {
+  name: 'plan_load_dod',
+  description: 'Fetch a Plan tracking-issue and extract its Definition of Done structure',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: z.infer<typeof inputSchema>;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
+    }
+
+    const adapter = getAdapter({ repo: args.repo });
+    const result = await adapter.fetchIssue({ number: args.plan_id, repo: args.repo });
+
+    if ('platform_unsupported' in result) {
+      return envelope({ ok: false, error: result.hint });
+    }
+
+    if (!result.ok) {
+      // Platform CLI failure
+      return envelope({ ok: false, error: result.error, code: result.code });
+    }
+
+    const issue = result.data;
+
+    // Check if issue exists (already handled by adapter, but explicit check for clarity)
+    if (!issue) {
+      return envelope({
+        ok: false,
+        code: 'plan_not_found',
+        error: `Plan issue #${args.plan_id} not found`,
+      });
+    }
+
+    // Validate Plan body structure
+    const missingHeadings = validatePlanBodyStructure(issue.body);
+    if (missingHeadings.length > 0) {
+      return envelope({
+        ok: false,
+        code: 'plan_body_invalid',
+        error: `Plan body missing required headings: ${missingHeadings.join(', ')}`,
+        missing_headings: missingHeadings,
+      });
+    }
+
+    // Parse the Plan body
+    const parsed = parsePlanBody(issue.body);
+
+    // Build response
+    return envelope({
+      ok: true,
+      plan_id: issue.number,
+      plan_title: issue.title,
+      plan_level_dod: parsed.plan_level_dod,
+      phases: parsed.phases,
+      devspec_path: parsed.devspec_path,
+      references: parsed.references,
+    });
+  },
+};
+
+export default planLoadDodHandler;

--- a/lib/plan-body-parse.test.ts
+++ b/lib/plan-body-parse.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Tests for `lib/plan-body-parse.ts` — Plan body parsing and DoD extraction.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { parsePlanBody, validatePlanBodyStructure } from './plan-body-parse';
+
+describe('parsePlanBody', () => {
+  test('parses canonical Plan body (golden path)', () => {
+    const body = `
+## Plan-level Definition of Done
+
+- [ ] All Phase deliverables complete
+- [x] Test coverage ≥ 90%
+- [ ] Documentation updated
+
+## Phases
+
+### Phase 1 — Foundation
+
+Setup and scaffolding.
+
+**DoD:**
+
+- [ ] Database schema created [R-01]
+- [ ] API endpoints stubbed [R-02]
+- [x] README updated
+
+### Phase 2 — Core Logic
+
+Implement business logic.
+
+**DoD:**
+
+- [ ] Payment processing integrated [R-03]
+- [ ] Validation rules applied
+
+## References
+
+Dev Spec: \`docs/specs/payment-system.md\`
+Architecture: \`docs/arch/overview.md\`
+`;
+
+    const result = parsePlanBody(body);
+
+    expect(result.plan_level_dod).toHaveLength(3);
+    expect(result.plan_level_dod[0]).toEqual({
+      checked: false,
+      text: 'All Phase deliverables complete',
+    });
+    expect(result.plan_level_dod[1]).toEqual({
+      checked: true,
+      text: 'Test coverage ≥ 90%',
+    });
+    expect(result.plan_level_dod[2]).toEqual({
+      checked: false,
+      text: 'Documentation updated',
+    });
+
+    expect(result.phases).toHaveLength(2);
+    expect(result.phases[0].phase_name).toBe('Foundation');
+    expect(result.phases[0].items).toHaveLength(3);
+    expect(result.phases[0].items[0]).toEqual({
+      checked: false,
+      text: 'Database schema created',
+      ref: 'R-01',
+    });
+    expect(result.phases[0].items[1]).toEqual({
+      checked: false,
+      text: 'API endpoints stubbed',
+      ref: 'R-02',
+    });
+    expect(result.phases[0].items[2]).toEqual({
+      checked: true,
+      text: 'README updated',
+    });
+
+    expect(result.phases[1].phase_name).toBe('Core Logic');
+    expect(result.phases[1].items).toHaveLength(2);
+    expect(result.phases[1].items[0]).toEqual({
+      checked: false,
+      text: 'Payment processing integrated',
+      ref: 'R-03',
+    });
+
+    expect(result.devspec_path).toBe('docs/specs/payment-system.md');
+    expect(result.references).toHaveLength(2);
+    expect(result.references[0]).toContain('Dev Spec:');
+    expect(result.references[1]).toContain('Architecture:');
+  });
+
+  test('extracts Plan-level DoD checkboxes with checked state', () => {
+    const body = `
+## Plan-level Definition of Done
+
+- [x] Item 1 checked
+- [ ] Item 2 unchecked
+- [X] Item 3 checked uppercase
+`;
+
+    const result = parsePlanBody(body);
+
+    expect(result.plan_level_dod).toHaveLength(3);
+    expect(result.plan_level_dod[0].checked).toBe(true);
+    expect(result.plan_level_dod[0].text).toBe('Item 1 checked');
+    expect(result.plan_level_dod[1].checked).toBe(false);
+    expect(result.plan_level_dod[1].text).toBe('Item 2 unchecked');
+    expect(result.plan_level_dod[2].checked).toBe(true);
+    expect(result.plan_level_dod[2].text).toBe('Item 3 checked uppercase');
+  });
+
+  test('extracts per-Phase DoD with [R-XX] ref suffix', () => {
+    const body = `
+## Phases
+
+### Phase 1 — Setup
+
+**DoD:**
+
+- [ ] Task A [R-01]
+- [ ] Task B [R-10]
+- [ ] Task C without ref
+`;
+
+    const result = parsePlanBody(body);
+
+    expect(result.phases).toHaveLength(1);
+    expect(result.phases[0].items).toHaveLength(3);
+    expect(result.phases[0].items[0].ref).toBe('R-01');
+    expect(result.phases[0].items[0].text).toBe('Task A');
+    expect(result.phases[0].items[1].ref).toBe('R-10');
+    expect(result.phases[0].items[2].ref).toBeUndefined();
+  });
+
+  test('extracts Dev Spec path from References', () => {
+    const body = `
+## References
+
+Dev Spec: \`path/to/spec.md\`
+Other: \`other.md\`
+`;
+
+    const result = parsePlanBody(body);
+
+    expect(result.devspec_path).toBe('path/to/spec.md');
+    expect(result.references).toHaveLength(2);
+  });
+
+  test('handles Dev Spec without backticks', () => {
+    const body = `
+## References
+
+Dev Spec: path/to/spec.md
+`;
+
+    const result = parsePlanBody(body);
+
+    expect(result.devspec_path).toBe('path/to/spec.md');
+  });
+
+  test('returns empty arrays when sections missing', () => {
+    const body = `
+## Some Other Section
+
+Content here.
+`;
+
+    const result = parsePlanBody(body);
+
+    expect(result.plan_level_dod).toHaveLength(0);
+    expect(result.phases).toHaveLength(0);
+    expect(result.references).toHaveLength(0);
+    expect(result.devspec_path).toBeUndefined();
+  });
+
+  test('handles Plan-level DoD alternative heading', () => {
+    const body = `
+## Plan-level DoD
+
+- [ ] Item 1
+`;
+
+    const result = parsePlanBody(body);
+
+    expect(result.plan_level_dod).toHaveLength(1);
+    expect(result.plan_level_dod[0].text).toBe('Item 1');
+  });
+
+  test('handles multiple phases with varying DoD items', () => {
+    const body = `
+## Phases
+
+### Phase 1 — Alpha
+
+**DoD:**
+
+- [ ] Alpha task 1
+
+### Phase 2 — Beta
+
+**DoD:**
+
+- [ ] Beta task 1
+- [ ] Beta task 2
+
+### Phase 3 — Gamma
+
+**DoD:**
+
+- [x] Gamma task done
+`;
+
+    const result = parsePlanBody(body);
+
+    expect(result.phases).toHaveLength(3);
+    expect(result.phases[0].phase_name).toBe('Alpha');
+    expect(result.phases[0].items).toHaveLength(1);
+    expect(result.phases[1].phase_name).toBe('Beta');
+    expect(result.phases[1].items).toHaveLength(2);
+    expect(result.phases[2].phase_name).toBe('Gamma');
+    expect(result.phases[2].items).toHaveLength(1);
+    expect(result.phases[2].items[0].checked).toBe(true);
+  });
+});
+
+describe('validatePlanBodyStructure', () => {
+  test('returns empty array when all required headings present', () => {
+    const body = `
+## Plan-level Definition of Done
+
+Content
+
+## Phases
+
+Content
+
+## References
+
+Content
+`;
+
+    const missing = validatePlanBodyStructure(body);
+    expect(missing).toHaveLength(0);
+  });
+
+  test('returns missing heading names', () => {
+    const body = `
+## Plan-level Definition of Done
+
+Content
+`;
+
+    const missing = validatePlanBodyStructure(body);
+    expect(missing).toContain('phases');
+    expect(missing).toContain('references');
+    expect(missing).not.toContain('plan-level definition of done');
+  });
+
+  test('accepts "Plan-level DoD" variant', () => {
+    const body = `
+## Plan-level DoD
+
+Content
+
+## Phases
+
+Content
+
+## References
+
+Content
+`;
+
+    const missing = validatePlanBodyStructure(body);
+    expect(missing).toHaveLength(0);
+  });
+
+  test('detects all missing headings', () => {
+    const body = `
+## Some Other Section
+
+Content
+`;
+
+    const missing = validatePlanBodyStructure(body);
+    expect(missing).toHaveLength(3);
+    expect(missing).toContain('plan-level definition of done');
+    expect(missing).toContain('phases');
+    expect(missing).toContain('references');
+  });
+});

--- a/lib/plan-body-parse.ts
+++ b/lib/plan-body-parse.ts
@@ -1,0 +1,232 @@
+/**
+ * Plan body parser — extracts Definition of Done and Phase info from Plan
+ * tracking-issue markdown.
+ *
+ * A Plan issue body has:
+ * - `## Plan-level Definition of Done` with a checklist
+ * - `## Phases` with `### Phase N — <Name>` sub-headings, each containing
+ *   a `**DoD:**` sub-list
+ * - `## References` with paths (notably `Dev Spec: <path>`)
+ *
+ * Lives in `lib/` so the handler registry codegen (which scans
+ * `handlers/*.ts`) ignores it.
+ */
+
+export interface ChecklistItem {
+  checked: boolean;
+  text: string;
+  ref?: string;
+}
+
+export interface PhaseDoD {
+  phase_name: string;
+  items: ChecklistItem[];
+}
+
+export interface ParsedPlanBody {
+  plan_level_dod: ChecklistItem[];
+  phases: PhaseDoD[];
+  devspec_path?: string;
+  references: string[];
+}
+
+/**
+ * Parse a Plan issue body and extract:
+ * - Plan-level DoD checkboxes
+ * - Per-phase DoD checklists
+ * - Dev Spec path from References
+ * - All reference lines
+ */
+export function parsePlanBody(body: string): ParsedPlanBody {
+  const result: ParsedPlanBody = {
+    plan_level_dod: [],
+    phases: [],
+    references: [],
+  };
+
+  // Split into H2 sections
+  const sections = splitIntoH2Sections(body);
+
+  // Extract Plan-level DoD
+  const dodSection = sections['plan-level definition of done'] || sections['plan-level dod'];
+  if (dodSection) {
+    result.plan_level_dod = extractChecklistItems(dodSection);
+  }
+
+  // Extract Phases
+  const phasesSection = sections['phases'];
+  if (phasesSection) {
+    result.phases = extractPhases(phasesSection);
+  }
+
+  // Extract References
+  const referencesSection = sections['references'];
+  if (referencesSection) {
+    result.references = referencesSection
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line.length > 0);
+
+    // Look for Dev Spec line
+    const devSpecLine = result.references.find(line =>
+      line.toLowerCase().startsWith('dev spec:')
+    );
+    if (devSpecLine) {
+      // Extract path after "Dev Spec:" (may be in backticks or plain text)
+      const match = devSpecLine.match(/dev spec:\s*`?([^`\n]+)`?/i);
+      if (match) {
+        result.devspec_path = match[1].trim();
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Split markdown body into H2 sections.
+ * Returns a map of normalized heading → content.
+ */
+function splitIntoH2Sections(body: string): Record<string, string> {
+  const sections: Record<string, string> = {};
+  const lines = body.split('\n');
+  let currentHeading: string | null = null;
+  let currentLines: string[] = [];
+
+  const flush = () => {
+    if (currentHeading !== null) {
+      sections[currentHeading] = currentLines.join('\n').trim();
+    }
+  };
+
+  for (const line of lines) {
+    const h2Match = line.match(/^##\s+(.+)$/);
+    if (h2Match) {
+      flush();
+      currentHeading = h2Match[1].trim().toLowerCase();
+      currentLines = [];
+    } else if (currentHeading !== null) {
+      currentLines.push(line);
+    }
+  }
+  flush();
+
+  return sections;
+}
+
+/**
+ * Extract checklist items from a section.
+ * Recognizes:
+ * - `- [ ] Item text`
+ * - `- [x] Item text`
+ * - `- [X] Item text`
+ * - Optional [R-XX] ref suffix
+ */
+function extractChecklistItems(text: string): ChecklistItem[] {
+  const items: ChecklistItem[] = [];
+  const lines = text.split('\n');
+
+  for (const line of lines) {
+    const match = line.match(/^[\s-]*\[([xX\s])\]\s*(.+)$/);
+    if (match) {
+      const checked = match[1].toLowerCase() === 'x';
+      let itemText = match[2].trim();
+      let ref: string | undefined;
+
+      // Extract [R-XX] ref suffix
+      const refMatch = itemText.match(/\[R-(\d+)\]\s*$/);
+      if (refMatch) {
+        ref = `R-${refMatch[1]}`;
+        itemText = itemText.replace(/\s*\[R-\d+\]\s*$/, '').trim();
+      }
+
+      items.push({ checked, text: itemText, ref });
+    }
+  }
+
+  return items;
+}
+
+/**
+ * Extract Phase blocks from the Phases section.
+ * Each phase is a `### Phase N — <Name>` heading followed by content
+ * that includes a `**DoD:**` sub-list.
+ */
+function extractPhases(phasesSection: string): PhaseDoD[] {
+  const phases: PhaseDoD[] = [];
+  const lines = phasesSection.split('\n');
+  let currentPhaseName: string | null = null;
+  let currentPhaseLines: string[] = [];
+
+  const flushPhase = () => {
+    if (currentPhaseName !== null) {
+      const dodItems = extractDoDFromPhase(currentPhaseLines.join('\n'));
+      phases.push({
+        phase_name: currentPhaseName,
+        items: dodItems,
+      });
+    }
+  };
+
+  for (const line of lines) {
+    const h3Match = line.match(/^###\s+Phase\s+\d+\s+[—–-]\s+(.+)$/i);
+    if (h3Match) {
+      flushPhase();
+      currentPhaseName = h3Match[1].trim();
+      currentPhaseLines = [];
+    } else if (currentPhaseName !== null) {
+      currentPhaseLines.push(line);
+    }
+  }
+  flushPhase();
+
+  return phases;
+}
+
+/**
+ * Extract DoD checklist from a Phase's content.
+ * Looks for `**DoD:**` followed by checklist items.
+ */
+function extractDoDFromPhase(phaseContent: string): ChecklistItem[] {
+  const lines = phaseContent.split('\n');
+  let inDoD = false;
+  const dodLines: string[] = [];
+
+  for (const line of lines) {
+    if (line.match(/^\*\*DoD:\*\*/i)) {
+      inDoD = true;
+      continue;
+    }
+
+    if (inDoD) {
+      // Stop at next bold heading or empty line after content
+      if (line.match(/^\*\*.+\*\*/) || (line.trim() === '' && dodLines.length > 0 && dodLines[dodLines.length - 1].trim() === '')) {
+        break;
+      }
+      dodLines.push(line);
+    }
+  }
+
+  return extractChecklistItems(dodLines.join('\n'));
+}
+
+/**
+ * Validate that a Plan body has required headings.
+ * Returns an array of missing heading names, or empty array if all present.
+ */
+export function validatePlanBodyStructure(body: string): string[] {
+  const sections = splitIntoH2Sections(body);
+  const required = ['plan-level definition of done', 'phases', 'references'];
+  const missing: string[] = [];
+
+  for (const heading of required) {
+    // Check for exact match or common variants
+    const variants = [heading, heading.replace('definition of done', 'dod')];
+    const found = variants.some(v => sections[v] !== undefined);
+    if (!found) {
+      missing.push(heading);
+    }
+  }
+
+  return missing;
+}

--- a/tests/plan_load_dod.test.ts
+++ b/tests/plan_load_dod.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Tests for `handlers/plan_load_dod.ts` — Plan DoD extraction handler.
+ */
+
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+// Mock child_process registry — matched by substring so individual tests can
+// install exec fixtures for `git remote`, `gh issue view`, `glab api projects/...`.
+// The handler dispatches through getAdapter().fetchIssue(...), which under
+// the hood execs `gh issue view` (GitHub) / `glab api projects/...` (GitLab).
+let execRegistry: Record<string, string> = {};
+
+function mockExec(cmd: string): string {
+  for (const [key, value] of Object.entries(execRegistry)) {
+    if (cmd.includes(key)) return value;
+  }
+  throw new Error(`Unexpected exec call: ${cmd}`);
+}
+
+const mockExecSync = mock((cmd: string, _opts?: unknown) => mockExec(cmd));
+mock.module('child_process', () => ({ execSync: mockExecSync }));
+
+const { default: handler } = await import('../handlers/plan_load_dod.ts');
+
+function resetMocks() {
+  execRegistry = {};
+  mockExecSync.mockClear();
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+const CANONICAL_PLAN_BODY = `# Plan: Payment System
+
+## Plan-level Definition of Done
+
+- [ ] All Phase deliverables complete
+- [x] Architecture approved
+- [ ] Documentation complete
+
+## Phases
+
+### Phase 1 — Foundation
+
+Database schema and API scaffolding.
+
+**DoD:**
+
+- [ ] Schema migrations created [R-01]
+- [ ] API endpoints stubbed [R-02]
+- [x] README updated
+
+### Phase 2 — Core Logic
+
+Payment processing integration.
+
+**DoD:**
+
+- [ ] Stripe integration complete [R-03]
+- [ ] Validation rules applied
+- [ ] Error handling implemented
+
+## References
+
+Dev Spec: \`docs/specs/payment-system.md\`
+Architecture: \`docs/arch/payments-overview.md\`
+`;
+
+const INVALID_PLAN_BODY = `# Plan: Broken
+
+## Some Section
+
+Content without required headings.
+`;
+
+describe('plan_load_dod handler', () => {
+  beforeEach(resetMocks);
+  afterEach(resetMocks);
+
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('plan_load_dod');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('parses canonical Plan body (golden path) — GitHub', async () => {
+    execRegistry['git remote get-url origin'] = 'git@github.com:Wave-Engineering/mcp-server-sdlc.git';
+    execRegistry['gh issue view 123'] = JSON.stringify({
+      number: 123,
+      title: 'Plan: Payment System',
+      state: 'OPEN',
+      body: CANONICAL_PLAN_BODY,
+      labels: [],
+    });
+
+    const result = await handler.execute({ plan_id: 123 });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.plan_id).toBe(123);
+    expect(parsed.plan_title).toBe('Plan: Payment System');
+
+    expect(parsed.plan_level_dod).toHaveLength(3);
+    expect(parsed.plan_level_dod[0]).toEqual({
+      checked: false,
+      text: 'All Phase deliverables complete',
+    });
+    expect(parsed.plan_level_dod[1]).toEqual({
+      checked: true,
+      text: 'Architecture approved',
+    });
+
+    expect(parsed.phases).toHaveLength(2);
+    expect(parsed.phases[0].phase_name).toBe('Foundation');
+    expect(parsed.phases[0].items).toHaveLength(3);
+    expect(parsed.phases[0].items[0]).toEqual({
+      checked: false,
+      text: 'Schema migrations created',
+      ref: 'R-01',
+    });
+
+    expect(parsed.phases[1].phase_name).toBe('Core Logic');
+    expect(parsed.phases[1].items).toHaveLength(3);
+
+    expect(parsed.devspec_path).toBe('docs/specs/payment-system.md');
+    expect(parsed.references).toHaveLength(2);
+  });
+
+  test('parses canonical Plan body (golden path) — GitLab', async () => {
+    execRegistry['git remote get-url origin'] = 'git@gitlab.com:wave-eng/mcp-server-sdlc.git';
+    execRegistry['glab api projects/wave-eng%2Fmcp-server-sdlc/issues/456'] = JSON.stringify({
+      iid: 456,
+      title: 'Plan: Payment System',
+      state: 'opened',
+      web_url: 'https://gitlab.com/wave-eng/mcp-server-sdlc/-/issues/456',
+      description: CANONICAL_PLAN_BODY,
+      labels: [],
+    });
+
+    const result = await handler.execute({ plan_id: 456 });
+    const parsed = parseResult(result);
+
+    if (!parsed.ok) {
+      console.log('GitLab test failed:', parsed);
+    }
+    expect(parsed.ok).toBe(true);
+    expect(parsed.plan_id).toBe(456);
+    expect(parsed.plan_title).toBe('Plan: Payment System');
+    expect(parsed.plan_level_dod).toHaveLength(3);
+    expect(parsed.phases).toHaveLength(2);
+    expect(parsed.devspec_path).toBe('docs/specs/payment-system.md');
+  });
+
+  test('extracts Plan-level DoD checkboxes with checked state', async () => {
+    const bodyWithChecks = `
+## Plan-level Definition of Done
+
+- [x] Task 1 done
+- [ ] Task 2 pending
+- [X] Task 3 done uppercase
+
+## Phases
+
+### Phase 1 — Test
+
+**DoD:**
+
+- [ ] Item
+
+## References
+
+None
+`;
+
+    execRegistry['git remote get-url origin'] ='origin\tgit@github.com:test/repo.git (fetch)';
+    execRegistry['gh issue view 100'] = JSON.stringify({
+      number: 100,
+      title: 'Plan',
+      state: 'OPEN',
+      body: bodyWithChecks,
+      labels: [],
+    });
+
+    const result = await handler.execute({ plan_id: 100 });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.plan_level_dod).toHaveLength(3);
+    expect(parsed.plan_level_dod[0].checked).toBe(true);
+    expect(parsed.plan_level_dod[1].checked).toBe(false);
+    expect(parsed.plan_level_dod[2].checked).toBe(true);
+  });
+
+  test('extracts per-Phase DoD with [R-XX] ref suffix', async () => {
+    const bodyWithRefs = `
+## Plan-level Definition of Done
+
+- [ ] Done
+
+## Phases
+
+### Phase 1 — Test
+
+**DoD:**
+
+- [ ] Task A [R-01]
+- [ ] Task B [R-10]
+- [ ] Task C without ref
+
+## References
+
+None
+`;
+
+    execRegistry['git remote get-url origin'] ='origin\tgit@github.com:test/repo.git (fetch)';
+    execRegistry['gh issue view 100'] = JSON.stringify({
+      number: 100,
+      title: 'Plan',
+      state: 'OPEN',
+      body: bodyWithRefs,
+      labels: [],
+    });
+
+    const result = await handler.execute({ plan_id: 100 });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.phases[0].items).toHaveLength(3);
+    expect(parsed.phases[0].items[0].ref).toBe('R-01');
+    expect(parsed.phases[0].items[1].ref).toBe('R-10');
+    expect(parsed.phases[0].items[2].ref).toBeUndefined();
+  });
+
+  test('extracts Dev Spec path from References', async () => {
+    const bodyWithDevSpec = `
+## Plan-level Definition of Done
+
+- [ ] Done
+
+## Phases
+
+### Phase 1 — Test
+
+**DoD:**
+
+- [ ] Task
+
+## References
+
+Dev Spec: \`path/to/devspec.md\`
+Other: \`other.md\`
+`;
+
+    execRegistry['git remote get-url origin'] ='origin\tgit@github.com:test/repo.git (fetch)';
+    execRegistry['gh issue view 100'] = JSON.stringify({
+      number: 100,
+      title: 'Plan',
+      state: 'OPEN',
+      body: bodyWithDevSpec,
+      labels: [],
+    });
+
+    const result = await handler.execute({ plan_id: 100 });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.devspec_path).toBe('path/to/devspec.md');
+    expect(parsed.references).toHaveLength(2);
+  });
+
+  test('body missing required headings → plan_body_invalid', async () => {
+    execRegistry['git remote get-url origin'] ='origin\tgit@github.com:test/repo.git (fetch)';
+    execRegistry['gh issue view 999'] = JSON.stringify({
+      number: 999,
+      title: 'Broken Plan',
+      state: 'OPEN',
+      body: INVALID_PLAN_BODY,
+      labels: [],
+    });
+
+    const result = await handler.execute({ plan_id: 999 });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.code).toBe('plan_body_invalid');
+    expect(parsed.missing_headings).toBeDefined();
+    expect(parsed.missing_headings.length).toBeGreaterThan(0);
+  });
+
+  test('nonexistent plan_id → plan_not_found (via adapter)', async () => {
+    execRegistry['git remote get-url origin'] ='origin\tgit@github.com:test/repo.git (fetch)';
+    // Simulate gh issue view returning error (nonzero exit caught by adapter)
+    execRegistry['gh issue view 404'] = ''; // Empty response will fail parse
+
+    const result = await handler.execute({ plan_id: 404 });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(false);
+    // The exact error code depends on adapter behavior; could be parse error or CLI error
+    expect(parsed.error).toBeDefined();
+  });
+
+  test('handler dispatches to GitHub on github cwd', async () => {
+    execRegistry['git remote get-url origin'] ='origin\tgit@github.com:test/repo.git (fetch)';
+    execRegistry['gh issue view 123'] = JSON.stringify({
+      number: 123,
+      title: 'Plan',
+      state: 'OPEN',
+      body: CANONICAL_PLAN_BODY,
+      labels: [],
+    });
+
+    await handler.execute({ plan_id: 123 });
+
+    // Verify gh was called (not glab)
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string);
+    expect(calls.some(c => c.includes('gh issue view'))).toBe(true);
+    expect(calls.some(c => c.includes('glab api'))).toBe(false);
+  });
+
+  test('handler dispatches to GitLab on gitlab cwd, no -F flag', async () => {
+    execRegistry['git remote get-url origin'] ='origin\tgit@gitlab.com:wave-eng/mcp-server-sdlc.git (fetch)';
+    execRegistry['glab api projects/wave-eng%2Fmcp-server-sdlc/issues/456'] = JSON.stringify({
+      iid: 456,
+      title: 'Plan',
+      state: 'opened',
+      web_url: 'https://gitlab.com/wave-eng/mcp-server-sdlc/-/issues/456',
+      description: CANONICAL_PLAN_BODY,
+      labels: [],
+    });
+
+    await handler.execute({ plan_id: 456 });
+
+    // Verify glab was called (not gh), and no -F flag
+    const calls = mockExecSync.mock.calls.map(c => c[0] as string);
+    expect(calls.some(c => c.includes('glab api'))).toBe(true);
+    expect(calls.some(c => c.includes('gh issue view'))).toBe(false);
+    expect(calls.some(c => c.includes(' -F '))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `plan_load_dod` MCP tool to load Definition of Done from Plan tracking issues.

## Changes

- Created `lib/plan-body-parse.ts` with `parsePlanBody()` function
- Created `handlers/plan_load_dod.ts` MCP handler
- Added 22 tests (12 parser + 10 handler integration)
- Modified `CHANGELOG.md`

## Tests

- ✅ 2097 tests pass, 0 fail
- ✅ All new tests pass (22/22)
- ✅ Handler auto-registered in `handlers/_registry.ts`

Closes #388