### PR TITLE
fix(ibm): distinguish unrecognized-prefix from missing-issue errors

### DIFF
--- a/handlers/ibm.ts
+++ b/handlers/ibm.ts
@@ -11,7 +11,17 @@ import type { HandlerDef } from '../types.js';
 import { getAdapter } from '../lib/adapters/index.js';
 
 const inputSchema = z.object({ branch: z.string().optional() });
-const BRANCH_PATTERN = /^(feature|fix|chore|doc|bug|kahuna)\/(\d+)-/;
+
+// Single source of truth for the allowed branch prefixes — the regex and the
+// error message are both derived from this list so they can never drift apart.
+// Prefixes are SINGULAR (the prefix names the topic, not the file type):
+// `doc/` not `docs/`. A plural/unknown prefix is the most common mistake (#448),
+// and it must report as an unrecognized-prefix error, NOT "no linked issue" —
+// the regex fails before any issue lookup runs, so the issue/work-item framework
+// is never involved.
+const BRANCH_PREFIXES = ['feature', 'fix', 'chore', 'doc', 'bug', 'kahuna'] as const;
+const BRANCH_PATTERN = new RegExp(`^(${BRANCH_PREFIXES.join('|')})\\/(\\d+)-`);
+const BRANCH_FORMAT_HINT = `(${BRANCH_PREFIXES.join('|')})/NNN-description (prefixes are singular — e.g. 'doc/' not 'docs/')`;
 const PROTECTED_PATTERN = /^(main|release\/.+)$/;
 
 function envelope(payload: unknown) {
@@ -34,14 +44,18 @@ const ibmHandler: HandlerDef = {
     if (PROTECTED_PATTERN.test(branch)) {
       return envelope({
         ok: false,
-        error: `Branch '${branch}' is protected — create a feature/fix/chore/docs branch from main.`,
+        error: `Branch '${branch}' is protected — create a branch from main named ${BRANCH_FORMAT_HINT}`,
       });
     }
     const match = BRANCH_PATTERN.exec(branch);
     if (!match) {
+      // Unrecognized prefix or missing issue number — the branch name itself is
+      // malformed. This is NOT an issue-linkage failure: no issue lookup runs.
+      // Naming the expected format (and the singular-prefix rule) here avoids
+      // misdirecting the caller toward a non-existent issue/work-item problem.
       return envelope({
         ok: false,
-        error: 'Branch has no linked issue. Name format: type/NNN-description',
+        error: `Branch '${branch}' has an unrecognized prefix or missing issue number. Expected: ${BRANCH_FORMAT_HINT}`,
       });
     }
 
@@ -49,7 +63,15 @@ const ibmHandler: HandlerDef = {
     const adapter = getAdapter();
     const issueResult = await adapter.fetchIssue({ number: issueNumber });
     if ('platform_unsupported' in issueResult) return envelope({ ok: false, error: issueResult.hint });
-    if (!issueResult.ok) return envelope({ ok: false, error: issueResult.error });
+    // Well-formed branch, but the referenced issue could not be read (missing,
+    // not linked, or a transient lookup failure). Name the parsed number so the
+    // caller knows which issue and that the branch format was accepted.
+    if (!issueResult.ok) {
+      return envelope({
+        ok: false,
+        error: `Branch '${branch}' references issue #${issueNumber}, but the lookup failed: ${issueResult.error}`,
+      });
+    }
     const issue = issueResult.data;
 
     if (issue.state !== 'OPEN') {

--- a/tests/ibm.test.ts
+++ b/tests/ibm.test.ts
@@ -41,6 +41,9 @@ describe('ibm handler', () => {
 
     expect(data.ok).toBe(false);
     expect((data.error as string)).toContain("protected");
+    // #448: the protected-branch guidance must use the singular convention too
+    // (it previously hardcoded plural 'docs', contradicting the regex path).
+    expect((data.error as string)).toContain("'doc/' not 'docs/'");
   });
 
   // --- protected_branch_release ---
@@ -55,14 +58,18 @@ describe('ibm handler', () => {
   });
 
   // --- no_issue_in_branch ---
-  test('no_issue_in_branch — branch without issue number returns error', async () => {
+  test('no_issue_in_branch — branch without issue number returns unrecognized-prefix error', async () => {
     execRegistry['git branch --show-current'] = 'feat-no-number';
 
     const result = await ibmHandler.execute({});
     const data = parseResult(result.content);
 
     expect(data.ok).toBe(false);
-    expect(data.error).toBe('Branch has no linked issue. Name format: type/NNN-description');
+    // Distinct from an issue-linkage failure (#448): name the format + branch.
+    expect(data.error as string).toContain("Branch 'feat-no-number'");
+    expect(data.error as string).toContain('unrecognized prefix or missing issue number');
+    expect(data.error as string).toContain("'doc/' not 'docs/'");
+    expect(data.error as string).not.toContain('no linked issue');
   });
 
   // --- issue_open ---
@@ -171,15 +178,39 @@ describe('ibm handler', () => {
     }
   });
 
-  // --- plural docs/ rejected (regression guard for #381) ---
-  test('plural_docs_rejected — docs/ (plural) returns no-issue error', async () => {
+  // --- plural docs/ rejected (regression guard for #381, message clarity #448) ---
+  test('plural_docs_rejected — docs/ (plural) returns unrecognized-prefix error, not a linkage error', async () => {
     execRegistry['git branch --show-current'] = 'docs/42-some-doc';
 
     const result = await ibmHandler.execute({});
     const data = parseResult(result.content);
 
     expect(data.ok).toBe(false);
-    expect(data.error).toBe('Branch has no linked issue. Name format: type/NNN-description');
+    // #448: a plural/unknown prefix must read as a branch-name problem, not as
+    // "no linked issue" — that misdirection sent an agent chasing work-items.
+    expect(data.error as string).toContain('unrecognized prefix');
+    expect(data.error as string).toContain("'doc/' not 'docs/'");
+    // The regex fails before any issue lookup — no fetchIssue call is registered.
+    expect(data.error as string).not.toContain('no linked issue');
+  });
+
+  // --- issue-not-found is distinct from an unrecognized prefix (#448) ---
+  test('issue_lookup_failed — well-formed branch names the parsed issue number on lookup failure', async () => {
+    const branch = 'feature/77-missing-issue';
+    execRegistry['git branch --show-current'] = branch;
+    execRegistry['git remote get-url origin'] = 'https://github.com/org/repo.git';
+    // 'gh issue view 77' is deliberately NOT registered → the adapter's
+    // execSync throws, fetchIssueGithub bounds it into { ok:false }, and the
+    // handler surfaces the issue-specific message.
+
+    const result = await ibmHandler.execute({});
+    const data = parseResult(result.content);
+
+    expect(data.ok).toBe(false);
+    // Issue-specific message: names #77 and signals the branch format was accepted.
+    expect(data.error as string).toContain('references issue #77');
+    expect(data.error as string).toContain('lookup failed');
+    expect(data.error as string).not.toContain('unrecognized prefix');
   });
 
   // --- gitlab platform ---


### PR DESCRIPTION
## Summary

`ibm` reported a malformed branch name (wrong/plural prefix like `docs/`, or missing `NNN`) with `Branch has no linked issue` — pointing at issue linkage when the branch regex had failed *before* any issue lookup ran. That misdirected an agent into chasing a non-existent GitLab work-item bug (#448).

## Changes

- Derive `BRANCH_PATTERN` and the error hint from one `BRANCH_PREFIXES` constant so the regex and the message can never drift apart.
- Regex non-match → unrecognized-prefix/missing-number message naming the allowed singular prefixes (`doc/` not `docs/`).
- Issue-lookup failure → issue-specific message naming the parsed `#NNN`, signalling the branch format was accepted.
- Protected-branch guidance no longer hardcodes plural `docs` — reuses the same singular hint (caught in review; it leaked the exact misdirection this change removes).

## Linked Issues

Closes #448

## Test Plan

- `bun test tests/ibm.test.ts` → 11 pass (added `issue_lookup_failed`; updated `no_issue_in_branch`, `plural_docs_rejected`, `protected_branch_main`).
- Full `bun test` → 2302 pass; only the pre-existing #415 `wave_finalize` cluster fails locally (CI-green).
- `tsc --noEmit`, codegen, gate-greps → clean.

Follow-ups filed: #449 (reconcile canonical prefix set across CLAUDE.md / ibm / wave-reconcile), #450 (fast-uri HIGH CVE dep-bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)