### PR TITLE
fix(routing): getAdapter uses repo slug depth to infer platform

### DIFF
--- a/lib/adapters/route.test.ts
+++ b/lib/adapters/route.test.ts
@@ -38,8 +38,23 @@ describe('getAdapter dispatch', () => {
     expect(getAdapter()).toBe(githubAdapter);
   });
 
-  test('accepts {repo} arg without throwing (forward-compat for cross-repo dispatch)', () => {
+  test('2-segment repo falls back to cwd detection (github origin)', () => {
     execMockFn = () => 'https://github.com/owner/repo.git';
-    expect(getAdapter({ repo: 'org/somewhere-else' })).toBe(githubAdapter);
+    expect(getAdapter({ repo: 'Wave-Engineering/ccwork-testtarget' })).toBe(githubAdapter);
+  });
+
+  test('2-segment repo falls back to cwd detection (gitlab origin)', () => {
+    execMockFn = () => 'https://gitlab.com/owner/repo.git';
+    expect(getAdapter({ repo: 'some-org/some-repo' })).toBe(gitlabAdapter);
+  });
+
+  test('3+-segment repo routes to gitlab regardless of cwd', () => {
+    execMockFn = () => 'https://github.com/owner/repo.git';
+    expect(getAdapter({ repo: 'analogicdev/blueshift/blueshift-cue' })).toBe(gitlabAdapter);
+  });
+
+  test('deeply nested repo routes to gitlab', () => {
+    execMockFn = () => 'https://github.com/owner/repo.git';
+    expect(getAdapter({ repo: 'analogicdev/internal/tools/blueshift/blueshift-cue' })).toBe(gitlabAdapter);
   });
 });

--- a/lib/adapters/route.ts
+++ b/lib/adapters/route.ts
@@ -1,7 +1,11 @@
 /**
  * Dispatch layer — `getAdapter()` returns the `PlatformAdapter` for the
- * current execution context (cwd-based detection by default; an optional
- * `repo` arg is reserved for future cross-repo dispatch).
+ * current execution context.
+ *
+ * When a `repo` slug is provided with 3+ segments (e.g. `org/sub/repo`),
+ * the slug structure is unambiguously GitLab (GitHub only supports flat
+ * `owner/repo`). For 2-segment slugs the platform is ambiguous, so we
+ * fall back to cwd-based detection via `detectPlatform()`.
  *
  * Sync because `detectPlatform()` is sync (CT-03 — current behavior preserved
  * during the retrofit).
@@ -12,11 +16,15 @@ import { githubAdapter } from './github.js';
 import { gitlabAdapter } from './gitlab.js';
 import type { PlatformAdapter } from './types.js';
 
-// `args.repo` is accepted today for forward-compat with the §5.4 spec but
-// not yet consumed — current behavior delegates to cwd-based `detectPlatform()`.
-// Cross-repo dispatch lands when an upcoming story (Phase 2) extends
-// `detectPlatform` to accept a repo slug; this signature won't change.
-export function getAdapter(_args?: { repo?: string }): PlatformAdapter {
-  const platform = detectPlatform();
+export function getAdapter(args?: { repo?: string }): PlatformAdapter {
+  const platform = inferPlatform(args?.repo);
   return platform === 'gitlab' ? gitlabAdapter : githubAdapter;
+}
+
+function inferPlatform(repo?: string) {
+  if (repo) {
+    const segments = repo.split('/').length;
+    if (segments > 2) return 'gitlab' as const;
+  }
+  return detectPlatform();
 }


### PR DESCRIPTION
## Summary

`getAdapter()` ignored its `repo` argument, always routing by the MCP server process's cwd. Agents in GitHub-cwd sessions calling CI tools against GitLab repos got 404s.

## Changes

- `lib/adapters/route.ts` — `getAdapter` now uses repo slug segment count: 3+ segments → GitLab (nested groups are structurally unambiguous); 2 segments → fall back to cwd detection (ambiguous)
- `lib/adapters/route.test.ts` — 4 new cases covering the inference logic

## Linked Issues

Closes #426

## Test Plan

- `bun test` — 2242 pass, 0 fail
- Route test covers: nested gitlab slug from github cwd → gitlabAdapter, flat slug → cwd fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)