### PR TITLE
fix(integration-tests): use node: prefix to bypass bun module mocks

### DIFF
--- a/tests/integration/cli-flag-shapes.test.ts
+++ b/tests/integration/cli-flag-shapes.test.ts
@@ -10,7 +10,11 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { execSync, spawnSync } from 'child_process';
+// Use the `node:` prefix to bypass bun module mocks. Other test files
+// (e.g. pr-merge-github.test.ts) mock 'child_process' to override execSync,
+// and that mock leaks across the shared test-runner module space — without
+// the prefix, `spawnSync` resolves to the partial mock and is undefined.
+import { execSync, spawnSync } from 'node:child_process';
 
 // --- Helper ----------------------------------------------------------------
 // `gh` and `glab` may write `--help` output to either stdout or stderr


### PR DESCRIPTION
## Summary

Third hotfix attempt for the kahuna→main blocking integration tests. CI failed with:

```
SyntaxError: Export named 'spawnSync' not found in module 'node:child_process'.
```

## Root Cause

Other test files (notably `pr-merge-github.test.ts`) call `mock.module('child_process', () => ({ execSync: mockExecSync }))`. This mock leaks across bun's shared test-runner module space. The mock only exports `execSync`, so when `cli-flag-shapes.test.ts` imports `spawnSync` from `'child_process'` (no prefix), it hits the partial mock and the import fails.

This explains why local tests passed (test ordering happened to load the integration test before the mock was registered) but CI failed (different test order).

## Fix

Use the `node:child_process` prefix which forces explicit Node built-in resolution and bypasses bun's module mock layer.

## Tests

- ✅ 18/18 pass locally
- Goal: CI green, unblock kahuna→main (PR #402)