### PR TITLE
fix(wave_init): expose force param to allow plan overwrite (#439)

### DIFF
--- a/handlers/wave_init.ts
+++ b/handlers/wave_init.ts
@@ -41,6 +41,7 @@ import { repoOptionalSchema } from '../lib/schemas/repo.js';
 const inputSchema = z.object({
   plan_json: z.string().min(1, 'plan_json must be a non-empty JSON string'),
   extend: z.boolean().optional().default(false),
+  force: z.boolean().optional().default(false),
   project_root: z.string().optional(),
   // GitLab nested groups need arbitrary `/` depth — see lib/schemas/repo.ts (#290).
   repo: repoOptionalSchema,
@@ -112,8 +113,9 @@ const waveInitHandler: HandlerDef = {
       // ---- Step 3: persist plan to disk -----------------------------------
       const planFile = writePlanFile(args.plan_json);
       const extendFlag = args.extend ? ' --extend' : '';
+      const forceFlag = args.force ? ' --force' : '';
       const repoFlag = args.repo ? ` --repo ${shellQuote(args.repo)}` : '';
-      execSync(`wave-status init${extendFlag}${repoFlag} ${planFile}`, { cwd, encoding: 'utf8' });
+      execSync(`wave-status init${extendFlag}${forceFlag}${repoFlag} ${planFile}`, { cwd, encoding: 'utf8' });
 
       const counts = countIssuesFromPlan(plan);
       const totals = await readPhasesWavesTotals(cwd);

--- a/tests/wave_init.test.ts
+++ b/tests/wave_init.test.ts
@@ -808,4 +808,24 @@ describe('wave_init handler', () => {
     expect(typeof parsed.error).toBe('string');
     expect(mockExecSync.mock.calls.length).toBe(0);
   });
+
+  test('force_param — passes --force flag to wave-status init', async () => {
+    await setupStatusFixture(null);
+    const planJson = JSON.stringify({ project: 'org/repo', phases: [] });
+    const result = await handler.execute({ plan_json: planJson, force: true });
+    expect(lastExecCall).toContain('wave-status init');
+    expect(lastExecCall).toContain('--force');
+    expect(lastExecCall).not.toContain('--extend');
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+  });
+
+  test('force_param — not present when force is false/omitted', async () => {
+    await setupStatusFixture(null);
+    const planJson = JSON.stringify({ project: 'org/repo', phases: [] });
+    const result = await handler.execute({ plan_json: planJson });
+    expect(lastExecCall).not.toContain('--force');
+    const parsed = parseResult(result);
+    expect(parsed.ok).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Adds `force: boolean` to `wave_init`'s schema and passes `--force` through to `wave-status init`, unblocking the `/devspec upshift → /wavemachine` chain when `phases-waves.json` already exists.

## Changes

- Add `force: z.boolean().optional().default(false)` to `wave_init` input schema
- Pass `--force` flag to `wave-status init` CLI when set
- Add 2 tests: flag present when force=true, flag absent when omitted

## Linked Issues

Closes #439

## Test Plan

- `bun test tests/wave_init.test.ts` — 38/38 pass
- TypeScript check clean