### PR TITLE
Plan #607 (Beta) — Wave-pattern feature MCP additions (sdlc-server side)

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,35 @@
+# MCP Tools
+
+Tool reference for the `sdlc-server` MCP. The authoritative list is the registered handlers in `handlers/_registry.ts` (auto-generated from `handlers/*.ts` on build/test/validate). This document records prose summaries; for complete schemas use `ListTools` against the running server.
+
+Tools below are listed in alphabetic order. To add a tool: drop a file in `handlers/<name>.ts`; the next CI run regenerates the registry and exposes it.
+
+## wave_wait_for_signal
+
+**Purpose.** Sanctioned idle-wait for wave-pattern Orchestrators (and Primes) that have dispatched work and need to block until filesystem-bus artifacts appear. Replaces ad-hoc polling loops, `Bash(sleep)` invocations, and the agent-anxiety failure mode where idle loops are exited prematurely with non-canonical lines like `"Sleep is still running. Let me wait for the notification."` See `pattern_sanctioned_fidget_tool.md` (cc-workflow memory) for the design rationale.
+
+**Inputs.**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `signal_path` | string | (required) | Absolute path or glob pattern (Bun.Glob syntax). Examples: `/wavebus/wave-4a/flights/*.done`, `wavebus/<wave_id>/flight-1.done`. |
+| `timeout_sec` | number | `1800` | Maximum wall-clock wait, in seconds. |
+| `min_count` | number | `1` | Minimum match count required to satisfy the signal. |
+
+**Behavior.** Polls every 5 seconds. Returns immediately if `min_count` matches already exist (no opening sleep). Glob patterns and literal paths are both accepted; relative patterns scan from `CLAUDE_PROJECT_DIR` (or `cwd()`). Matches are sorted alphabetically.
+
+**Returns (success).**
+
+```json
+{ "ok": true, "matched": ["...absolute paths..."], "elapsed_sec": 7 }
+```
+
+**Returns (timeout).**
+
+```json
+{ "ok": true, "timed_out": true, "elapsed_sec": 1800, "partial_matches": ["...subset paths..."] }
+```
+
+`partial_matches` is the snapshot from the final poll before timeout — empty array if no matches ever appeared.
+
+**See also.** `docs/wave-pattern-orchestration.md` for the canonical Orchestrator-wait-on-Flights example.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -4,6 +4,73 @@ Tool reference for the `sdlc-server` MCP. The authoritative list is the register
 
 Tools below are listed in alphabetic order. To add a tool: drop a file in `handlers/<name>.ts`; the next CI run regenerates the registry and exposes it.
 
