### PR TITLE
fix(integration-tests): use spawnSync to capture stdout+stderr (CI fix)

### DIFF
--- a/tests/integration/cli-flag-shapes.test.ts
+++ b/tests/integration/cli-flag-shapes.test.ts
@@ -10,15 +10,24 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { execSync } from 'child_process';
+import { execSync, spawnSync } from 'child_process';
 
 // --- Helper ----------------------------------------------------------------
-// `gh` and `glab` write `--help` output to stderr in some environments
-// (notably GitHub Actions runners); locally they write to stdout. We need
-// both. `2>&1` merges stderr into stdout so `execSync`'s captured output
-// contains the help text regardless of where the CLI sent it.
+// `gh` and `glab` may write `--help` output to either stdout or stderr
+// depending on environment, version, and whether a TTY is attached. On
+// GitHub Actions runners, gh writes --help to a stream that bash's `2>&1`
+// redirection through execSync doesn't capture reliably (likely related
+// to gh's pager/TTY detection).
+//
+// Use spawnSync — it separates stdout and stderr buffers and we concatenate
+// them — to get the help text regardless of where the CLI sent it.
 function captureHelp(cmd: string): string {
-  return execSync(`${cmd} 2>&1`, { encoding: 'utf8' });
+  const tokens = cmd.split(/\s+/);
+  const result = spawnSync(tokens[0]!, tokens.slice(1), {
+    encoding: 'utf8',
+    env: { ...process.env, GH_PAGER: '', PAGER: 'cat', GLAB_PAGER: '' },
+  });
+  return (result.stdout ?? '') + (result.stderr ?? '');
 }
 
 // --- CLI Availability Guards -----------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to PR #410. The `execSync(cmd 2>&1)` approach didn't work in GitHub Actions runners — `gh --help` still produced empty output even with stderr merged. Switching to `spawnSync` which gives separate stdout/stderr buffers we can concatenate.

Also unsets pager environment variables (`GH_PAGER`, `PAGER`, `GLAB_PAGER`) to defeat any pager-detection short-circuiting — some `gh` versions check terminal capabilities and suppress `--help` output if pagination is unavailable.

## Changes

- `tests/integration/cli-flag-shapes.test.ts`:
  - `captureHelp()` now uses `spawnSync` instead of `execSync`
  - Concatenates `result.stdout + result.stderr`
  - Unsets pager env vars

## Tests

- ✅ 18/18 pass locally
- Goal: unblock the kahuna→main merge (PR #402) which is failing on these tests in CI

## Why this matters

PR #410's first attempt didn't work because shell-level `2>&1` doesn't capture output that `gh` writes via TTY-aware paths. `spawnSync` bypasses the shell entirely and captures the actual file descriptors.