### PR TITLE
fix(epic_sub_issues): parse nested-bullet refs in Phase checklists

### DIFF
--- a/lib/epic-sub-issues-parser.ts
+++ b/lib/epic-sub-issues-parser.ts
@@ -111,14 +111,14 @@ export function parseChecklistOrBullets(
     const text = m[1].trim();
     if (!text) continue;
     const refM =
-      /(?:^|\s)([^/\s#]+\/[^/\s#]+#\d+|https?:\/\/\S+\/issues\/\d+|#\d+)/.exec(text);
+      /(?:^|[\s(])([^/\s#()]+\/[^/\s#()]+#\d+|https?:\/\/\S+\/issues\/\d+|#\d+)/.exec(text);
     if (!refM) continue;
     const raw = refM[1];
     const ref = normalizeRef(raw, currentSlug);
     // Title = text with the ref token stripped out. Also strip leading
     // list/separator punctuation including em/en dashes commonly used in
     // `- #NN — Title` style bullets.
-    const title = text.replace(refM[0], '').trim().replace(/^[-:*\s—–]+/, '').trim();
+    const title = text.replace(refM[0], '').replace(/\s*\)+\s*$/, '').trim().replace(/^[-:*\s—–]+/, '').trim();
     subs.push({
       ref,
       title: title.length > 0 ? title : undefined,

--- a/tests/epic_sub_issues.test.ts
+++ b/tests/epic_sub_issues.test.ts
@@ -158,6 +158,28 @@ describe('epic_sub_issues handler', () => {
     expect(parsed.count).toBe(2);
   });
 
+  test('parses_nested_bullet_phase_checklist — devspec upshift format', async () => {
+    mockBody(`## Phases
+
+- [ ] **Phase 1: Toolkit Foundation** (1 Story, 1 Wave)
+  - [ ] Story 1.1: Initialize toolkit foundation (#5)
+- [ ] **Phase 2: Bake Pipeline** (3 Stories, 2 Waves)
+  - [ ] Story 2.1: Bake orchestrator (#6)
+  - [ ] Story 2.2: Provision AppRole (other-org/other-repo#19)
+  - [ ] Story 2.3: Phase A secrets generation (#14)
+`);
+    const result = await handler.execute({ epic_ref: '#100' });
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.count).toBe(4);
+    expect(parsed.sub_issues[0].ref).toBe('myorg/myrepo#5');
+    expect(parsed.sub_issues[0].title).toContain('Story 1.1');
+    expect(parsed.sub_issues[1].ref).toBe('myorg/myrepo#6');
+    expect(parsed.sub_issues[2].ref).toBe('other-org/other-repo#19');
+    expect(parsed.sub_issues[2].title).toBe('Story 2.2: Provision AppRole');
+    expect(parsed.sub_issues[3].ref).toBe('myorg/myrepo#14');
+  });
+
   test('accepted_sections_surfaced_when_missing', async () => {
     mockBody('## Summary\nnothing here.\n');
     const result = await handler.execute({ epic_ref: '#100' });


### PR DESCRIPTION
## Summary

Fixes `epic_sub_issues` failing to parse Story refs in nested-bullet Phase checklists written by `/devspec upshift`.

## Changes

- **lib/epic-sub-issues-parser.ts**: Added `(` to regex boundary class and `()` to exclusion class for cross-repo ref segments; strip trailing `)` from titles when ref was inside parentheses
- **tests/epic_sub_issues.test.ts**: New test for nested-bullet Phase checklist format with title validation

## Linked Issues

Closes #434

## Test Plan

- New test `parses_nested_bullet_phase_checklist` passes (17/17 in file)
- Full suite: 2291 pass, 4 pre-existing failures (wave_finalize, unrelated)
- Validates: local `(#N)`, cross-repo `(org/repo#N)`, title extraction without trailing `)`