+## pr_wait_ci
+
+**Purpose.** Block until a PR/MR's status checks settle. Server-side polling with configurable interval (default `30s`, hard floor `5s`) and timeout (default `1800s`). Used by `/scpmmr`, the wave-pattern Flight finalizer, and any caller that needs a deterministic "wait for CI to finish" with a typed terminal.
+
+**Inputs.**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `number` | number | (required) | PR (GitHub) or MR (GitLab) iid. |
+| `poll_interval_sec` | number | `30` | Seconds between snapshots. Hard floor `5`. |
+| `timeout_sec` | number | `1800` | Maximum wall-clock wait. |
+| `repo` | string | (cwd remote) | `owner/repo` slug for cross-repo dispatch. GitLab nested groups (`group/subgroup/repo`) are accepted. |
+
+**Returns — polling-loop path** (one or more checks configured on the head ref).
+
+```json
+{
+  "ok": true,
+  "number": 42,
+  "final_state": "passed" | "failed" | "timed_out",
+  "checks": { "total": 3, "passed": 3, "failed": 0, "pending": 0, "summary": "3/3 passed" },
+  "waited_sec": 8,
+  "url": "https://github.com/org/repo/pull/42"
+}
+```
+
+`final_state: 'passed'` requires `total > 0 && pending === 0 && failed === 0`. All-skipped checks (every workflow's `if:` guard didn't match) count as `passed` — see #221.
+
+**Returns — empty-rollup short-circuit** (#416). When the head ref has no required status checks, the handler returns immediately at t=0 instead of spinning to timeout. The semantics is "wait until CI is settled" — if there are no checks to settle, that condition is satisfied at t=0.
+
+```json
+{
+  "ok": true,
+  "number": 42,
+  "status": "no_checks_required",
+  "elapsed_sec": 0,
+  "mergeable": true,
+  "url": "https://github.com/org/repo/pull/42"
+}
+```
+
+When the rollup is empty AND the PR/MR is obstructed (draft, closed, conflicts, …), `mergeable` is `false` and a `blocker` field names the obstruction:
+
+```json
+{
+  "ok": true,
+  "number": 42,
+  "status": "no_checks_required",
+  "elapsed_sec": 0,
+  "mergeable": false,
+  "blocker": "draft" | "closed" | "merged" | "conflicts" | "not_mergeable" | "locked",
+  "url": "https://github.com/org/repo/pull/42"
+}
+```
+
+**Discriminator.** Callers should branch on the response shape via either field:
+
+- `status === 'no_checks_required'` → empty-rollup short-circuit (`final_state` absent).
+- `final_state` present → polling-loop result (`status` absent).
+
+**Platform notes.**
+
+- GitHub: probe is `gh pr view <num> --json statusCheckRollup,url,state,isDraft,mergeable,mergeStateStatus`. Polling-loop snapshot uses the slimmer `--json statusCheckRollup,url` (per-iteration cost stays minimal). `gh pr checks --json` is NOT used — it broke on Ubuntu 24.04's gh 2.45 (#220).
+- GitLab: probe is `glab api projects/<encoded-slug>/merge_requests/<iid>`. Empty-rollup means `head_pipeline === null && pipeline === null`. Polling-loop status mapping: `success → passed`, `failed/canceled → failed`, `running/pending/created/preparing/waiting_for_resource/scheduled/manual → pending`, anything else → uncounted (loop times out).
+
+**See also.** `pattern_decorative_ac_and_stub_orphan.md` for the failure mode this short-circuit closes (autopilot callers losing 30-minute timeout windows on docs-only PRs with no CI).
+
 ## wave_wait_for_signal
 
 **Purpose.** Sanctioned idle-wait for wave-pattern Orchestrators (and Primes) that have dispatched work and need to block until filesystem-bus artifacts appear. Replaces ad-hoc polling loops, `Bash(sleep)` invocations, and the agent-anxiety failure mode where idle loops are exited prematurely with non-canonical lines like `"Sleep is still running. Let me wait for the notification."` See `pattern_sanctioned_fidget_tool.md` (cc-workflow memory) for the design rationale.

--- a/docs/wave-pattern-orchestration.md
+++ b/docs/wave-pattern-orchestration.md
@@ -1,0 +1,71 @@
+# Wave-Pattern Orchestration
+
+How sdlc-server tools support the wave-pattern execution model (Orchestrator + Prime + Flight, filesystem-bus signaling).
+
+## Idle-Waiting on Flight Completion: `wave_wait_for_signal`
+
+When the Orchestrator has dispatched N parallel Flights and must wait for their completion artifacts to appear, it has nothing legitimate to call. Without a sanctioned idle-wait tool, anxious agents invent polling loops, hallucinate completions, or exit prematurely with non-canonical lines like `"Sleep is still running. Let me wait for the notification."` The `wave_wait_for_signal` tool exists so the model has something legitimate to call while it waits.
+
+### Canonical Example: Orchestrator Waiting on Flights
+
+The Orchestrator dispatches three Flight sub-agents, each of which writes `flight-<id>.done` to the wave's filesystem bus when finished:
+
+```
+wavebus/
+└── wave-4a/
+    └── flights/
+        ├── flight-1.done   ← written by Flight 1 on completion
+        ├── flight-2.done   ← written by Flight 2 on completion
+        └── flight-3.done   ← written by Flight 3 on completion
+```
+
+After dispatch, the Orchestrator calls:
+
+```jsonc
+{
+  "tool": "wave_wait_for_signal",
+  "args": {
+    "signal_path": "wavebus/wave-4a/flights/*.done",
+    "timeout_sec": 1800,
+    "min_count": 3
+  }
+}
+```
+
+The tool polls every 5 seconds. As soon as all three artifacts exist, it returns:
+
+```json
+{
+  "ok": true,
+  "matched": [
+    "/abs/path/wavebus/wave-4a/flights/flight-1.done",
+    "/abs/path/wavebus/wave-4a/flights/flight-2.done",
+    "/abs/path/wavebus/wave-4a/flights/flight-3.done"
+  ],
+  "elapsed_sec": 142
+}
+```
+
+If the timeout expires before all three Flights complete, the response carries `timed_out: true` plus `partial_matches` containing whatever subset did finish. The Orchestrator can then make an informed decision (extend, fail the wave, etc.) instead of guessing.
+
+### Why This Tool Replaces Inline Polling
+
+Without `wave_wait_for_signal`, an Orchestrator wanting the same behavior must either:
+
+1. Call `Bash(sleep ...)` repeatedly with a check between each call — slow, clutters transcripts, and the model frequently exits the loop body early.
+2. Use `Bash(while ...)` — large `run:` blocks that violate the project's "no procedural logic in CI/CD YAML" rule when ported and that the model perceives as "I'm not really doing anything" (the anxiety failure mode).
+3. Skip waiting entirely and assume Flights are done — produces incorrect verdicts.
+
+`wave_wait_for_signal` collapses all three into one tool call whose entire purpose is to sit still on the agent's behalf. The tool's existence is the mitigation: the model sees a legitimate thing to call and calls it instead of inventing a polling loop or exiting prematurely.
+
+### Configuration Tips
+
+- **`signal_path`.** Use glob patterns (`*.done`, `flight-?.done`) when waiting on N artifacts; use literal paths when waiting on a specific marker file. Relative patterns scan from `CLAUDE_PROJECT_DIR` (or `process.cwd()`). Absolute patterns scan from the filesystem root.
+- **`timeout_sec`.** Default 1800 (30 minutes). Should comfortably exceed the longest expected Flight runtime; the Orchestrator can recover from `timed_out` but not from "I gave up too soon."
+- **`min_count`.** Set to the number of Flights dispatched. The tool will not return early on a partial set — it sits until either the threshold is met or the timeout fires.
+
+### Related Tools
+
+- `wave_flight_done` — written by Flights to mark completion.
+- `wave_flight_plan` — written by Prime(pre-flight) to record the dispatch list the Orchestrator is waiting on.
+- `wave_complete` — terminal state transition the Orchestrator drives after `wave_wait_for_signal` returns successfully.

--- a/handlers/wave_finalize.ts
+++ b/handlers/wave_finalize.ts
@@ -8,7 +8,7 @@ import type { HandlerDef } from '../types.js';
 import { getAdapter } from '../lib/adapters/index.js';
 import { branchExistsOnRemote } from '../lib/shared/git-remote.js';
 import {
-  assembleBody, defaultArtifactsDir, epicSlugFromBranch, hashBody,
+  assembleBody, assembleBodyFromState, defaultArtifactsDir, epicSlugFromBranch, hashBody,
   projectDir, resolveArtifactsDir,
 } from '../lib/wave-finalize.js';
 
@@ -29,8 +29,10 @@ const waveFinalizeHandler: HandlerDef = {
   name: 'wave_finalize',
   description:
     'Open (or return the existing) kahuna→target_branch MR for a KAHUNA epic. ' +
-    'Idempotent on (kahuna_branch, target_branch). The MR body is assembled from wavebus artifacts under `body_artifacts_dir` (default: /tmp/wavemachine/<slug>/). ' +
-    'Returns kahuna_branch_not_found if the branch is absent on the remote; no_artifacts if the artifact tree contains no flight results. ' +
+    'Idempotent on (kahuna_branch, target_branch). The MR body is assembled from wavebus artifacts under `body_artifacts_dir` (default: /tmp/wavemachine/<slug>/); ' +
+    'when those are absent (e.g. wave_complete cleanup wiped them on the last wave), the handler falls back to durable wave-status state ' +
+    '(`<project>/.claude/status/{phases-waves.json,state.json}`) to re-derive the body from plan + recorded mr_urls. ' +
+    'Returns kahuna_branch_not_found if the branch is absent on the remote; no_artifacts if neither the bus nor durable state yields any issues. ' +
     'body_sha is a SHA-256 digest of the assembled body for drift detection.',
   inputSchema,
   async execute(rawArgs: unknown) {
@@ -41,6 +43,14 @@ const waveFinalizeHandler: HandlerDef = {
       const cwd = projectDir(args.root);
       const resolved = resolveArtifactsDir(args.body_artifacts_dir, defaultArtifactsDir(args.kahuna_branch), cwd);
       if (!resolved.ok) return envelope({ ok: false, error: resolved.error });
+      // Try the bus first; fall back to durable wave-status state when the
+      // bus has been cleaned up (#415). assembleBodyFromState consults
+      // `<project>/.claude/status/{phases-waves.json,state.json}`.
+      const composeBody = async () => {
+        const fromBus = await assembleBody(resolved.path, args.plan_id, args.kahuna_branch, args.target_branch);
+        if (fromBus.issueCount > 0) return fromBus;
+        return await assembleBodyFromState(cwd, args.plan_id, args.kahuna_branch, args.target_branch);
+      };
       const adapter = getAdapter();
       // Idempotency first (per devspec §5.1.1 step 1). Covers the post-merge
       // edge case where the kahuna branch was deleted after the MR was opened.
@@ -48,12 +58,13 @@ const waveFinalizeHandler: HandlerDef = {
       if ('platform_unsupported' in existing) return envelope({ ok: false, error: `findExistingPr unsupported: ${existing.hint}` });
       if (!existing.ok) return envelope({ ok: false, error: existing.error });
       if (existing.data !== null) {
-        // body_sha is empty when artifacts are absent — legitimate post-cleanup state.
-        const { body, issueCount } = await assembleBody(resolved.path, args.plan_id, args.kahuna_branch, args.target_branch);
+        // body_sha is empty when neither bus nor durable state has issues —
+        // legitimate post-cleanup state on a brand-new PR.
+        const { body, issueCount } = await composeBody();
         return envelope({ ok: true, number: existing.data.number, url: existing.data.url, state: 'open', created: false, body_sha: issueCount > 0 ? hashBody(body) : '' });
       }
       if (!branchExistsOnRemote(cwd, args.kahuna_branch)) return envelope({ ok: false, error: 'kahuna_branch_not_found' });
-      const { body, issueCount } = await assembleBody(resolved.path, args.plan_id, args.kahuna_branch, args.target_branch);
+      const { body, issueCount } = await composeBody();
       if (issueCount === 0) return envelope({ ok: false, error: 'no_artifacts' });
       const title = `plan(#${args.plan_id}): ${epicSlugFromBranch(args.kahuna_branch)} — kahuna to ${args.target_branch}`;
       const created = await adapter.prCreate({ title, body, base: args.target_branch, head: args.kahuna_branch });

--- a/handlers/wave_wait_for_signal.ts
+++ b/handlers/wave_wait_for_signal.ts
@@ -1,0 +1,160 @@
+// Sanctioned anxiety outlet for idle agents (issue #414).
+//
+// When a wave-pattern Orchestrator (or Prime) has dispatched work and is
+// supposed to wait for filesystem-bus artifacts to appear, it has nothing
+// to call. Idle loops without a sanctioned tool drive anxious agents to
+// invent polling, hallucinate completions, or exit prematurely. This tool
+// exists so the model has something legitimate to call while it waits.
+//
+// Behavior: poll `signal_path` (literal path or glob) every 5s until at
+// least `min_count` matches exist, or `timeout_sec` elapses. On match,
+// return `{ matched: [...paths], elapsed_sec: N }`. On timeout, return
+// `{ timed_out: true, elapsed_sec: timeout_sec, partial_matches: [...] }`.
+
+import { Glob } from 'bun';
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+
+export const POLL_INTERVAL_SEC = 5;
+
+const inputSchema = z
+  .object({
+    signal_path: z.string().min(1, 'signal_path must be a non-empty string'),
+    timeout_sec: z.number().int().positive().optional().default(1800),
+    min_count: z.number().int().positive().optional().default(1),
+  })
+  .strict();
+
+type Input = z.infer<typeof inputSchema>;
+
+function envelope(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] };
+}
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+/**
+ * Resolve `signal_path` to a list of currently-matching filesystem paths.
+ *
+ * Two modes:
+ *   - If the path contains a glob metacharacter (`*`, `?`, `[`), use Bun.Glob
+ *     against the project root and return matching files.
+ *   - Otherwise treat as a literal path; return [path] if it exists, else [].
+ *
+ * Glob patterns are rooted at projectDir() so that callers can pass relative
+ * patterns like `wavebus/<wave_id>/flights/*.done`.
+ */
+export function matchSignal(signalPath: string, cwd: string = projectDir()): string[] {
+  // We use Bun.Glob exclusively (not node:fs) because other tests in this
+  // codebase call `mock.module('fs', ...)` and the mock leaks across the
+  // shared Bun test-runner module space, leaving `existsSync` etc.
+  // undefined for this handler. Bun.Glob handles both literal paths
+  // (no metacharacters → matches iff the file exists) and patterns
+  // uniformly.
+  const isAbsolute = signalPath.startsWith('/');
+  const scanCwd = isAbsolute ? '/' : cwd;
+  const pattern = isAbsolute ? signalPath.slice(1) : signalPath;
+  const results: string[] = [];
+  for (const match of new Glob(pattern).scanSync({
+    cwd: scanCwd,
+    absolute: true,
+    onlyFiles: false,
+  })) {
+    results.push(match);
+  }
+  return results.sort();
+}
+
+export interface WaitDeps {
+  matchFn: (signalPath: string) => string[];
+  sleepFn: (ms: number) => Promise<void>;
+  nowFn: () => number;
+}
+
+export interface WaitResult {
+  ok: true;
+  matched?: string[];
+  elapsed_sec?: number;
+  timed_out?: true;
+  partial_matches?: string[];
+}
+
+/**
+ * Test seam — drives the polling loop with injected dependencies so unit
+ * tests can avoid real wall-clock waits and real filesystem state.
+ */
+export async function __runWithDeps(rawArgs: unknown, deps: Partial<WaitDeps>): Promise<WaitResult> {
+  const args = inputSchema.parse(rawArgs) as Input;
+  const fullDeps: WaitDeps = {
+    matchFn: deps.matchFn ?? ((p) => matchSignal(p)),
+    sleepFn: deps.sleepFn ?? ((ms) => new Promise((r) => setTimeout(r, ms))),
+    nowFn: deps.nowFn ?? (() => Date.now()),
+  };
+  return runWaitLoop(args, fullDeps);
+}
+
+async function runWaitLoop(args: Input, deps: WaitDeps): Promise<WaitResult> {
+  const startMs = deps.nowFn();
+  const timeoutMs = args.timeout_sec * 1000;
+  const intervalMs = POLL_INTERVAL_SEC * 1000;
+
+  // Check immediately so callers whose artifacts already exist return
+  // without an opening 5s sleep.
+  let matches = deps.matchFn(args.signal_path);
+  if (matches.length >= args.min_count) {
+    return {
+      ok: true,
+      matched: matches,
+      elapsed_sec: Math.round((deps.nowFn() - startMs) / 1000),
+    };
+  }
+
+  while (deps.nowFn() - startMs < timeoutMs) {
+    await deps.sleepFn(intervalMs);
+    matches = deps.matchFn(args.signal_path);
+    if (matches.length >= args.min_count) {
+      return {
+        ok: true,
+        matched: matches,
+        elapsed_sec: Math.round((deps.nowFn() - startMs) / 1000),
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    timed_out: true,
+    elapsed_sec: args.timeout_sec,
+    partial_matches: matches,
+  };
+}
+
+const waveWaitForSignalHandler: HandlerDef = {
+  name: 'wave_wait_for_signal',
+  description:
+    'Block until min_count filesystem artifacts matching signal_path exist, or timeout_sec elapses. Sanctioned idle-wait for wave-pattern Orchestrators waiting on Flight completion artifacts.',
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args: Input;
+    try {
+      args = inputSchema.parse(rawArgs) as Input;
+    } catch (err) {
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
+    }
+
+    try {
+      const result = await runWaitLoop(args, {
+        matchFn: (p) => matchSignal(p),
+        sleepFn: (ms) => new Promise((r) => setTimeout(r, ms)),
+        nowFn: () => Date.now(),
+      });
+      return envelope(result);
+    } catch (err) {
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
+    }
+  },
+};
+
+export default waveWaitForSignalHandler;

--- a/lib/adapters/pr-wait-ci-github.test.ts
+++ b/lib/adapters/pr-wait-ci-github.test.ts
@@ -35,6 +35,8 @@ const {
   prWaitCiGithub,
   classifyRollupItem,
   snapshotGithub,
+  emptyRollupBlocker,
+  probeGithub,
 } = await import('./pr-wait-ci-github.ts');
 
 function on(match: string, respond: string | (() => string)): void {
@@ -243,11 +245,200 @@ describe('prWaitCiGithub — #221 all-skipped regression', () => {
     if (!('ok' in result) || !result.ok) {
       throw new Error(`expected ok result, got ${JSON.stringify(result)}`);
     }
+    if (!('final_state' in result.data)) {
+      throw new Error(`expected polled-response shape, got ${JSON.stringify(result.data)}`);
+    }
     expect(result.data.final_state).toBe('passed');
     expect(result.data.checks.passed).toBe(0);
     expect(result.data.checks.total).toBe(3); // total counts SKIPPED
     expect(result.data.checks.failed).toBe(0);
     expect(result.data.checks.pending).toBe(0);
+  });
+});
+
+// --- #416: empty-rollup short-circuit at the adapter boundary -----------
+describe('prWaitCiGithub — empty-rollup short-circuit (#416)', () => {
+  test('empty rollup + mergeable → no_checks_required immediately', async () => {
+    on(
+      'gh pr view',
+      JSON.stringify({
+        url: 'https://github.com/org/repo/pull/42',
+        statusCheckRollup: [],
+        state: 'OPEN',
+        isDraft: false,
+        mergeable: 'MERGEABLE',
+        mergeStateStatus: 'CLEAN',
+      }),
+    );
+
+    const result = await prWaitCiGithub({
+      number: 42,
+      poll_interval_sec: 5,
+      timeout_sec: 1800, // huge — proves we don't enter the poll loop
+    });
+    if (!('ok' in result) || !result.ok) {
+      throw new Error(`expected ok result, got ${JSON.stringify(result)}`);
+    }
+    const data = result.data as { status?: string; mergeable?: boolean; blocker?: string; elapsed_sec?: number; url?: string };
+    expect(data.status).toBe('no_checks_required');
+    expect(data.mergeable).toBe(true);
+    expect(data.blocker).toBeUndefined();
+    expect(data.elapsed_sec).toBeLessThan(5);
+    expect(data.url).toBe('https://github.com/org/repo/pull/42');
+    // Probe argv must include the new fields the short-circuit needs.
+    const viewCall = execCalls.find((c) => c.startsWith('gh pr view')) ?? '';
+    expect(viewCall).toContain('mergeable');
+    expect(viewCall).toContain('isDraft');
+    expect(viewCall).toContain('state');
+    // #220 regression — never use the broken `gh pr checks --json` form.
+    expect(execCalls.some((c) => c.startsWith('gh pr checks'))).toBe(false);
+  });
+
+  test('empty rollup + CONFLICTING → no_checks_required + conflicts blocker', async () => {
+    on(
+      'gh pr view',
+      JSON.stringify({
+        url: 'https://github.com/org/repo/pull/43',
+        statusCheckRollup: [],
+        state: 'OPEN',
+        isDraft: false,
+        mergeable: 'CONFLICTING',
+        mergeStateStatus: 'DIRTY',
+      }),
+    );
+    const result = await prWaitCiGithub({
+      number: 43,
+      poll_interval_sec: 5,
+      timeout_sec: 1800,
+    });
+    if (!('ok' in result) || !result.ok) throw new Error('expected ok');
+    const data = result.data as { status?: string; mergeable?: boolean; blocker?: string };
+    expect(data.status).toBe('no_checks_required');
+    expect(data.mergeable).toBe(false);
+    expect(data.blocker).toBe('conflicts');
+  });
+
+  test('empty rollup + draft → no_checks_required + draft blocker', async () => {
+    on(
+      'gh pr view',
+      JSON.stringify({
+        url: 'https://github.com/org/repo/pull/44',
+        statusCheckRollup: [],
+        state: 'OPEN',
+        isDraft: true,
+        mergeable: 'MERGEABLE',
+        mergeStateStatus: 'CLEAN',
+      }),
+    );
+    const result = await prWaitCiGithub({ number: 44, poll_interval_sec: 5, timeout_sec: 60 });
+    if (!('ok' in result) || !result.ok) throw new Error('expected ok');
+    const data = result.data as { status?: string; mergeable?: boolean; blocker?: string };
+    expect(data.status).toBe('no_checks_required');
+    expect(data.mergeable).toBe(false);
+    expect(data.blocker).toBe('draft');
+  });
+
+  test('empty rollup + closed PR → no_checks_required + closed blocker', async () => {
+    on(
+      'gh pr view',
+      JSON.stringify({
+        url: 'https://github.com/org/repo/pull/45',
+        statusCheckRollup: [],
+        state: 'CLOSED',
+        isDraft: false,
+        mergeable: 'UNKNOWN',
+        mergeStateStatus: 'UNKNOWN',
+      }),
+    );
+    const result = await prWaitCiGithub({ number: 45, poll_interval_sec: 5, timeout_sec: 60 });
+    if (!('ok' in result) || !result.ok) throw new Error('expected ok');
+    const data = result.data as { status?: string; mergeable?: boolean; blocker?: string };
+    expect(data.status).toBe('no_checks_required');
+    expect(data.mergeable).toBe(false);
+    expect(data.blocker).toBe('closed');
+  });
+
+  test('non-empty rollup does NOT short-circuit — polled-response shape returned', async () => {
+    // Regression — proves the addition is conditional on rollup.length === 0.
+    on(
+      'gh pr view',
+      JSON.stringify({
+        url: 'https://github.com/org/repo/pull/46',
+        statusCheckRollup: [
+          { __typename: 'CheckRun', name: 'ci', status: 'COMPLETED', conclusion: 'SUCCESS' },
+        ],
+        state: 'OPEN',
+        isDraft: false,
+        mergeable: 'MERGEABLE',
+        mergeStateStatus: 'CLEAN',
+      }),
+    );
+    const result = await prWaitCiGithub({ number: 46, poll_interval_sec: 5, timeout_sec: 10 });
+    if (!('ok' in result) || !result.ok) throw new Error('expected ok');
+    const data = result.data as { status?: string; final_state?: string };
+    expect(data.final_state).toBe('passed');
+    expect(data.status).toBeUndefined();
+  });
+});
+
+// --- pure mapper tests for the empty-rollup blocker classifier (#416) ------
+describe('emptyRollupBlocker — pure mapping table', () => {
+  test('OPEN + mergeable + not draft → null (no blocker)', () => {
+    expect(emptyRollupBlocker({ state: 'OPEN', isDraft: false, mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN' })).toBeNull();
+  });
+
+  test('OPEN + mergeable=true (boolean) → null', () => {
+    expect(emptyRollupBlocker({ state: 'OPEN', isDraft: false, mergeable: true })).toBeNull();
+  });
+
+  test('CLOSED → closed', () => {
+    expect(emptyRollupBlocker({ state: 'CLOSED', mergeable: 'MERGEABLE' })).toBe('closed');
+  });
+
+  test('MERGED → merged', () => {
+    expect(emptyRollupBlocker({ state: 'MERGED', mergeable: 'MERGEABLE' })).toBe('merged');
+  });
+
+  test('isDraft=true → draft (even when mergeable)', () => {
+    expect(emptyRollupBlocker({ state: 'OPEN', isDraft: true, mergeable: 'MERGEABLE' })).toBe('draft');
+  });
+
+  test('CONFLICTING → conflicts', () => {
+    expect(emptyRollupBlocker({ state: 'OPEN', isDraft: false, mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY' })).toBe('conflicts');
+  });
+
+  test('mergeable=UNKNOWN → not_mergeable (defensive)', () => {
+    // GitHub returns UNKNOWN while it's still computing mergeability. We don't
+    // promise the caller "yes mergeable" until GitHub has actually decided.
+    expect(emptyRollupBlocker({ state: 'OPEN', isDraft: false, mergeable: 'UNKNOWN' })).toBe('not_mergeable');
+  });
+
+  test('mergeable=false (boolean) → not_mergeable', () => {
+    expect(emptyRollupBlocker({ state: 'OPEN', isDraft: false, mergeable: false })).toBe('not_mergeable');
+  });
+});
+
+describe('probeGithub — argv shape', () => {
+  test('asks for statusCheckRollup,url,state,isDraft,mergeable,mergeStateStatus', () => {
+    on(
+      'gh pr view',
+      JSON.stringify({
+        url: 'https://github.com/org/repo/pull/1',
+        statusCheckRollup: [],
+        state: 'OPEN',
+        isDraft: false,
+        mergeable: 'MERGEABLE',
+        mergeStateStatus: 'CLEAN',
+      }),
+    );
+    probeGithub(1);
+    const viewCall = execCalls.find((c) => c.startsWith('gh pr view')) ?? '';
+    expect(viewCall).toContain('statusCheckRollup');
+    expect(viewCall).toContain('url');
+    expect(viewCall).toContain('state');
+    expect(viewCall).toContain('isDraft');
+    expect(viewCall).toContain('mergeable');
+    expect(viewCall).toContain('mergeStateStatus');
   });
 });
 

--- a/lib/adapters/pr-wait-ci-github.ts
+++ b/lib/adapters/pr-wait-ci-github.ts
@@ -30,6 +30,7 @@ import {
 import type {
   AdapterResult,
   PrWaitCiArgs,
+  PrWaitCiNoChecksResponse,
   PrWaitCiResponse,
 } from './types.js';
 
@@ -59,6 +60,15 @@ export interface RollupItem {
 interface PrViewResponse {
   url?: string;
   statusCheckRollup?: RollupItem[];
+}
+
+interface PrProbeResponse {
+  url?: string;
+  statusCheckRollup?: RollupItem[];
+  state?: string; // OPEN | CLOSED | MERGED
+  isDraft?: boolean;
+  mergeable?: string | boolean; // MERGEABLE | CONFLICTING | UNKNOWN | bool
+  mergeStateStatus?: string; // CLEAN | DIRTY | BLOCKED | UNSTABLE | UNKNOWN
 }
 
 type Bucket = 'pass' | 'fail' | 'pending' | 'skipping';
@@ -139,12 +149,73 @@ export function snapshotGithub(number: number, repo?: string): ChecksSnapshot {
   };
 }
 
+/**
+ * Initial probe — single `gh pr view` that pulls rollup + mergeability fields
+ * in one shot (#416). Used to detect the empty-rollup short-circuit case
+ * before the polling loop even starts. Separate from `snapshotGithub` because
+ * the polling loop's per-iteration query stays minimal (no need to repeat
+ * mergeability on every poll).
+ */
+export function probeGithub(number: number, repo?: string): PrProbeResponse {
+  const raw = exec(
+    `gh pr view ${number} --json statusCheckRollup,url,state,isDraft,mergeable,mergeStateStatus${repoFlag(repo)}`,
+  );
+  return JSON.parse(raw) as PrProbeResponse;
+}
+
+/**
+ * Resolve the empty-rollup short-circuit blocker (#416). Returns `null` when
+ * the PR is mergeable today (no checks AND no obstructions). Otherwise returns
+ * a short string naming the obstruction — `draft`, `closed`, `merged`,
+ * `conflicts`, or `not_mergeable` — for inclusion in the typed response.
+ *
+ * `mergeable` is a tri-state on GitHub: `MERGEABLE | CONFLICTING | UNKNOWN`
+ * (or boolean on older REST shapes). We treat anything that isn't an explicit
+ * "yes, mergeable" as a blocker so callers never get a false-positive on a PR
+ * that GitHub is still computing.
+ */
+export function emptyRollupBlocker(probe: PrProbeResponse): string | null {
+  const state = (probe.state ?? '').toUpperCase();
+  if (state === 'CLOSED') return 'closed';
+  if (state === 'MERGED') return 'merged';
+  if (probe.isDraft === true) return 'draft';
+
+  const mergeableRaw =
+    typeof probe.mergeable === 'string' ? probe.mergeable.toUpperCase() : probe.mergeable;
+  const mergeable = mergeableRaw === true || mergeableRaw === 'MERGEABLE';
+  if (!mergeable) {
+    const mergeState = (probe.mergeStateStatus ?? '').toUpperCase();
+    if (mergeState === 'DIRTY' || mergeableRaw === 'CONFLICTING') return 'conflicts';
+    return 'not_mergeable';
+  }
+  return null;
+}
+
 export async function prWaitCiGithub(
   args: PrWaitCiArgs,
 ): Promise<AdapterResult<PrWaitCiResponse>> {
   // Bound any exception that escapes the snapshot helper into a typed result —
   // adapter callers must not have to try/catch.
   try {
+    // #416 short-circuit. One probe BEFORE entering the polling loop: if the
+    // PR's rollup is empty there is nothing to settle and we return at t=0.
+    const probeStart = Date.now();
+    const probe = probeGithub(args.number, args.repo);
+    const rollup = probe.statusCheckRollup ?? [];
+    if (rollup.length === 0) {
+      const blocker = emptyRollupBlocker(probe);
+      const elapsedSec = Math.max(0, Math.floor((Date.now() - probeStart) / 1000));
+      const data: PrWaitCiNoChecksResponse = {
+        number: args.number,
+        status: 'no_checks_required',
+        elapsed_sec: elapsedSec,
+        mergeable: blocker === null,
+        url: probe.url ?? '',
+        ...(blocker !== null ? { blocker } : {}),
+      };
+      return { ok: true, data };
+    }
+
     const pollArgs: PollArgs = {
       number: args.number,
       poll_interval_sec: args.poll_interval_sec,

--- a/lib/adapters/pr-wait-ci-gitlab.test.ts
+++ b/lib/adapters/pr-wait-ci-gitlab.test.ts
@@ -185,6 +185,9 @@ describe('prWaitCiGitlab — full poll path', () => {
     if (!('ok' in result) || !result.ok) {
       throw new Error(`expected ok result, got ${JSON.stringify(result)}`);
     }
+    if (!('final_state' in result.data)) {
+      throw new Error(`expected polled-response shape, got ${JSON.stringify(result.data)}`);
+    }
     expect(result.data.final_state).toBe('passed');
     expect(result.data.url).toBe('https://gitlab.com/org/repo/-/merge_requests/3');
     expect(result.data.number).toBe(3);
@@ -202,8 +205,116 @@ describe('prWaitCiGitlab — full poll path', () => {
     if (!('ok' in result) || !result.ok) {
       throw new Error(`expected ok result, got ${JSON.stringify(result)}`);
     }
+    if (!('final_state' in result.data)) {
+      throw new Error(`expected polled-response shape, got ${JSON.stringify(result.data)}`);
+    }
     expect(result.data.final_state).toBe('failed');
     expect(result.data.checks.failed).toBe(1);
+  });
+
+  // --- #416: empty-pipeline short-circuit ---
+  test('empty pipeline + mergeable MR → no_checks_required immediately', async () => {
+    on('git remote get-url origin', 'https://gitlab.com/org/repo.git');
+    on(
+      'glab api projects/org%2Frepo/merge_requests/3',
+      JSON.stringify({
+        iid: 3,
+        state: 'opened',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/3',
+        // No head_pipeline / pipeline → empty pipeline.
+        draft: false,
+        has_conflicts: false,
+        merge_status: 'can_be_merged',
+        detailed_merge_status: 'mergeable',
+      }),
+    );
+
+    const result = await prWaitCiGitlab({
+      number: 3,
+      // Generous timeout — proves we never enter the poll loop.
+      poll_interval_sec: 5,
+      timeout_sec: 1800,
+    });
+    if (!('ok' in result) || !result.ok) {
+      throw new Error(`expected ok result, got ${JSON.stringify(result)}`);
+    }
+    const data = result.data as { status?: string; mergeable?: boolean; blocker?: string; elapsed_sec?: number };
+    expect(data.status).toBe('no_checks_required');
+    expect(data.mergeable).toBe(true);
+    expect(data.blocker).toBeUndefined();
+    expect(data.elapsed_sec).toBeLessThan(5);
+  });
+
+  test('empty pipeline + draft MR → no_checks_required + draft blocker', async () => {
+    on('git remote get-url origin', 'https://gitlab.com/org/repo.git');
+    on(
+      'glab api projects/org%2Frepo/merge_requests/4',
+      JSON.stringify({
+        iid: 4,
+        state: 'opened',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/4',
+        draft: true,
+      }),
+    );
+
+    const result = await prWaitCiGitlab({
+      number: 4,
+      poll_interval_sec: 5,
+      timeout_sec: 1800,
+    });
+    if (!('ok' in result) || !result.ok) {
+      throw new Error(`expected ok result, got ${JSON.stringify(result)}`);
+    }
+    const data = result.data as { status?: string; mergeable?: boolean; blocker?: string };
+    expect(data.status).toBe('no_checks_required');
+    expect(data.mergeable).toBe(false);
+    expect(data.blocker).toBe('draft');
+  });
+
+  test('empty pipeline + conflicts → no_checks_required + conflicts blocker', async () => {
+    on('git remote get-url origin', 'https://gitlab.com/org/repo.git');
+    on(
+      'glab api projects/org%2Frepo/merge_requests/5',
+      JSON.stringify({
+        iid: 5,
+        state: 'opened',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/5',
+        has_conflicts: true,
+        merge_status: 'cannot_be_merged',
+      }),
+    );
+
+    const result = await prWaitCiGitlab({
+      number: 5,
+      poll_interval_sec: 5,
+      timeout_sec: 1800,
+    });
+    if (!('ok' in result) || !result.ok) {
+      throw new Error(`expected ok result, got ${JSON.stringify(result)}`);
+    }
+    const data = result.data as { status?: string; mergeable?: boolean; blocker?: string };
+    expect(data.status).toBe('no_checks_required');
+    expect(data.mergeable).toBe(false);
+    expect(data.blocker).toBe('conflicts');
+  });
+
+  test('non-empty pipeline (success) does NOT short-circuit — polled-response shape returned', async () => {
+    // Regression — when head_pipeline is present we hit the poll path and the
+    // returned envelope must carry `final_state`, NOT `status: no_checks_required`.
+    on('git remote get-url origin', 'https://gitlab.com/org/repo.git');
+    on('glab api projects/org%2Frepo/merge_requests/6', mrJson('success', 'https://gitlab.com/org/repo/-/merge_requests/6'));
+
+    const result = await prWaitCiGitlab({
+      number: 6,
+      poll_interval_sec: 5,
+      timeout_sec: 10,
+    });
+    if (!('ok' in result) || !result.ok) {
+      throw new Error(`expected ok result, got ${JSON.stringify(result)}`);
+    }
+    const data = result.data as { status?: string; final_state?: string };
+    expect(data.final_state).toBe('passed');
+    expect(data.status).toBeUndefined();
   });
 
   test('glab failure → AdapterResult ok:false with unexpected_error code', async () => {

--- a/lib/adapters/pr-wait-ci-gitlab.ts
+++ b/lib/adapters/pr-wait-ci-gitlab.ts
@@ -29,6 +29,7 @@ import {
 import type {
   AdapterResult,
   PrWaitCiArgs,
+  PrWaitCiNoChecksResponse,
   PrWaitCiResponse,
 } from './types.js';
 
@@ -99,10 +100,61 @@ export function snapshotGitlab(number: number, repo?: string): ChecksSnapshot {
   };
 }
 
+/**
+ * Resolve the empty-pipeline short-circuit blocker (#416). Mirrors the GitHub
+ * adapter's `emptyRollupBlocker` but reads from a `GitlabMr` shape: an MR with
+ * no pipeline AND no obstructions returns `null`. Anything else returns a
+ * short string naming the obstruction — `draft`, `closed`, `merged`,
+ * `locked`, `conflicts`, or `not_mergeable`.
+ */
+function emptyPipelineBlockerGitlab(
+  mr: { state?: string; draft?: boolean; work_in_progress?: boolean; has_conflicts?: boolean; merge_status?: string; detailed_merge_status?: string },
+): string | null {
+  const state = (mr.state ?? '').toLowerCase();
+  if (state === 'closed') return 'closed';
+  if (state === 'merged') return 'merged';
+  if (state === 'locked') return 'locked';
+  if (mr.draft === true || mr.work_in_progress === true) return 'draft';
+  if (mr.has_conflicts === true) return 'conflicts';
+  // GitLab's `merge_status: 'cannot_be_merged'` (or the newer
+  // `detailed_merge_status` non-`mergeable` value) is the catch-all for any
+  // obstruction we haven't named explicitly above. `can_be_merged` /
+  // `mergeable` is the only happy path.
+  const ms = (mr.merge_status ?? '').toLowerCase();
+  const dms = (mr.detailed_merge_status ?? '').toLowerCase();
+  if (ms === 'cannot_be_merged') return 'not_mergeable';
+  if (dms !== '' && dms !== 'mergeable' && dms !== 'unchecked' && dms !== 'checking') {
+    return 'not_mergeable';
+  }
+  return null;
+}
+
 export async function prWaitCiGitlab(
   args: PrWaitCiArgs,
 ): Promise<AdapterResult<PrWaitCiResponse>> {
   try {
+    // #416 short-circuit. One probe BEFORE entering the polling loop: if the
+    // MR has no pipeline data at all (neither `head_pipeline` nor `pipeline`),
+    // there is nothing to settle and we return at t=0.
+    const probeStart = Date.now();
+    const mr = gitlabApiMr(args.number, parseSlugOpts(args.repo));
+    const hasPipeline =
+      (mr.head_pipeline !== undefined && mr.head_pipeline !== null) ||
+      (mr.pipeline !== undefined && mr.pipeline !== null);
+    if (!hasPipeline) {
+      const blocker = emptyPipelineBlockerGitlab(mr);
+      const elapsedSec = Math.max(0, Math.floor((Date.now() - probeStart) / 1000));
+      const data: PrWaitCiNoChecksResponse = {
+        number: args.number,
+        status: 'no_checks_required',
+        elapsed_sec: elapsedSec,
+        mergeable: blocker === null,
+        url: mr.web_url ?? '',
+        ...(blocker !== null ? { blocker } : {}),
+      };
+      return { ok: true, data };
+    }
+
     const pollArgs: PollArgs = {
       number: args.number,
       poll_interval_sec: args.poll_interval_sec,

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -276,13 +276,40 @@ export interface PrWaitCiChecks {
   summary: string;
 }
 
-export interface PrWaitCiResponse {
+/**
+ * Polling-loop return shape — the original `pr_wait_ci` response from before
+ * #416. Reached when the PR has at least one configured check; the adapter
+ * polls until every check is settled (or timeout).
+ */
+export interface PrWaitCiPolledResponse {
   number: number;
   final_state: PrWaitCiFinalState;
   checks: PrWaitCiChecks;
   waited_sec: number;
   url: string;
 }
+
+/**
+ * Short-circuit return shape (#416). Reached on the very first probe when the
+ * PR's status-check rollup is empty — there is nothing to settle, so the
+ * "wait until CI is settled" semantics are satisfied at t=0. `mergeable` and
+ * an optional `blocker` distinguish the happy path (PR is ready to merge)
+ * from the obstructed path (draft / conflicts / closed PR).
+ *
+ * `elapsed_sec` is intentionally a small integer (the wall-clock cost of the
+ * single probe), not a polling-loop duration.
+ */
+export interface PrWaitCiNoChecksResponse {
+  number: number;
+  status: 'no_checks_required';
+  elapsed_sec: number;
+  mergeable: boolean;
+  /** Reason the PR is not mergeable today (e.g. `draft`, `conflicts`, `closed`). Omitted when mergeable. */
+  blocker?: string;
+  url: string;
+}
+
+export type PrWaitCiResponse = PrWaitCiPolledResponse | PrWaitCiNoChecksResponse;
 
 export type CiWaitRunArgs = unknown;
 export type CiWaitRunResponse = unknown;

--- a/lib/wave-finalize.ts
+++ b/lib/wave-finalize.ts
@@ -12,6 +12,15 @@
 // writeFileSync), and Bun's mock.module leaks across the entire suite —
 // any handler importing readFileSync/readdirSync from 'fs' or 'node:fs' gets
 // `undefined` if the offending test runs first. See lesson_mcp_gotchas.md §6.
+//
+// Durable-state fallback (#415): the bus directory under
+// `body_artifacts_dir` is wiped by `wave_complete` per-wave cleanup. If the
+// finalize handler is reached after the LAST wave has cleaned up, the bus
+// returns zero entries and we would emit `no_artifacts`. To survive that,
+// `assembleBodyFromState` re-derives the body from
+// `<project>/.claude/status/{phases-waves.json,state.json}` (or the .sdlc/
+// equivalent), which are persisted across wave cleanup. The handler tries
+// the bus first and falls back to durable state when the bus is empty.
 
 import { createHash } from 'crypto';
 import { join, resolve } from 'path';
@@ -248,4 +257,118 @@ export async function assembleBody(
 /** SHA-256 hex digest of the assembled body for drift detection. */
 export function hashBody(body: string): string {
   return createHash('sha256').update(body).digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// Durable-state fallback (#415)
+// ---------------------------------------------------------------------------
+//
+// `wave_complete` wipes the per-wave bus dir (the directory `assembleBody`
+// reads from). After the LAST wave's cleanup, the bus is gone but
+// `phases-waves.json` (plan structure: phases→waves→issues) and `state.json`
+// (`waves[wave_id].mr_urls` mapping issue#→PR URL) survive — they are
+// rewritten in place by the wave-status CLI, never deleted by the per-wave
+// cleanup. `assembleBodyFromState` re-derives the MR body from those two
+// files so finalize succeeds after cleanup.
+
+/** Resolve the wave-status state directory used by the project — see
+ *  `lib/wave_init_plan.ts:statusDir` and `lib/wave_reconcile_mrs_plan.ts`
+ *  for the authoritative pair. We keep this resolver separate to avoid
+ *  importing those modules (and the platform-adapter they pull in) into a
+ *  pure-helper file. */
+async function resolveStatusDir(root: string): Promise<string> {
+  const sdlc = join(root, '.sdlc');
+  if (await Bun.file(sdlc).exists()) return join(sdlc, 'waves');
+  return join(root, '.claude', 'status');
+}
+
+interface DurablePlanIssue { number: number }
+interface DurablePlanWave { id?: string; issues?: DurablePlanIssue[] }
+interface DurablePlanPhase { waves?: DurablePlanWave[] }
+interface DurablePlanData { phases?: DurablePlanPhase[] }
+
+interface DurableWaveState { mr_urls?: Record<string, string> }
+interface DurableStateData {
+  waves?: Record<string, DurableWaveState>;
+  current_wave?: string | null;
+}
+
+/**
+ * Re-derive the kahuna→target MR body from durable wave-status state when
+ * the bus directory has been cleaned. Returns `issueCount: 0` when the
+ * state files are absent or the plan contains no issues — caller decides
+ * whether to surface `no_artifacts` after this fallback also fails.
+ *
+ * The body shape mirrors `assembleBody`:
+ *   - one `### <wave-id>` heading per wave that has issues
+ *   - one bullet per issue, with a `[PR](url) — ` prefix when state has an
+ *     mr_url for that issue
+ *
+ * Per-flight grouping is intentionally collapsed: `state.json` records
+ * mr_urls keyed by issue#, NOT by flight, so we cannot reconstruct the
+ * flight partition. The wave-level grouping is enough to honor AC-2 ("one
+ * bullet per flight as before") in the practical case where each issue is
+ * its own flight; multi-issue flights will appear as flat per-issue
+ * bullets under the wave heading. This is a deliberate trade-off — durable
+ * state is the only source surviving cleanup, and capturing flight ids
+ * there is out of scope for #415.
+ */
+export async function assembleBodyFromState(
+  projectRoot: string,
+  epicId: number,
+  kahunaBranch: string,
+  targetBranch: string,
+): Promise<AssembleResult> {
+  const dir = await resolveStatusDir(projectRoot);
+  const planPath = join(dir, 'phases-waves.json');
+  const statePath = join(dir, 'state.json');
+
+  const emptyResult: AssembleResult = { body: '', issueCount: 0, flightCount: 0 };
+  let plan: DurablePlanData;
+  let state: DurableStateData;
+  try {
+    if (!(await Bun.file(planPath).exists()) || !(await Bun.file(statePath).exists())) {
+      return emptyResult;
+    }
+    plan = (await Bun.file(planPath).json()) as DurablePlanData;
+    state = (await Bun.file(statePath).json()) as DurableStateData;
+  } catch {
+    return emptyResult;
+  }
+
+  const lines: string[] = [];
+  lines.push(`Epic #${epicId} — integration branch \`${kahunaBranch}\` ready for merge into \`${targetBranch}\`.`);
+  lines.push('');
+  lines.push('## Waves');
+
+  let issueCount = 0;
+  const waveSet = new Set<string>();
+
+  for (const phase of plan.phases ?? []) {
+    for (const wave of phase.waves ?? []) {
+      const waveId = wave.id ?? '';
+      const issues = wave.issues ?? [];
+      if (waveId.length === 0 || issues.length === 0) continue;
+
+      const mrUrls = state.waves?.[waveId]?.mr_urls ?? {};
+      lines.push('');
+      lines.push(`### ${waveId}`);
+      waveSet.add(waveId);
+
+      // Sort issues by number for stable output.
+      const sortedIssues = [...issues].sort((a, b) => a.number - b.number);
+      for (const issue of sortedIssues) {
+        const url = mrUrls[String(issue.number)];
+        const prefix = url !== undefined && url.length > 0 ? `[PR](${url}) — ` : '';
+        lines.push(`- Issue #${issue.number}: ${prefix}`.trimEnd().replace(/ — $/, ''));
+        issueCount++;
+      }
+    }
+  }
+
+  if (issueCount === 0) return emptyResult;
+  // `flightCount` from durable state can't distinguish flights — surface
+  // wave count instead. Callers use issueCount for the no_artifacts gate;
+  // flightCount is only logged.
+  return { body: lines.join('\n'), issueCount, flightCount: waveSet.size };
 }

--- a/tests/integration/orchestrator-wait-on-flights.test.ts
+++ b/tests/integration/orchestrator-wait-on-flights.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Integration test for wave_wait_for_signal — the canonical Orchestrator
+ * scenario where the tool replaces an inline polling loop.
+ *
+ * Scenario: an Orchestrator dispatches three Flights, each writing a
+ * `flight-N.done` artifact to a shared wavebus directory. The Orchestrator
+ * calls wave_wait_for_signal with `min_count: 3` and waits. We verify the
+ * tool returns once all three artifacts exist, with `matched` populated and
+ * no `timed_out` flag.
+ *
+ * This is a real-filesystem test (no fs mocks). It uses Bun-native APIs
+ * (Bun.write, Bun.spawnSync) instead of node:fs to stay immune to the
+ * `mock.module('fs')` leakage from sibling test files.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { join } from 'path';
+
+import handler from '../../handlers/wave_wait_for_signal.ts';
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+async function makeTmpDir(prefix: string): Promise<string> {
+  const path = `/tmp/${prefix}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  await Bun.write(`${path}/.tmp-marker`, '');
+  return path;
+}
+
+function cleanupTmpDir(path: string): void {
+  Bun.spawnSync(['rm', '-rf', path]);
+}
+
+describe('orchestrator-wait-on-flights integration', () => {
+  let waveDir: string;
+  let flightsDir: string;
+
+  beforeEach(async () => {
+    waveDir = await makeTmpDir('orchestrator-wait');
+    flightsDir = join(waveDir, 'flights');
+    await Bun.write(`${flightsDir}/.keep`, '');
+  });
+
+  afterEach(() => {
+    cleanupTmpDir(waveDir);
+  });
+
+  test('Orchestrator waits on Flight artifacts and returns matched paths', async () => {
+    // Pre-stage all three artifacts so the tool returns on the first
+    // immediate check (no real wall-clock 5s sleep). The polling-loop
+    // semantics are exercised by the unit tests with mocked sleep.
+    await Bun.write(join(flightsDir, 'flight-1.done'), '');
+    await Bun.write(join(flightsDir, 'flight-2.done'), '');
+    await Bun.write(join(flightsDir, 'flight-3.done'), '');
+
+    const pattern = join(flightsDir, '*.done');
+    const result = await handler.execute({
+      signal_path: pattern,
+      timeout_sec: 10,
+      min_count: 3,
+    });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.timed_out).toBeUndefined();
+    expect(parsed.matched).toBeDefined();
+    expect(parsed.matched).toHaveLength(3);
+    expect(parsed.matched.sort()).toEqual([
+      join(flightsDir, 'flight-1.done'),
+      join(flightsDir, 'flight-2.done'),
+      join(flightsDir, 'flight-3.done'),
+    ]);
+    // elapsed_sec ≤ 1 because all artifacts existed at call time.
+    expect(parsed.elapsed_sec).toBeLessThanOrEqual(1);
+  });
+
+  test('partial pre-stage: caller can detect under-min via matched.length', async () => {
+    // Real-filesystem variant: the immediate check returns < min_count, so
+    // the loop would sleep. We verify the immediate-check classification
+    // against a real glob without paying for the real 5s sleep by calling
+    // the matchSignal helper directly here. End-to-end timeout/partial_matches
+    // semantics are covered by the unit test suite with a mocked clock; this
+    // test asserts the glob plumbing (real Bun.Glob against real files) is
+    // wired correctly.
+    const { matchSignal } = await import('../../handlers/wave_wait_for_signal.ts');
+    await Bun.write(join(flightsDir, 'flight-1.done'), '');
+
+    const pattern = join(flightsDir, '*.done');
+    const matches = matchSignal(pattern);
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toBe(join(flightsDir, 'flight-1.done'));
+  });
+});

--- a/tests/pr_wait_ci.test.ts
+++ b/tests/pr_wait_ci.test.ts
@@ -595,6 +595,139 @@ describe('pr_wait_ci handler', () => {
     expect(data.final_state).toBe('passed');
   });
 
+  // --- #416: empty-rollup short-circuit ---
+  // When `pr_wait_ci` is called against a PR whose head branch has no required
+  // status checks (or whose check rollup is empty for any reason), the handler
+  // must return immediately rather than spinning to timeout. The semantics is:
+  // "wait until CI is settled" — if there are no checks to settle, that
+  // condition is satisfied at t=0.
+
+  test('test_pr_wait_ci_empty_rollup_mergeable — empty rollup + mergeable returns no_checks_required immediately', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote'))
+        return 'https://github.com/org/repo.git\n';
+      if (cmd.startsWith('gh pr view'))
+        return JSON.stringify({
+          url: 'https://github.com/org/repo/pull/42',
+          statusCheckRollup: [], // empty — nothing to settle
+          state: 'OPEN',
+          isDraft: false,
+          mergeable: 'MERGEABLE',
+          mergeStateStatus: 'CLEAN',
+        });
+      throw new Error(`unexpected exec: ${cmd}`);
+    };
+
+    const result = await handler.execute({
+      number: 42,
+      poll_interval_sec: 5,
+      // Generous timeout — proves the short-circuit returns *before* any sleep.
+      timeout_sec: 1800,
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(data.status).toBe('no_checks_required');
+    expect(data.mergeable).toBe(true);
+    expect(typeof data.elapsed_sec).toBe('number');
+    expect(data.elapsed_sec).toBeLessThan(5); // far less than poll_interval
+    expect(data.blocker).toBeUndefined();
+    expect(data.url).toBe('https://github.com/org/repo/pull/42');
+    // `final_state` is the polling-loop shape — must NOT appear on the
+    // short-circuit envelope (would confuse callers reading the discriminator).
+    expect(data.final_state).toBeUndefined();
+  });
+
+  test('test_pr_wait_ci_empty_rollup_with_conflict — empty rollup + conflict returns no_checks_required + blocker', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote'))
+        return 'https://github.com/org/repo.git\n';
+      if (cmd.startsWith('gh pr view'))
+        return JSON.stringify({
+          url: 'https://github.com/org/repo/pull/43',
+          statusCheckRollup: [],
+          state: 'OPEN',
+          isDraft: false,
+          mergeable: 'CONFLICTING',
+          mergeStateStatus: 'DIRTY',
+        });
+      throw new Error(`unexpected exec: ${cmd}`);
+    };
+
+    const result = await handler.execute({
+      number: 43,
+      poll_interval_sec: 5,
+      timeout_sec: 1800,
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(data.status).toBe('no_checks_required');
+    expect(data.mergeable).toBe(false);
+    expect(data.blocker).toBe('conflicts');
+    expect(data.elapsed_sec).toBeLessThan(5);
+  });
+
+  test('test_pr_wait_ci_empty_rollup_draft — empty rollup + draft PR returns no_checks_required + draft blocker', async () => {
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote'))
+        return 'https://github.com/org/repo.git\n';
+      if (cmd.startsWith('gh pr view'))
+        return JSON.stringify({
+          url: 'https://github.com/org/repo/pull/44',
+          statusCheckRollup: [],
+          state: 'OPEN',
+          isDraft: true,
+          mergeable: 'MERGEABLE',
+          mergeStateStatus: 'CLEAN',
+        });
+      throw new Error(`unexpected exec: ${cmd}`);
+    };
+
+    const result = await handler.execute({ number: 44, poll_interval_sec: 5, timeout_sec: 60 });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    expect(data.status).toBe('no_checks_required');
+    expect(data.mergeable).toBe(false);
+    expect(data.blocker).toBe('draft');
+  });
+
+  test('test_pr_wait_ci_normal_path_still_works — non-empty rollup behaves as today', async () => {
+    // Regression for #416 — the polling-loop path must NOT change shape when
+    // the rollup is non-empty. We expect `final_state: passed` and the full
+    // polled-response envelope, NOT the short-circuit `status` discriminator.
+    execMockFn = (cmd: string) => {
+      if (cmd.startsWith('git remote'))
+        return 'https://github.com/org/repo.git\n';
+      if (cmd.startsWith('gh pr view'))
+        return JSON.stringify({
+          url: 'https://github.com/org/repo/pull/45',
+          statusCheckRollup: [
+            { __typename: 'CheckRun', name: 'build', status: 'COMPLETED', conclusion: 'SUCCESS' },
+            { __typename: 'CheckRun', name: 'test', status: 'COMPLETED', conclusion: 'SUCCESS' },
+          ],
+          state: 'OPEN',
+          isDraft: false,
+          mergeable: 'MERGEABLE',
+          mergeStateStatus: 'CLEAN',
+        });
+      throw new Error(`unexpected exec: ${cmd}`);
+    };
+
+    const result = await handler.execute({
+      number: 45,
+      poll_interval_sec: 5,
+      timeout_sec: 10,
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(true);
+    // Polled-response shape — `final_state` present, `status` absent.
+    expect(data.final_state).toBe('passed');
+    expect(data.status).toBeUndefined();
+    expect(data.url).toBe('https://github.com/org/repo/pull/45');
+    const checks = data.checks as Record<string, number>;
+    expect(checks.passed).toBe(2);
+    expect(checks.total).toBe(2);
+  });
+
   test('strict_schema_accepts_repo — .strict() schema does not reject new field', async () => {
     // Proof that adding repo to a .strict() schema doesn't trigger InvalidParams
     // via the real MCP dispatch surface (handler.execute), not just the test seam.

--- a/tests/wave_finalize.test.ts
+++ b/tests/wave_finalize.test.ts
@@ -522,4 +522,116 @@ describe('wave_finalize handler', () => {
     expect(data.created).toBe(false);
     expect(data.body_sha).toBe('');
   });
+
+  // --- #415: durable-state fallback after wave_complete cleanup -------------
+  // Regression coverage for `test_wave_finalize_after_wave_complete_cleanup`:
+  // simulate the post-cleanup state where the wavebus dir is empty (every
+  // results.md/merge-report.md has been wiped by `wave_complete`) but
+  // `<project>/.claude/status/{phases-waves.json,state.json}` are intact.
+  // The handler must re-derive the body from durable state instead of
+  // returning `no_artifacts`.
+  test('falls back to durable state when bus is empty (post-wave-complete cleanup)', async () => {
+    // Project root with .claude/status/ wave-status fixtures, NO bus artifacts.
+    const projectRoot = `/tmp/wave-finalize-state-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    await Bun.write(`${projectRoot}/.claude/status/phases-waves.json`, JSON.stringify({
+      phases: [{
+        waves: [
+          { id: 'w1', issues: [{ number: 10 }, { number: 11 }] },
+          { id: 'w2', issues: [{ number: 12 }] },
+        ],
+      }],
+    }));
+    await Bun.write(`${projectRoot}/.claude/status/state.json`, JSON.stringify({
+      current_wave: 'w2',
+      waves: {
+        w1: { status: 'complete', mr_urls: {
+          '10': 'https://github.com/o/r/pull/100',
+          '11': 'https://github.com/o/r/pull/101',
+        } },
+        w2: { status: 'complete', mr_urls: {
+          '12': 'https://github.com/o/r/pull/102',
+        } },
+      },
+    }));
+
+    mockGithubCreate(555, 'kahuna/42-foo');
+
+    const result = await handler.execute({
+      plan_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      // bus tmpRoot is intentionally empty (cleanup happened).
+      body_artifacts_dir: tmpRoot,
+      // route the durable-state read at projectRoot.
+      root: projectRoot,
+    });
+    const data = parseResult(result);
+
+    // The fallback re-derived the body — finalize succeeded, no `no_artifacts`.
+    expect(data.ok).toBe(true);
+    expect(data.created).toBe(true);
+    expect(data.number).toBe(555);
+    expect(typeof data.body_sha).toBe('string');
+    expect((data.body_sha as string).length).toBe(64);
+
+    // The submitted body must contain one bullet per issue with the recorded
+    // PR URL — verify by inspecting the `gh pr create` argv.
+    const createCall = execCalls.find(c => c.includes("'pr' 'create'"));
+    expect(createCall).toBeDefined();
+    expect(createCall as string).toContain('Issue #10');
+    expect(createCall as string).toContain('Issue #11');
+    expect(createCall as string).toContain('Issue #12');
+    expect(createCall as string).toContain('https://github.com/o/r/pull/100');
+    expect(createCall as string).toContain('https://github.com/o/r/pull/101');
+    expect(createCall as string).toContain('https://github.com/o/r/pull/102');
+  });
+
+  test('still returns no_artifacts when both bus AND durable state are empty', async () => {
+    // Empty project root — no .claude/status/ at all.
+    const emptyRoot = `/tmp/wave-finalize-empty-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    await Bun.write(`${emptyRoot}/.gitkeep`, '');
+
+    onExec('gh pr list', '[]');
+    onExec('ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
+
+    const result = await handler.execute({
+      plan_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      body_artifacts_dir: tmpRoot,
+      root: emptyRoot,
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+    expect(data.error).toBe('no_artifacts');
+  });
+
+  test('bus artifacts take precedence over durable state when both are present', async () => {
+    // Bus has results from issue 99; durable state has issues 10/11/12.
+    // The handler should use the bus body (issue 99 bullet), not the state.
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-99/results.md',
+      'Bus-sourced summary.\nPR: https://github.com/o/r/pull/999\n');
+
+    const projectRoot = `/tmp/wave-finalize-prec-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    await Bun.write(`${projectRoot}/.claude/status/phases-waves.json`, JSON.stringify({
+      phases: [{ waves: [{ id: 'w1', issues: [{ number: 10 }] }] }],
+    }));
+    await Bun.write(`${projectRoot}/.claude/status/state.json`, JSON.stringify({
+      waves: { w1: { mr_urls: { '10': 'https://github.com/o/r/pull/100' } } },
+    }));
+
+    mockGithubCreate(555, 'kahuna/42-foo');
+
+    await handler.execute({
+      plan_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      body_artifacts_dir: tmpRoot,
+      root: projectRoot,
+    });
+
+    const createCall = execCalls.find(c => c.includes("'pr' 'create'"));
+    expect(createCall).toBeDefined();
+    expect(createCall as string).toContain('Issue #99');
+    expect(createCall as string).toContain('https://github.com/o/r/pull/999');
+    // Durable-state issue must NOT leak into the body.
+    expect(createCall as string).not.toContain('Issue #10');
+  });
 });

--- a/tests/wave_wait_for_signal.test.ts
+++ b/tests/wave_wait_for_signal.test.ts
@@ -1,0 +1,259 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { join } from 'path';
+
+import handler, {
+  __runWithDeps,
+  matchSignal,
+  POLL_INTERVAL_SEC,
+} from '../handlers/wave_wait_for_signal.ts';
+
+// File operations use Bun.write/Bun.spawnSync('rm') instead of node:fs to
+// avoid leakage from `mock.module('fs', ...)` calls in sibling test files
+// (lesson_bun_native_apis.md).
+async function makeTmpDir(prefix: string): Promise<string> {
+  const path = `/tmp/${prefix}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  // Bun.write creates parent directories on demand; make a marker then
+  // delete it, leaving the directory in place.
+  await Bun.write(`${path}/.tmp-marker`, '');
+  return path;
+}
+
+async function cleanupTmpDir(path: string): Promise<void> {
+  Bun.spawnSync(['rm', '-rf', path]);
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('wave_wait_for_signal handler', () => {
+  test('handler exports valid HandlerDef shape', () => {
+    expect(handler.name).toBe('wave_wait_for_signal');
+    expect(typeof handler.execute).toBe('function');
+    expect(handler.description).toContain('signal_path');
+  });
+
+  describe('schema validation', () => {
+    test('rejects missing signal_path', async () => {
+      const result = await handler.execute({});
+      const parsed = parseResult(result);
+      expect(parsed.ok).toBe(false);
+    });
+
+    test('rejects empty signal_path', async () => {
+      const result = await handler.execute({ signal_path: '' });
+      const parsed = parseResult(result);
+      expect(parsed.ok).toBe(false);
+    });
+
+    test('rejects non-positive timeout_sec', async () => {
+      const result = await handler.execute({ signal_path: 'x', timeout_sec: 0 });
+      const parsed = parseResult(result);
+      expect(parsed.ok).toBe(false);
+    });
+
+    test('rejects non-positive min_count', async () => {
+      const result = await handler.execute({ signal_path: 'x', min_count: 0 });
+      const parsed = parseResult(result);
+      expect(parsed.ok).toBe(false);
+    });
+
+    test('applies defaults: timeout_sec=1800, min_count=1', async () => {
+      // Uses __runWithDeps so we don't hit the real 1800s timeout. We
+      // verify defaults indirectly: the loop returns immediately because
+      // matchFn returns one path, and min_count default is 1.
+      const result = await __runWithDeps(
+        { signal_path: 'wavebus/x.done' },
+        {
+          matchFn: () => ['/tmp/x.done'],
+          sleepFn: async () => {
+            throw new Error('should not sleep on immediate match');
+          },
+          nowFn: () => 0,
+        },
+      );
+      expect(result.ok).toBe(true);
+      expect(result.matched).toEqual(['/tmp/x.done']);
+    });
+  });
+
+  describe('matchSignal — real filesystem', () => {
+    let tmpDir: string;
+    beforeEach(async () => {
+      tmpDir = await makeTmpDir('wave-wait-test');
+    });
+    afterEach(async () => {
+      await cleanupTmpDir(tmpDir);
+    });
+
+    test('literal path: returns [path] when file exists, [] otherwise', async () => {
+      const filePath = join(tmpDir, 'flight-1.done');
+      expect(matchSignal(filePath)).toEqual([]);
+      await Bun.write(filePath, '');
+      expect(matchSignal(filePath)).toEqual([filePath]);
+    });
+
+    test('glob pattern: returns sorted absolute paths of matching files', async () => {
+      await Bun.write(join(tmpDir, 'flights', 'flight-2.done'), '');
+      await Bun.write(join(tmpDir, 'flights', 'flight-1.done'), '');
+      await Bun.write(join(tmpDir, 'flights', 'flight-3.pending'), '');
+
+      const matches = matchSignal('flights/*.done', tmpDir);
+      expect(matches).toHaveLength(2);
+      expect(matches[0]).toContain('flight-1.done');
+      expect(matches[1]).toContain('flight-2.done');
+      // sorted
+      expect(matches[0] < matches[1]).toBe(true);
+    });
+
+    test('glob pattern: returns [] when no matches', () => {
+      const matches = matchSignal('nothing/*.done', tmpDir);
+      expect(matches).toEqual([]);
+    });
+  });
+
+  describe('polling loop (via __runWithDeps)', () => {
+    test('test_wave_wait_for_signal_matches_immediately', async () => {
+      let sleeps = 0;
+      const result = await __runWithDeps(
+        { signal_path: 'foo.done', timeout_sec: 100, min_count: 1 },
+        {
+          matchFn: () => ['/abs/foo.done'],
+          sleepFn: async () => {
+            sleeps += 1;
+          },
+          nowFn: () => 0,
+        },
+      );
+      expect(result.ok).toBe(true);
+      expect(result.matched).toEqual(['/abs/foo.done']);
+      expect(result.elapsed_sec).toBe(0);
+      expect(result.timed_out).toBeUndefined();
+      expect(sleeps).toBe(0); // never slept — matched on first check
+    });
+
+    test('test_wave_wait_for_signal_polls_until_match', async () => {
+      // Simulate: first 2 checks return 0 matches, third returns 2 matches
+      // (>= min_count of 2). Verify it sleeps twice and returns matched.
+      const matchSequence = [[], [], ['/a/1.done', '/a/2.done']];
+      let checkCount = 0;
+      const sleepDurationsMs: number[] = [];
+      let virtualNow = 0;
+
+      const result = await __runWithDeps(
+        { signal_path: 'a/*.done', timeout_sec: 100, min_count: 2 },
+        {
+          matchFn: () => matchSequence[checkCount++] ?? [],
+          sleepFn: async (ms) => {
+            sleepDurationsMs.push(ms);
+            virtualNow += ms;
+          },
+          nowFn: () => virtualNow,
+        },
+      );
+
+      expect(result.ok).toBe(true);
+      expect(result.matched).toEqual(['/a/1.done', '/a/2.done']);
+      expect(result.timed_out).toBeUndefined();
+      expect(sleepDurationsMs).toEqual([
+        POLL_INTERVAL_SEC * 1000,
+        POLL_INTERVAL_SEC * 1000,
+      ]);
+      expect(checkCount).toBe(3);
+      expect(result.elapsed_sec).toBe(POLL_INTERVAL_SEC * 2);
+    });
+
+    test('test_wave_wait_for_signal_times_out', async () => {
+      // No matches ever. Verify timed_out=true, elapsed_sec === timeout_sec,
+      // partial_matches is empty.
+      let virtualNow = 0;
+      const result = await __runWithDeps(
+        { signal_path: 'never.done', timeout_sec: 30, min_count: 1 },
+        {
+          matchFn: () => [],
+          sleepFn: async (ms) => {
+            virtualNow += ms;
+          },
+          nowFn: () => virtualNow,
+        },
+      );
+
+      expect(result.ok).toBe(true);
+      expect(result.timed_out).toBe(true);
+      expect(result.elapsed_sec).toBe(30);
+      expect(result.partial_matches).toEqual([]);
+      expect(result.matched).toBeUndefined();
+    });
+
+    test('test_wave_wait_for_signal_partial_matches', async () => {
+      // min_count=3, but only 2 files ever appear before timeout.
+      // partial_matches should contain those 2 paths.
+      let virtualNow = 0;
+      let checkCount = 0;
+      const matchSequence: string[][] = [
+        [],
+        ['/a/1.done'],
+        ['/a/1.done', '/a/2.done'],
+        ['/a/1.done', '/a/2.done'],
+        ['/a/1.done', '/a/2.done'],
+      ];
+      const result = await __runWithDeps(
+        { signal_path: 'a/*.done', timeout_sec: 20, min_count: 3 },
+        {
+          matchFn: () => matchSequence[Math.min(checkCount++, matchSequence.length - 1)],
+          sleepFn: async (ms) => {
+            virtualNow += ms;
+          },
+          nowFn: () => virtualNow,
+        },
+      );
+
+      expect(result.ok).toBe(true);
+      expect(result.timed_out).toBe(true);
+      expect(result.partial_matches).toEqual(['/a/1.done', '/a/2.done']);
+      expect(result.elapsed_sec).toBe(20);
+    });
+
+    test('does NOT return early when match count is below min_count', async () => {
+      // matchFn returns 2 matches, but min_count=5. Must wait for timeout.
+      let virtualNow = 0;
+      const result = await __runWithDeps(
+        { signal_path: 'a/*.done', timeout_sec: 25, min_count: 5 },
+        {
+          matchFn: () => ['/a/1.done', '/a/2.done'],
+          sleepFn: async (ms) => {
+            virtualNow += ms;
+          },
+          nowFn: () => virtualNow,
+        },
+      );
+      expect(result.timed_out).toBe(true);
+      expect(result.partial_matches).toEqual(['/a/1.done', '/a/2.done']);
+    });
+  });
+
+  describe('execute (full handler entry point)', () => {
+    let tmpDir: string;
+    beforeEach(async () => {
+      tmpDir = await makeTmpDir('wave-wait-exec');
+    });
+    afterEach(async () => {
+      await cleanupTmpDir(tmpDir);
+    });
+
+    test('immediate match against real filesystem returns ok:true with matched paths', async () => {
+      const sigPath = join(tmpDir, 'ready.done');
+      await Bun.write(sigPath, '');
+
+      const result = await handler.execute({
+        signal_path: sigPath,
+        timeout_sec: 10,
+        min_count: 1,
+      });
+      const parsed = parseResult(result);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.matched).toEqual([sigPath]);
+      expect(parsed.timed_out).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Plan #607 (Beta) — sdlc-server side

3 mcp-server-sdlc issues from Plan #607 (Beta), all merged into kahuna/607-beta. Companion to claudecode-workflow's kahuna→main MR.

### Wave 1a — Reliability fixes
- #415 bug(wave_finalize): durable-state fallback after wave_complete cleanup → PR #417

### Wave 4a — Wave-pattern feature completion
- #414 feat(wave): wave_wait_for_signal MCP tool → PR #419
- #416 feat(pr_wait_ci): short-circuit on empty rollup → PR #420

Closes Wave-Engineering/claudecode-workflow#607 (PM-side; this MR delivers the sdlc-server portion of that Plan)