### PR TITLE
fix(wave_init): normalize devspec-upshift plan shape before persist (#438)

### DIFF
--- a/handlers/wave_init.ts
+++ b/handlers/wave_init.ts
@@ -33,7 +33,7 @@ import { getAdapter } from '../lib/adapters/index.js';
 import {
   projectDir, writePlanFile, statusDir, readJson, countIssuesFromPlan,
   extendModePrescan, readPhasesWavesTotals, bootstrapKahunaBranchRemote,
-  recordKahunaBranchInState, branchExistsOnRemote, fileExists,
+  recordKahunaBranchInState, branchExistsOnRemote, fileExists, normalizePlanJson,
   type PlanData, type StateData,
 } from '../lib/wave_init_plan.js';
 import { repoOptionalSchema } from '../lib/schemas/repo.js';
@@ -80,6 +80,7 @@ const waveInitHandler: HandlerDef = {
     catch (err) { return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) }); }
 
     const cwd = projectDir(args.project_root);
+    args.plan_json = normalizePlanJson(args.plan_json, args.repo);
     if (args.extend) {
       const pre = await extendModePrescan(args.plan_json, cwd);
       if (!pre.ok) return envelope(pre);

--- a/lib/wave_init_plan.test.ts
+++ b/lib/wave_init_plan.test.ts
@@ -1,0 +1,112 @@
+import { describe, test, expect } from 'bun:test';
+import { normalizePlanJson } from './wave_init_plan.ts';
+
+describe('normalizePlanJson', () => {
+  test('transforms devspec-upshift shape to wave-status shape', () => {
+    const upshift = JSON.stringify({
+      plan_id: 2,
+      slug: 'org/repo',
+      phases: [{
+        name: 'Phase 1: Foundation',
+        dod: ['deliverable'],
+        waves: [{
+          name: 'P1W1',
+          stories: [
+            { id: '1.1', issue: 501, title: 'Story A', depends_on: [] },
+            { id: '1.2', issue: 502, title: 'Story B', depends_on: ['1.1'] },
+          ],
+        }],
+      }],
+    });
+
+    const result = JSON.parse(normalizePlanJson(upshift));
+    expect(result.project).toBe('org/repo');
+    expect(result.phases[0].waves[0].id).toBe('P1W1');
+    expect(result.phases[0].waves[0].stories).toBeUndefined();
+    expect(result.phases[0].waves[0].name).toBeUndefined();
+    expect(result.phases[0].waves[0].issues).toHaveLength(2);
+    expect(result.phases[0].waves[0].issues[0]).toEqual({
+      number: 501,
+      repo: 'org/repo',
+      ref: 'org/repo#501',
+      title: 'Story A',
+      depends_on: [],
+    });
+  });
+
+  test('passes through already-correct wave-status shape', () => {
+    const correct = JSON.stringify({
+      project: 'org/repo',
+      phases: [{
+        waves: [{
+          id: 'P1W1',
+          issues: [{ number: 501, repo: 'org/repo', ref: 'org/repo#501' }],
+        }],
+      }],
+    });
+
+    expect(normalizePlanJson(correct)).toBe(correct);
+  });
+
+  test('uses repoSlug param when plan has no slug/project', () => {
+    const upshift = JSON.stringify({
+      plan_id: 2,
+      phases: [{
+        waves: [{
+          name: 'P1W1',
+          stories: [{ id: '1.1', issue: 10, title: 'Story', depends_on: [] }],
+        }],
+      }],
+    });
+
+    const result = JSON.parse(normalizePlanJson(upshift, 'team/project'));
+    expect(result.project).toBe('team/project');
+    expect(result.phases[0].waves[0].issues[0].repo).toBe('team/project');
+    expect(result.phases[0].waves[0].issues[0].ref).toBe('team/project#10');
+  });
+
+  test('preserves multi-phase structure', () => {
+    const upshift = JSON.stringify({
+      plan_id: 5,
+      slug: 'org/repo',
+      phases: [
+        { name: 'Phase 1', waves: [{ name: 'P1W1', stories: [{ id: '1.1', issue: 1, title: 'A', depends_on: [] }] }] },
+        { name: 'Phase 2', waves: [{ name: 'P2W1', stories: [{ id: '2.1', issue: 2, title: 'B', depends_on: [] }] }] },
+      ],
+    });
+
+    const result = JSON.parse(normalizePlanJson(upshift));
+    expect(result.phases).toHaveLength(2);
+    expect(result.phases[0].waves[0].id).toBe('P1W1');
+    expect(result.phases[1].waves[0].id).toBe('P2W1');
+  });
+
+  test('returns original on invalid JSON', () => {
+    expect(normalizePlanJson('not-json')).toBe('not-json');
+  });
+
+  test('returns original when phases is empty', () => {
+    const empty = JSON.stringify({ phases: [] });
+    expect(normalizePlanJson(empty)).toBe(empty);
+  });
+
+  test('cross-repo stories preserve their own repo field', () => {
+    const upshift = JSON.stringify({
+      plan_id: 2,
+      slug: 'org/main-repo',
+      phases: [{
+        waves: [{
+          name: 'P1W1',
+          stories: [
+            { id: '1.1', issue: 10, title: 'local', depends_on: [], repo: 'org/main-repo' },
+            { id: '1.2', issue: 19, title: 'cross', depends_on: [], repo: 'org/other-repo' },
+          ],
+        }],
+      }],
+    });
+
+    const result = JSON.parse(normalizePlanJson(upshift));
+    expect(result.phases[0].waves[0].issues[1].repo).toBe('org/other-repo');
+    expect(result.phases[0].waves[0].issues[1].ref).toBe('org/other-repo#19');
+  });
+});

--- a/lib/wave_init_plan.ts
+++ b/lib/wave_init_plan.ts
@@ -58,6 +58,56 @@ export async function statusDir(root: string): Promise<string> {
   return join(root, '.claude', 'status');
 }
 
+/**
+ * Detect and transform `/devspec upshift` plan shape into `wave-status init`
+ * shape. The upshift format uses `waves[].name` + `waves[].stories[]` while
+ * wave-status expects `waves[].id` + `waves[].issues[]`. Also injects
+ * top-level `project` from the plan's own slug field or the provided repo slug.
+ *
+ * Returns the JSON string (transformed if needed, original if already correct).
+ */
+export function normalizePlanJson(planJson: string, repoSlug?: string): string {
+  let plan: Record<string, unknown>;
+  try { plan = JSON.parse(planJson); }
+  catch { return planJson; }
+
+  const phases = plan.phases as Array<Record<string, unknown>> | undefined;
+  if (!Array.isArray(phases) || phases.length === 0) return planJson;
+
+  const firstWave = (phases[0].waves as Array<Record<string, unknown>> | undefined)?.[0];
+  if (!firstWave) return planJson;
+
+  const isUpshiftShape = Array.isArray(firstWave.stories) || (firstWave.name !== undefined && firstWave.id === undefined);
+  if (!isUpshiftShape) return planJson;
+
+  const project = (plan.project as string) ?? repoSlug ?? (plan.slug as string) ?? undefined;
+  const transformed: Record<string, unknown> = { ...plan };
+  if (project) transformed.project = project;
+
+  transformed.phases = phases.map((phase) => {
+    const waves = (phase.waves as Array<Record<string, unknown>> | undefined) ?? [];
+    return {
+      ...phase,
+      waves: waves.map((wave) => {
+        const id = (wave.id as string) ?? (wave.name as string) ?? undefined;
+        const stories = (wave.stories as Array<Record<string, unknown>> | undefined) ?? [];
+        const issues = (wave.issues as unknown[] | undefined) ?? stories.map((story) => {
+          const issueNum = (story.issue as number) ?? (story.number as number);
+          const storyRepo = (story.repo as string) ?? project;
+          const ref = storyRepo ? `${storyRepo}#${issueNum}` : `#${issueNum}`;
+          return { number: issueNum, repo: storyRepo, ref, title: story.title, depends_on: story.depends_on };
+        });
+        const result: Record<string, unknown> = { ...wave, id, issues };
+        delete result.name;
+        delete result.stories;
+        return result;
+      }),
+    };
+  });
+
+  return JSON.stringify(transformed);
+}
+
 export function countIssuesFromPlan(plan: PlanData): {
   phases_added: number;
   waves_added: number;


### PR DESCRIPTION
## Summary

`wave_init` now auto-detects the `/devspec upshift` plan schema and transforms it to the `wave-status init` expected shape before persisting. Plans already in the correct format pass through unchanged.

## Changes

- Add `normalizePlanJson()` in `lib/wave_init_plan.ts` — detects upshift shape (`waves[].name` + `waves[].stories[]`) and transforms to wave-status shape (`waves[].id` + `waves[].issues[]` + `project`)
- Wire normalizer into `handlers/wave_init.ts` — runs before extend-mode prescan and plan persist
- Add 7 unit tests covering: transform, passthrough, cross-repo stories, multi-phase, invalid JSON, missing phases, repo slug injection

## Linked Issues

Closes #438

## Test Plan

- `bun test lib/wave_init_plan.test.ts` — 7/7 pass (normalizer unit tests)
- `bun test tests/wave_init.test.ts` — 36/36 pass (handler integration tests)
- Full suite: 2299 pass (4 pre-existing wave_finalize failures unrelated)