### PR TITLE
fix(security): shell-escape repo arg in buildGithubMergeCommand (sibling to #403)

### DIFF
--- a/lib/adapters/pr-merge-github.test.ts
+++ b/lib/adapters/pr-merge-github.test.ts
@@ -305,12 +305,51 @@ describe('prMergeGithub — subprocess boundary', () => {
     });
     expectOk(result);
     const mergeCall = findCall('gh pr merge 42');
-    expect(mergeCall).toContain('--repo Wave-Engineering/mcp-server-sdlc');
+    expect(unquote(mergeCall!)).toContain('--repo Wave-Engineering/mcp-server-sdlc');
     const viewCall = findCall('gh pr view 42');
-    expect(viewCall).toContain('--repo Wave-Engineering/mcp-server-sdlc');
+    expect(unquote(viewCall!)).toContain('--repo Wave-Engineering/mcp-server-sdlc');
     const graphqlCall = findCall('gh api graphql');
     expect(graphqlCall).toContain('-F owner=Wave-Engineering');
     expect(graphqlCall).toContain('-F name=mcp-server-sdlc');
+  });
+
+  test('pr-merge-github — buildGithubMergeCommand shell-escapes repo (security)', async () => {
+    // Defence-in-depth: even though the schema layer rejects shell metachars
+    // in `repo`, the adapter must shell-escape before joining argv into a
+    // shell command. The test passes a value that bypasses schema validation
+    // (we call prMergeGithub directly, not the handler) and verifies the
+    // resulting command contains the dangerous chars only inside a single
+    // shell-quoted token.
+    on('git remote get-url origin', 'https://github.com/cwd-org/cwd-repo.git\n');
+    stubNoQueue();
+    on('gh pr merge 99', '');
+    on(
+      'gh pr view 99',
+      JSON.stringify({
+        state: 'MERGED',
+        url: 'https://github.com/sec/repo/pull/99',
+        mergeCommit: { oid: 'abc' },
+      }),
+    );
+
+    // Hostile repo value with shell-injection characters
+    const hostileRepo = `sec/repo'; echo PWNED; #`;
+    await prMergeGithub({ number: 99, repo: hostileRepo });
+
+    const mergeCall = execCalls.find((c) => c.includes('gh pr merge 99'));
+    expect(mergeCall).toBeDefined();
+    // shellEscape wraps each argv element in `'...'` and rewrites embedded
+    // single quotes as `'\''` (close + escape + reopen). The hostile value
+    // becomes `'sec/repo'\''; echo PWNED; #'` — three safe shell tokens
+    // joined by an escaped quote, treated as ONE argv element by the shell.
+    // Strip both `'\''` sequences and `'...'` regions; no shell-active chars
+    // should remain in the residual.
+    const stripped = mergeCall!
+      .replace(/'\\''/g, '') // remove escaped-quote sequences
+      .replace(/'[^']*'/g, ''); // remove single-quoted regions
+    expect(stripped).not.toContain(';');
+    expect(stripped).not.toContain('echo');
+    expect(stripped).not.toContain('PWNED');
   });
 
   // =========================================================================

--- a/lib/adapters/pr-merge-github.ts
+++ b/lib/adapters/pr-merge-github.ts
@@ -158,7 +158,7 @@ function buildGithubMergeCommand(
     }
   }
   if (repo !== undefined) {
-    parts.push('--repo', repo);
+    parts.push('--repo', shellEscape(repo));
   }
   return parts.join(' ');
 }

--- a/tests/pr_merge.test.ts
+++ b/tests/pr_merge.test.ts
@@ -632,9 +632,11 @@ describe('pr_merge handler — aggregate response (#225)', () => {
     expect(data.ok).toBe(true);
 
     const mergeCall = execCalls.find((c) => c.startsWith('gh pr merge 42')) ?? '';
-    expect(mergeCall).toContain('--repo Wave-Engineering/mcp-server-sdlc');
+    // shellEscape wraps the repo arg in single quotes; strip them for the
+    // contains check.
+    expect(mergeCall.replace(/'/g, '')).toContain('--repo Wave-Engineering/mcp-server-sdlc');
     const viewCall = execCalls.find((c) => c.startsWith('gh pr view 42')) ?? '';
-    expect(viewCall).toContain('--repo Wave-Engineering/mcp-server-sdlc');
+    expect(viewCall.replace(/'/g, '')).toContain('--repo Wave-Engineering/mcp-server-sdlc');
     // Queue detection should also use the explicit repo, not the cwd remote.
     const graphqlCall = execCalls.find((c) => c.includes('gh api graphql')) ?? '';
     expect(graphqlCall).toContain('-F owner=Wave-Engineering');


### PR DESCRIPTION
## Summary

Sibling fix to PR #403. The original code-reviewer finding flagged BOTH `repoFlag` in `enqueuePullRequestViaGraphQL` AND the `repo` arg in `buildGithubMergeCommand` as shell-injection surfaces. PR #403 fixed only the former (via `runArgv`); this PR closes the `buildGithubMergeCommand` path with `shellEscape()` — matching the existing pattern used for `squashMessage` and `tempFile` two lines above.

Surfaced by re-running the trust-score gate code-reviewer pass after PR #403 merged.

## Changes

- `lib/adapters/pr-merge-github.ts:161` — wrap `repo` in `shellEscape()` to match `squashMessage`/`tempFile` pattern
- `lib/adapters/pr-merge-github.test.ts` — adds regression test injecting `sec/repo'; echo PWNED; #`
- `tests/pr_merge.test.ts` — updates two assertions that expected unquoted form

## Tests

- ✅ 2239 pass / 0 fail / 3 skip (full suite)
- ✅ 17 pass in `pr-merge-github.test.ts`
- ✅ `./scripts/ci/validate.sh` green (76/76 tools)

## Defence-in-depth note

The schema layer (`repoOptionalSchema`) already rejects shell metacharacters at the handler boundary, so this is not exploitable in practice. But every other `parts.push()` in this function shell-escapes; the inconsistency was a regression risk for any future code that bypasses the schema (e.g. internal callers, refactors).

Closes #390 (gate hotfix sibling)