### PR TITLE
fix(gitlab-api): treat empty stdout from glab list endpoints as empty collection

### DIFF
--- a/lib/adapters/fetch-pr-for-branch-gitlab.test.ts
+++ b/lib/adapters/fetch-pr-for-branch-gitlab.test.ts
@@ -227,4 +227,18 @@ describe('fetch-pr-for-branch-gitlab — AdapterResult wrapper', () => {
     expect(result.code).toBe('glab_api_mr_list_failed');
     expect(result.error).toContain('glab');
   });
+
+  test('returns ok:true + data:null when glab returns empty output (#428)', async () => {
+    on('git remote get-url origin', 'https://gitlab.com/org/repo.git');
+    on('glab api projects/org%2Frepo/merge_requests', () => {
+      throw new Error(
+        'glab returned empty output for: glab api projects/org%2Frepo/merge_requests?state=opened&source_branch=chore%2F4-thing&per_page=1',
+      );
+    });
+    const result = await fetchPrForBranchGitlab({
+      branch: 'chore/4-thing',
+    });
+    expectOk(result);
+    expect(result.data).toBeNull();
+  });
 });

--- a/lib/adapters/fetch-pr-for-branch-gitlab.ts
+++ b/lib/adapters/fetch-pr-for-branch-gitlab.ts
@@ -59,10 +59,18 @@ export async function fetchPrForBranchGitlab(
     const data = fetchPrForBranchGitlabSync(args.branch, state, args.repo);
     return { ok: true, data };
   } catch (err) {
+    // "empty output" from glab for an MR-list query means "no MRs" — treat
+    // the same as an empty array rather than propagating as a tool error.
+    // Intermittent: glab occasionally returns empty stdout with exit 0 for
+    // queries that legitimately have zero results (#428).
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes('empty output')) {
+      return { ok: true, data: null };
+    }
     return {
       ok: false,
       code: 'glab_api_mr_list_failed',
-      error: err instanceof Error ? err.message : String(err),
+      error: msg,
     };
   }
 }

--- a/lib/gitlab-api.ts
+++ b/lib/gitlab-api.ts
@@ -146,6 +146,8 @@ function execGlab(cmd: string): string {
   // Zero-exit-empty-stdout: caller would do JSON.parse('') → SyntaxError
   // ("Unexpected EOF") that loses the underlying cause. Surface a named
   // error instead so the failure is diagnosable. (#382)
+  // Note: `[]` and `{}` are valid empty-collection responses (e.g. "no MRs
+  // for this branch") — only truly empty output indicates a glab failure.
   if (raw.trim() === '') {
     throw new Error(`glab returned empty output for: ${cmd}`);
   }
@@ -255,7 +257,16 @@ export function gitlabApiMrList(
   }
 
   const query = queryParts.length > 0 ? `?${queryParts.join('&')}` : '';
-  const raw = execGlab(`glab api projects/${path}/merge_requests${query}`);
+  let raw: string;
+  try {
+    raw = execGlab(`glab api projects/${path}/merge_requests${query}`);
+  } catch (err) {
+    // List endpoints: empty output means "no results" — return [] rather
+    // than propagating "empty output" as a fatal error (#428).
+    const msg = err instanceof Error ? err.message : '';
+    if (msg.includes('empty output')) return [];
+    throw err;
+  }
   return JSON.parse(raw) as GitlabMr[];
 }
 
@@ -286,7 +297,14 @@ export function gitlabApiCiList(
   }
 
   const query = queryParts.length > 0 ? `?${queryParts.join('&')}` : '';
-  const raw = execGlab(`glab api projects/${path}/pipelines${query}`);
+  let raw: string;
+  try {
+    raw = execGlab(`glab api projects/${path}/pipelines${query}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : '';
+    if (msg.includes('empty output')) return [];
+    throw err;
+  }
   return JSON.parse(raw) as GitlabPipeline[];
 }
 


### PR DESCRIPTION
## Summary

`glab api` intermittently returns empty stdout (exit 0) for MR-list and pipeline-list queries with zero results. `execGlab`'s defensive empty-output check throws, which propagates as a tool error through `ibm()` during precheck — blocking agents on GitLab projects that haven't created their MR yet.

## Changes

- `lib/gitlab-api.ts` — `gitlabApiMrList` and `gitlabApiCiList` catch "empty output" errors and return `[]`
- `lib/adapters/fetch-pr-for-branch-gitlab.ts` — adapter-level catch returns `{ok: true, data: null}` on empty output
- `lib/adapters/fetch-pr-for-branch-gitlab.test.ts` — new test for the empty-output → null case

## Linked Issues

Closes #428

## Test Plan

- `bun test` — 2280 pass (4 pre-existing wave_finalize failures unrelated)
- New test: "returns ok:true + data:null when glab returns empty output"
- Reported by @faraday in blueshift-onprem-airgap — `ibm()` now returns success when no MR exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)