### PR TITLE
fix(gitlab-api): URL-encode branch names in resolveBranchSha API path (#437)

### DIFF
--- a/lib/adapters/resolve-branch-sha-gitlab.test.ts
+++ b/lib/adapters/resolve-branch-sha-gitlab.test.ts
@@ -131,10 +131,10 @@ describe('resolveBranchShaGitlab — subprocess boundary', () => {
     expect((result as { code: string }).code).toBe('invalid_repo');
   });
 
-  test('passes branch names with slashes (feature/1-demo) unharmed', async () => {
+  test('URL-encodes branch names with slashes (feature/1-demo → feature%2F1-demo)', async () => {
     const sha = 'b'.repeat(40);
     on(
-      'glab api projects/org%2Frepo/repository/branches/feature/1-demo',
+      'glab api projects/org%2Frepo/repository/branches/feature%2F1-demo',
       JSON.stringify({ commit: { id: sha } }),
     );
 
@@ -144,6 +144,28 @@ describe('resolveBranchShaGitlab — subprocess boundary', () => {
     });
     expectOk(result);
     expect(result.data).toEqual({ sha });
+
+    const call = findCall('glab api');
+    expect(call).toContain('branches/feature%2F1-demo');
+    expect(call).not.toContain('branches/feature/1-demo');
+  });
+
+  test('URL-encodes multi-segment branches (release/0.0.1)', async () => {
+    const sha = 'd'.repeat(40);
+    on(
+      'glab api projects/team%2Fproject%2Fsub%2Frepo/repository/branches/release%2F0.0.1',
+      JSON.stringify({ commit: { id: sha } }),
+    );
+
+    const result = await resolveBranchShaGitlab({
+      branch: 'release/0.0.1',
+      repo: 'team/project/sub/repo',
+    });
+    expectOk(result);
+    expect(result.data).toEqual({ sha });
+
+    const call = findCall('glab api');
+    expect(call).toContain('branches/release%2F0.0.1');
   });
 
   test('supports nested group slugs (org/sub/repo → org%2Fsub%2Frepo)', async () => {

--- a/lib/adapters/resolve-branch-sha-gitlab.ts
+++ b/lib/adapters/resolve-branch-sha-gitlab.ts
@@ -66,10 +66,11 @@ export async function resolveBranchShaGitlab(
     }
 
     const encoded = slug.replace(/\//g, '%2F');
+    const encodedBranch = encodeURIComponent(args.branch);
     const cmd = [
       'glab',
       'api',
-      `projects/${encoded}/repository/branches/${args.branch}`,
+      `projects/${encoded}/repository/branches/${encodedBranch}`,
     ];
     const result = runArgv(cmd, projectDir());
     if (result.exitCode !== 0) {


### PR DESCRIPTION
## Summary

GitLab's `/repository/branches/:branch` endpoint expects the branch name as a single URL-encoded path segment. Branches containing `/` (e.g. `release/0.0.1`, `feature/N-desc`) were interpolated verbatim, splitting the URL path and causing 404s.

## Changes

- Add `encodeURIComponent(args.branch)` before interpolation in `resolveBranchShaGitlab`
- Update existing slash-branch test to assert encoded output
- Add new test for multi-segment branches (`release/0.0.1`)

## Linked Issues

Closes #437

## Test Plan

- `bun test lib/adapters/resolve-branch-sha-gitlab.test.ts` — 10/10 pass
- Full suite: 2292 pass (4 pre-existing `wave_finalize` failures unrelated)