### PR TITLE
fix(pr-merge-gitlab): silently drop skip_train instead of returning platform_unsupported (#423)

### DIFF
--- a/lib/adapters/pr-merge-gitlab.test.ts
+++ b/lib/adapters/pr-merge-gitlab.test.ts
@@ -3,12 +3,6 @@ import type { AdapterResult, PrMergeResponse } from './types.ts';
 
 // Subprocess-boundary tests for the GitLab pr_merge adapter (R-15).
 // Integration-level coverage stays in tests/pr_merge.test.ts.
-//
-// **R-03 typed-asymmetry exemplar lives here.** The headline test
-// (`skip_train returns platform_unsupported`) is the load-bearing case
-// that justified the entire platform-adapter retrofit — pre-#247, the
-// flag was silently ignored on GitLab; post-#247, the asymmetry is a
-// typed signal callers can branch on.
 
 interface ThrowableError extends Error {
   stderr?: string;
@@ -61,14 +55,6 @@ function expectErr(
   }
 }
 
-function expectPlatformUnsupported(
-  r: AdapterResult<PrMergeResponse>,
-): asserts r is { platform_unsupported: true; hint: string } {
-  if (!('platform_unsupported' in r)) {
-    throw new Error(`expected platform_unsupported result, got ${JSON.stringify(r)}`);
-  }
-}
-
 function findCall(needle: string): string {
   return execCalls.find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
 }
@@ -118,29 +104,47 @@ describe('prMergeGitlab — subprocess boundary', () => {
     expect(execCalls.find((c) => c.includes('gh api graphql'))).toBeUndefined();
   });
 
-  // ===========================================================================
-  // R-03 TYPED-ASYMMETRY EXEMPLAR — the headline test for the entire retrofit
-  // ===========================================================================
-  test('skip_train returns platform_unsupported (R-03 typed asymmetry exemplar)', async () => {
-    const result = await prMergeGitlab({ number: 9, skip_train: true });
-    expectPlatformUnsupported(result);
-    expect(result.platform_unsupported).toBe(true);
-    expect(result.hint).toBe(
-      'merge trains are auto-managed by GitLab; skip_train is GitHub-merge-queue-only',
+  test('skip_train is silently dropped — merge proceeds with warning (#423)', async () => {
+    on('glab mr merge 9 --squash --remove-source-branch --yes', '');
+    on(
+      'glab api projects/org%2Frepo/merge_requests/9',
+      JSON.stringify({
+        iid: 9,
+        state: 'merged',
+        source_branch: 'feature/train',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/9',
+        labels: [],
+        merge_commit_sha: 'abc123def456',
+      }),
     );
-    // Critical: NO subprocess work should have happened — the asymmetry
-    // is detected before any glab invocation.
-    expect(execCalls.length).toBe(0);
+
+    const result = await prMergeGitlab({ number: 9, skip_train: true, repo: 'org/repo' });
+    expectOk(result);
+    expect(result.data.merged).toBe(true);
+    expect(result.data.warnings).toContain(
+      'skip_train ignored on GitLab — merge trains are auto-managed at the project level',
+    );
   });
 
-  test('skip_train guard fires before slug parsing / repo resolution', async () => {
-    const result = await prMergeGitlab({
-      number: 1,
-      skip_train: true,
-      repo: 'org/repo',
-    });
-    expectPlatformUnsupported(result);
-    expect(execCalls.length).toBe(0);
+  test('skip_train omitted — no warning in response', async () => {
+    on('glab mr merge 10 --squash --remove-source-branch --yes', '');
+    on(
+      'glab api projects/org%2Frepo/merge_requests/10',
+      JSON.stringify({
+        iid: 10,
+        state: 'merged',
+        source_branch: 'feature/no-train',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/10',
+        labels: [],
+        merge_commit_sha: 'deadbeef0000',
+      }),
+    );
+
+    const result = await prMergeGitlab({ number: 10, repo: 'org/repo' });
+    expectOk(result);
+    expect(result.data.warnings).toEqual([]);
   });
 
   test('returns AdapterResult{ok:false, code} on glab failure (not thrown)', async () => {

--- a/lib/adapters/pr-merge-gitlab.ts
+++ b/lib/adapters/pr-merge-gitlab.ts
@@ -5,14 +5,11 @@
  * `pr-merge-github.ts` — the handler dispatches to either depending on cwd
  * platform.
  *
- * **Typed asymmetry exemplar (R-03).** `args.skip_train === true` returns
- * `{platform_unsupported: true, hint: ...}` — the HEADLINE behavior the entire
- * platform-adapter retrofit was built around. GitLab has merge trains, but
- * they are auto-managed at the project level — there is no caller-side
- * control equivalent to GitHub's merge queue + skip_train. Pre-retrofit, the
- * handler accepted the flag and silently swallowed it; the typed asymmetry
- * signal closes that leak so MCP callers can branch on the discriminator
- * instead of being lied to.
+ * `skip_train` is silently dropped (#423): GitLab merge trains are
+ * auto-managed at the project level — there is no caller-side equivalent to
+ * GitHub's merge queue + skip_train. Callers pass the flag unconditionally
+ * and the adapter proceeds with the merge, surfacing a warning in the
+ * response rather than short-circuiting with `platform_unsupported`.
  *
  * Story 1.11 (#248) routes the post-merge state lookup through
  * `getAdapter().fetchPrState(...)` — the FIRST hybrid sub-call dispatched
@@ -89,18 +86,11 @@ function buildGitlabMergeCommand(
 export async function prMergeGitlab(
   args: PrMergeArgs,
 ): Promise<AdapterResult<PrMergeResponse>> {
-  // R-03 typed-asymmetry exemplar: `skip_train` is meaningless on GitLab
-  // (merge trains are auto-managed at the project level — no caller-side
-  // control equivalent to GitHub's merge queue + skip_train). Surface the
-  // asymmetry as a typed signal so MCP callers can branch on the discriminator
-  // instead of being lied to with a fake "merged: true". See Dev Spec §4.4
-  // step 4 + the issue #247 description.
-  if (args.skip_train === true) {
-    return {
-      platform_unsupported: true,
-      hint: 'merge trains are auto-managed by GitLab; skip_train is GitHub-merge-queue-only',
-    };
-  }
+  // #423: `skip_train` is meaningless on GitLab (merge trains are
+  // auto-managed at the project level). Silently drop it and proceed with the
+  // merge — callers pass the flag unconditionally and expect the adapter to
+  // handle the asymmetry without short-circuiting.
+  const skippedTrain = args.skip_train === true;
 
   try {
     // GitLab has no merge-queue concept; queue stays empty.
@@ -140,7 +130,9 @@ export async function prMergeGitlab(
         pr_state: info.state === 'merged' ? 'MERGED' : 'OPEN',
         url: info.url,
         merge_commit_sha: info.mergeCommitSha,
-        warnings: [],
+        warnings: skippedTrain
+          ? ['skip_train ignored on GitLab — merge trains are auto-managed at the project level']
+          : [],
         // GitLab has no queue concept — queue_fallback always false. Required
         // by PrMergeResponse since bug #280 / #294 added the field.
         queue_fallback: false,

--- a/lib/adapters/pr-merge-wait-gitlab.test.ts
+++ b/lib/adapters/pr-merge-wait-gitlab.test.ts
@@ -144,22 +144,22 @@ describe('prMergeWaitGitlab — adapter orchestration (parity)', () => {
     expect(clock.sleepCount()).toBe(0);
   });
 
-  test('skip_train propagates platform_unsupported from prMerge as ok:false', async () => {
-    // GitLab's prMerge returns platform_unsupported for skip_train (R-03 typed
-    // asymmetry). pr_merge_wait can't proceed, so it surfaces this as ok:false
-    // with a descriptive code/error. Pre-state fetch happens first so we stub
-    // an OPEN MR.
-    on(
-      'glab api projects/org%2Frepo/merge_requests/55',
-      JSON.stringify({
+  test('skip_train is silently dropped — merge proceeds with warning (#423)', async () => {
+    let viewCalls = 0;
+    on('glab api projects/org%2Frepo/merge_requests/55', () => {
+      viewCalls += 1;
+      const merged = viewCalls >= 2;
+      return JSON.stringify({
         iid: 55,
-        state: 'opened',
+        state: merged ? 'merged' : 'opened',
         source_branch: 'feature/x',
         target_branch: 'main',
         web_url: 'https://gitlab.com/org/repo/-/merge_requests/55',
         labels: [],
-      }),
-    );
+        merge_commit_sha: merged ? 'skip55abc' : null,
+      });
+    });
+    on('glab mr merge 55 --squash --remove-source-branch --yes', '');
 
     const result = await prMergeWaitGitlab({
       number: 55,
@@ -167,9 +167,11 @@ describe('prMergeWaitGitlab — adapter orchestration (parity)', () => {
       skip_train: true,
     });
 
-    expectErr(result);
-    expect(result.error).toContain('platform_unsupported');
-    expect(result.error).toContain('merge trains');
+    expectOk(result);
+    expect(result.data.merged).toBe(true);
+    expect(result.data.warnings).toContain(
+      'skip_train ignored on GitLab — merge trains are auto-managed at the project level',
+    );
   });
 
   test('pr_merge failure propagates unchanged', async () => {


### PR DESCRIPTION
## Summary

`pr_merge({skip_train: true})` on GitLab was returning `platform_unsupported` and skipping the merge entirely, breaking `/wavemachine`'s unconditional `skip_train: true` pass-through. The adapter now silently drops the flag, proceeds with the merge, and surfaces a warning in the response.

## Changes

- Remove early `platform_unsupported` return for `skip_train` in `pr-merge-gitlab.ts`
- Capture `skip_train` presence and add descriptive warning to the response `warnings[]` array
- Update `pr-merge-gitlab.test.ts` to verify merge proceeds with warning when flag is set
- Update `pr-merge-wait-gitlab.test.ts` to verify the warning propagates through the wait path

## Linked Issues

Closes #423

## Test Plan

- `bun test lib/adapters/pr-merge-gitlab.test.ts` — 6 pass
- `bun test lib/adapters/pr-merge-wait-gitlab.test.ts` — 5 pass
- `bun test lib/adapters/` — 638 pass, 0 fail
- Full validation: 2301 pass, 4 pre-existing wave_finalize failures (#415)