### PR TITLE
feat(branch_guard): guard base/target vs live default + protection

### DIFF
--- a/handlers/branch_guard.ts
+++ b/handlers/branch_guard.ts
@@ -1,0 +1,181 @@
+// branch_guard — catch "based-on / merging-into the wrong mainline" (#465).
+//
+// Queries the git HOST LIVE for (a) the default branch and (b) whether a branch
+// is protected, then verdicts a base/target branch. Never trusts a cached
+// `.claude-project.md` value and never uses `git symbolic-ref origin/HEAD` — a
+// stale cached default is exactly the failure this tool exists to catch.
+//
+// Adapter-dispatching shell, mirroring handlers/pr_create.ts: platform-specific
+// work lives in the adapter (`resolveDefaultBranch`, `checkBranchProtected`,
+// `prList`); this handler owns only the platform-agnostic verdict logic.
+
+import { z } from 'zod';
+import type { HandlerDef } from '../types.js';
+import { getAdapter } from '../lib/adapters/index.js';
+import { repoOptionalSchema } from '../lib/schemas/repo.js';
+import { runArgv } from '../lib/shared/error-norm.js';
+
+// Kahuna per-wave integration branches (e.g. `kahuna/854-flightdeck`). These
+// are themselves protected, so the sandbox carve-out MUST be applied before the
+// protected gate — otherwise every legitimate kahuna base would falsely warn.
+const KAHUNA_SANDBOX = /^kahuna\/[0-9]+-/;
+
+const inputSchema = z.object({
+  role: z.enum(['base', 'target']),
+  // Optional: the branch to verdict. Omitted `target` → the live default (a PR
+  // that omits base targets the default); omitted `base` → inferred from the
+  // current branch's open PR.
+  branch: z.string().min(1).optional(),
+  repo: repoOptionalSchema,
+});
+
+function envelope(payload: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload) }] };
+}
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+/** Current branch via `git branch --show-current`; '' on failure/detached HEAD. */
+function currentBranch(cwd: string): string {
+  const r = runArgv(['git', 'branch', '--show-current'], cwd);
+  return r.exitCode === 0 ? r.stdout.trim() : '';
+}
+
+const branchGuardHandler: HandlerDef = {
+  name: 'branch_guard',
+  description:
+    "Guard against basing on / merging into the wrong mainline. Queries the git host LIVE for the default branch and branch-protection status, then verdicts a base/target branch. Returns {verdict: 'pass'|'warn', reason, default_branch, checked_branch, is_protected, is_sandbox}. A protected branch that is neither the live default nor a kahuna/* sandbox → warn.",
+  inputSchema,
+  async execute(rawArgs: unknown) {
+    let args;
+    try {
+      args = inputSchema.parse(rawArgs);
+    } catch (err) {
+      return envelope({ ok: false, error: err instanceof Error ? err.message : String(err) });
+    }
+
+    const adapter = getAdapter({ repo: args.repo });
+    const cwd = projectDir();
+
+    // Live default branch — required for the envelope AND the B===default
+    // comparison. Never a cached value.
+    const defRes = await adapter.resolveDefaultBranch({ repo: args.repo, cwd });
+    if ('platform_unsupported' in defRes) {
+      return envelope({ ok: false, error: `default-branch resolution unsupported: ${defRes.hint}` });
+    }
+    if (!defRes.ok) return envelope({ ok: false, error: defRes.error });
+    const default_branch = defRes.data.default_branch;
+
+    // -- Resolve B, the branch to verdict --------------------------------------
+    let checked_branch: string;
+    if (args.role === 'target') {
+      // A PR that omits base targets the live default (passes trivially); an
+      // explicit target is verdicted directly.
+      checked_branch = args.branch ?? default_branch;
+    } else {
+      // role === 'base'. Prefer the authoritative signal — the open PR's base
+      // for the current branch (reliable). `prList({head})` returns the base as
+      // `.base`, so no dedicated adapter method is needed.
+      const explicit = args.branch;
+      if (explicit !== undefined) {
+        checked_branch = explicit;
+      } else {
+        const cur = currentBranch(cwd);
+        let prBase: string | null = null;
+        if (cur.length > 0) {
+          const listRes = await adapter.prList({ head: cur, state: 'open', limit: 1, repo: args.repo });
+          if (!('platform_unsupported' in listRes) && listRes.ok && listRes.data.prs.length > 0) {
+            prBase = listRes.data.prs[0].base;
+          }
+        }
+        if (prBase === null) {
+          // No open PR — the fork base cannot be reliably named pre-PR. Return a
+          // deliberate PASS (never a spurious warn: a false warn here would block
+          // every precheck). The /scp target guard catches a wrong target at
+          // PR-creation time.
+          return envelope({
+            ok: true,
+            verdict: 'pass',
+            reason:
+              cur.length > 0
+                ? `No open PR for '${cur}'; the fork base cannot be reliably determined pre-PR — pass (the /scp target guard catches a wrong target at creation).`
+                : 'Current branch could not be determined (detached HEAD?); base cannot be verified pre-PR — pass.',
+            default_branch,
+            checked_branch: cur,
+            is_protected: false,
+            is_sandbox: cur.length > 0 ? KAHUNA_SANDBOX.test(cur) : false,
+          });
+        }
+        checked_branch = prBase;
+      }
+    }
+
+    // -- Verdict (ORDER IS LOAD-BEARING) --------------------------------------
+    const B = checked_branch;
+
+    // (2) Sandbox carve-out — BEFORE the protected gate. Kahuna sandbox branches
+    //     are legitimate integration bases/targets and are themselves protected,
+    //     so applying the protected gate first would falsely warn.
+    if (KAHUNA_SANDBOX.test(B)) {
+      return envelope({
+        ok: true,
+        verdict: 'pass',
+        reason: `Branch '${B}' is a kahuna/* sandbox integration branch — always a legitimate base/target.`,
+        default_branch,
+        checked_branch: B,
+        // Kahuna sandbox branches are protected by policy; reported without a
+        // live query because the sandbox carve-out short-circuits the gate.
+        is_protected: true,
+        is_sandbox: true,
+      });
+    }
+
+    // (3) Protected gate — resolve is_protected LIVE from the host.
+    const protRes = await adapter.checkBranchProtected({ branch: B, repo: args.repo, cwd });
+    if ('platform_unsupported' in protRes) {
+      return envelope({ ok: false, error: `protected-branch check unsupported: ${protRes.hint}` });
+    }
+    if (!protRes.ok) return envelope({ ok: false, error: protRes.error });
+    const is_protected = protRes.data.protected;
+
+    if (!is_protected) {
+      return envelope({
+        ok: true,
+        verdict: 'pass',
+        reason: `Branch '${B}' is not a protected branch — no mainline-guard opinion (feature→feature / stacked branches are legitimate).`,
+        default_branch,
+        checked_branch: B,
+        is_protected: false,
+        is_sandbox: false,
+      });
+    }
+
+    // (4) Protected AND the live default → pass.
+    if (B === default_branch) {
+      return envelope({
+        ok: true,
+        verdict: 'pass',
+        reason: `Branch '${B}' is the live default branch.`,
+        default_branch,
+        checked_branch: B,
+        is_protected: true,
+        is_sandbox: false,
+      });
+    }
+
+    // (5) Protected, non-default, non-sandbox → warn.
+    return envelope({
+      ok: true,
+      verdict: 'warn',
+      reason: `Branch '${B}' is a protected branch but not the live default '${default_branch}' and not a kahuna/* sandbox — likely a stale or renamed base/target. Confirm before proceeding.`,
+      default_branch,
+      checked_branch: B,
+      is_protected: true,
+      is_sandbox: false,
+    });
+  },
+};
+
+export default branchGuardHandler;

--- a/handlers/branch_guard.ts
+++ b/handlers/branch_guard.ts
@@ -46,7 +46,7 @@ function currentBranch(cwd: string): string {
 const branchGuardHandler: HandlerDef = {
   name: 'branch_guard',
   description:
-    "Guard against basing on / merging into the wrong mainline. Queries the git host LIVE for the default branch and branch-protection status, then verdicts a base/target branch. Returns {verdict: 'pass'|'warn', reason, default_branch, checked_branch, is_protected, is_sandbox}. A protected branch that is neither the live default nor a kahuna/* sandbox → warn.",
+    "Guard against basing on / merging into the wrong mainline. Queries the git host LIVE for the default branch and branch-protection status, then verdicts a base/target branch. Protection is detected across exact-name AND wildcard/ruleset rules — GitHub via classic branch protection plus repository rulesets (gh api rules/branches/<branch>); GitLab via wildcard-aware matching of the protected_branches list — so an LTS branch protected only by a glob like release/* is caught. Returns {verdict: 'pass'|'warn', reason, default_branch, checked_branch, is_protected, is_sandbox}. A protected branch that is neither the live default nor a kahuna/* sandbox → warn.",
   inputSchema,
   async execute(rawArgs: unknown) {
     let args;

--- a/lib/adapters/check-branch-protected-github.test.ts
+++ b/lib/adapters/check-branch-protected-github.test.ts
@@ -1,0 +1,106 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+import {
+  installChildProcessMock,
+  onExec,
+  resetExecMock,
+  execCalls,
+} from '../test-support/mock-child-process.ts';
+import type { AdapterResult, CheckBranchProtectedResponse } from './types.ts';
+
+// Subprocess-boundary tests for the GitHub checkBranchProtected adapter (#465).
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  status?: number;
+}
+
+installChildProcessMock();
+
+const { checkBranchProtectedGithub } = await import('./check-branch-protected-github.ts');
+
+function expectOk(
+  r: AdapterResult<CheckBranchProtectedResponse>,
+): asserts r is { ok: true; data: CheckBranchProtectedResponse } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+function findCall(needle: string): string {
+  const raw = execCalls().find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+  return unquote(raw);
+}
+
+function fail404(match: string): void {
+  onExec(match, () => {
+    const e = new Error('not found') as ThrowableError;
+    e.stderr = 'gh: Not Found (HTTP 404)';
+    e.status = 1;
+    throw e;
+  });
+}
+
+beforeEach(() => {
+  resetExecMock();
+});
+
+describe('checkBranchProtectedGithub — subprocess boundary', () => {
+  test('HTTP 200 ⇒ protected', async () => {
+    onExec('branches/main/protection', JSON.stringify({ required_status_checks: { strict: true } }));
+
+    const r = await checkBranchProtectedGithub({ branch: 'main', repo: 'org/repo' });
+    expectOk(r);
+    expect(r.data.protected).toBe(true);
+
+    const call = findCall('/protection');
+    expect(call).toContain('gh api');
+    expect(call).toContain('repos/org/repo/branches/main/protection');
+  });
+
+  test('HTTP 404 ⇒ not protected', async () => {
+    fail404('/protection');
+
+    const r = await checkBranchProtectedGithub({ branch: 'release-legacy', repo: 'org/repo' });
+    expectOk(r);
+    expect(r.data.protected).toBe(false);
+  });
+
+  test('non-404 failure ⇒ ok:false (does NOT collapse to unprotected)', async () => {
+    onExec('/protection', () => {
+      const e = new Error('bad creds') as ThrowableError;
+      e.stderr = 'gh: Bad credentials (HTTP 401)';
+      e.status = 1;
+      throw e;
+    });
+
+    const r = await checkBranchProtectedGithub({ branch: 'main', repo: 'org/repo' });
+    expect('ok' in r && r.ok).toBe(false);
+    expect((r as { code: string }).code).toBe('gh_protection_check_failed');
+  });
+
+  test('omitted repo uses {owner}/{repo} placeholders', async () => {
+    onExec('/protection', JSON.stringify({}));
+
+    const r = await checkBranchProtectedGithub({ branch: 'main' });
+    expectOk(r);
+    expect(findCall('/protection')).toContain('repos/{owner}/{repo}/branches/main/protection');
+  });
+
+  test('rejects invalid branch characters (no exec)', async () => {
+    const r = await checkBranchProtectedGithub({ branch: 'bad; rm -rf /', repo: 'org/repo' });
+    expect('ok' in r && r.ok).toBe(false);
+    expect((r as { code: string }).code).toBe('invalid_branch');
+    expect(execCalls().length).toBe(0);
+  });
+
+  test('rejects invalid repo slug (no exec)', async () => {
+    const r = await checkBranchProtectedGithub({ branch: 'main', repo: 'no-slash' });
+    expect('ok' in r && r.ok).toBe(false);
+    expect((r as { code: string }).code).toBe('invalid_repo');
+    expect(execCalls().length).toBe(0);
+  });
+});

--- a/lib/adapters/check-branch-protected-github.test.ts
+++ b/lib/adapters/check-branch-protected-github.test.ts
@@ -61,18 +61,48 @@ describe('checkBranchProtectedGithub — subprocess boundary', () => {
     expect(call).toContain('repos/org/repo/branches/main/protection');
   });
 
-  test('HTTP 404 ⇒ not protected', async () => {
+  test('classic 404 + empty rulesets ⇒ not protected', async () => {
     fail404('/protection');
+    onExec('rules/branches/release-legacy', '[]');
 
     const r = await checkBranchProtectedGithub({ branch: 'release-legacy', repo: 'org/repo' });
     expectOk(r);
     expect(r.data.protected).toBe(false);
   });
 
-  test('non-404 failure ⇒ ok:false (does NOT collapse to unprotected)', async () => {
+  test('classic 404 + NON-empty rulesets ⇒ protected (wildcard/ruleset)', async () => {
+    // The LTS false-negative: no classic protection, but a `release/*` ruleset
+    // applies. The effective-rules endpoint returns a non-empty array.
+    fail404('/protection');
+    onExec('rules/branches/release-0.0.1', JSON.stringify([{ type: 'pull_request' }]));
+
+    const r = await checkBranchProtectedGithub({ branch: 'release-0.0.1', repo: 'org/repo' });
+    expectOk(r);
+    expect(r.data.protected).toBe(true);
+
+    const call = findCall('rules/branches/release-0.0.1');
+    expect(call).toContain('gh api');
+    expect(call).toContain('repos/org/repo/rules/branches/release-0.0.1');
+  });
+
+  test('non-404 failure on classic ⇒ ok:false (does NOT collapse to unprotected)', async () => {
     onExec('/protection', () => {
       const e = new Error('bad creds') as ThrowableError;
       e.stderr = 'gh: Bad credentials (HTTP 401)';
+      e.status = 1;
+      throw e;
+    });
+
+    const r = await checkBranchProtectedGithub({ branch: 'main', repo: 'org/repo' });
+    expect('ok' in r && r.ok).toBe(false);
+    expect((r as { code: string }).code).toBe('gh_protection_check_failed');
+  });
+
+  test('non-404 failure on the rulesets fallback ⇒ ok:false', async () => {
+    fail404('/protection');
+    onExec('rules/branches/main', () => {
+      const e = new Error('server error') as ThrowableError;
+      e.stderr = 'gh: HTTP 500';
       e.status = 1;
       throw e;
     });

--- a/lib/adapters/check-branch-protected-github.ts
+++ b/lib/adapters/check-branch-protected-github.ts
@@ -1,0 +1,84 @@
+/**
+ * GitHub `checkBranchProtected` adapter implementation (#465).
+ *
+ * The genuinely-new host query behind `branch_guard`: is a branch protected on
+ * GitHub? Generalizes the hardcoded-`main` branch-protection call in
+ * `fetch-ci-trust-signal-github.ts` to an arbitrary branch.
+ *
+ * Argv: `gh api repos/<slug>/branches/<branch>/protection`.
+ *  - HTTP 200 ⇒ the branch is protected.
+ *  - HTTP 404 ⇒ the branch is not protected (or has no protection rule).
+ *
+ * When no slug is provided the `{owner}/{repo}` placeholders resolve the repo
+ * from the cwd remote (a documented `gh api` feature). A non-404 failure
+ * (auth, network) surfaces as `{ok: false}` rather than being misreported as
+ * "not protected" — a false "unprotected" would silently downgrade the guard
+ * to `pass`.
+ */
+
+import { execSync } from 'child_process';
+import { runArgv } from '../shared/error-norm.js';
+import type {
+  AdapterResult,
+  CheckBranchProtectedArgs,
+  CheckBranchProtectedResponse,
+} from './types.js';
+
+const GITHUB_REPO_SLUG = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+const BRANCH_CHARSET = /^[A-Za-z0-9._\-/]+$/;
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+export async function checkBranchProtectedGithub(
+  args: CheckBranchProtectedArgs,
+): Promise<AdapterResult<CheckBranchProtectedResponse>> {
+  try {
+    if (!BRANCH_CHARSET.test(args.branch)) {
+      return {
+        ok: false,
+        code: 'invalid_branch',
+        error: `checkBranchProtectedGithub: invalid branch ${JSON.stringify(args.branch)}`,
+      };
+    }
+    if (args.repo !== undefined && !GITHUB_REPO_SLUG.test(args.repo)) {
+      return {
+        ok: false,
+        code: 'invalid_repo',
+        error: `checkBranchProtectedGithub: invalid repo slug ${JSON.stringify(args.repo)}`,
+      };
+    }
+
+    const slug = args.repo ?? '{owner}/{repo}';
+    const cmd = ['gh', 'api', `repos/${slug}/branches/${args.branch}/protection`];
+    const result = runArgv(cmd, args.cwd ?? projectDir());
+
+    if (result.exitCode === 0) {
+      return { ok: true, data: { protected: true } };
+    }
+
+    // 404 (incl. "Branch not protected") ⇒ not protected. Any other failure
+    // (auth, network) must NOT collapse to "unprotected".
+    const combined = `${result.stderr}\n${result.stdout}`.toLowerCase();
+    if (/404|not protected|not found/.test(combined)) {
+      return { ok: true, data: { protected: false } };
+    }
+    return {
+      ok: false,
+      code: 'gh_protection_check_failed',
+      error: `gh api branch protection failed: ${result.stderr.trim() || result.stdout.trim()}`,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'unexpected_error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// `execSync` is intentionally re-imported above so that adapter-level test
+// files can `mock.module('child_process', ...)` and intercept this module's
+// subprocess calls.
+void execSync;

--- a/lib/adapters/check-branch-protected-github.ts
+++ b/lib/adapters/check-branch-protected-github.ts
@@ -2,22 +2,32 @@
  * GitHub `checkBranchProtected` adapter implementation (#465).
  *
  * The genuinely-new host query behind `branch_guard`: is a branch protected on
- * GitHub? Generalizes the hardcoded-`main` branch-protection call in
- * `fetch-ci-trust-signal-github.ts` to an arbitrary branch.
+ * GitHub? Two sources, because neither alone is complete:
  *
- * Argv: `gh api repos/<slug>/branches/<branch>/protection`.
- *  - HTTP 200 ⇒ the branch is protected.
- *  - HTTP 404 ⇒ the branch is not protected (or has no protection rule).
+ *   1. Classic / exact-name branch protection —
+ *      `gh api repos/<slug>/branches/<branch>/protection` (200 ⇒ protected,
+ *      404 ⇒ no classic protection). This is the endpoint
+ *      `fetch-ci-trust-signal-github.ts` hardcoded to `main`.
+ *   2. Repository rulesets (fallback when classic 404s) —
+ *      `gh api repos/<slug>/rules/branches/<branch>`, the effective-rules-for-a-
+ *      branch endpoint that returns rules from ALL rulesets applying to the
+ *      branch, including WILDCARD rules like `release/*`. A NON-EMPTY array ⇒
+ *      protected; `[]` ⇒ genuinely unprotected.
+ *
+ * `protected = (classic == 200) OR (rules/branches/<branch> is a non-empty
+ * array)`. Checking classic alone missed a branch protected only by a wildcard
+ * ruleset (e.g. an LTS `release/0.0.1` guarded by `release/*`) — the exact
+ * scenario this guard exists to catch.
  *
  * When no slug is provided the `{owner}/{repo}` placeholders resolve the repo
- * from the cwd remote (a documented `gh api` feature). A non-404 failure
+ * from the cwd remote (a documented `gh api` feature). A NON-404 failure
  * (auth, network) surfaces as `{ok: false}` rather than being misreported as
  * "not protected" — a false "unprotected" would silently downgrade the guard
  * to `pass`.
  */
 
 import { execSync } from 'child_process';
-import { runArgv } from '../shared/error-norm.js';
+import { runArgv, type RunResult } from '../shared/error-norm.js';
 import type {
   AdapterResult,
   CheckBranchProtectedArgs,
@@ -29,6 +39,13 @@ const BRANCH_CHARSET = /^[A-Za-z0-9._\-/]+$/;
 
 function projectDir(): string {
   return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+/** A 404 / "not found" / "not protected" response — distinct from a real
+ * (auth/network) failure, which must NOT collapse to "unprotected". */
+function isNotFound(result: RunResult): boolean {
+  const combined = `${result.stderr}\n${result.stdout}`.toLowerCase();
+  return /404|not protected|not found/.test(combined);
 }
 
 export async function checkBranchProtectedGithub(
@@ -51,23 +68,49 @@ export async function checkBranchProtectedGithub(
     }
 
     const slug = args.repo ?? '{owner}/{repo}';
-    const cmd = ['gh', 'api', `repos/${slug}/branches/${args.branch}/protection`];
-    const result = runArgv(cmd, args.cwd ?? projectDir());
+    const cwd = args.cwd ?? projectDir();
 
-    if (result.exitCode === 0) {
+    // (1) Classic / exact-name branch protection.
+    const classic = runArgv(
+      ['gh', 'api', `repos/${slug}/branches/${args.branch}/protection`],
+      cwd,
+    );
+    if (classic.exitCode === 0) {
       return { ok: true, data: { protected: true } };
     }
+    if (!isNotFound(classic)) {
+      return {
+        ok: false,
+        code: 'gh_protection_check_failed',
+        error: `gh api branch protection failed: ${classic.stderr.trim() || classic.stdout.trim()}`,
+      };
+    }
 
-    // 404 (incl. "Branch not protected") ⇒ not protected. Any other failure
-    // (auth, network) must NOT collapse to "unprotected".
-    const combined = `${result.stderr}\n${result.stdout}`.toLowerCase();
-    if (/404|not protected|not found/.test(combined)) {
+    // (2) No classic protection → fall back to the effective rulesets for this
+    //     branch. Covers wildcard/ruleset protection the exact-name endpoint
+    //     404s on.
+    const rules = runArgv(
+      ['gh', 'api', `repos/${slug}/rules/branches/${args.branch}`],
+      cwd,
+    );
+    if (rules.exitCode === 0) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(rules.stdout);
+      } catch {
+        parsed = null;
+      }
+      const protectedByRules = Array.isArray(parsed) && parsed.length > 0;
+      return { ok: true, data: { protected: protectedByRules } };
+    }
+    // No rules apply (endpoint reports the branch as ruleless) → not protected.
+    if (isNotFound(rules)) {
       return { ok: true, data: { protected: false } };
     }
     return {
       ok: false,
       code: 'gh_protection_check_failed',
-      error: `gh api branch protection failed: ${result.stderr.trim() || result.stdout.trim()}`,
+      error: `gh api branch rules failed: ${rules.stderr.trim() || rules.stdout.trim()}`,
     };
   } catch (err) {
     return {

--- a/lib/adapters/check-branch-protected-gitlab.test.ts
+++ b/lib/adapters/check-branch-protected-gitlab.test.ts
@@ -1,0 +1,106 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+import {
+  installChildProcessMock,
+  setExecMock,
+  resetExecMock,
+  execCalls,
+} from '../test-support/mock-child-process.ts';
+import type { AdapterResult, CheckBranchProtectedResponse } from './types.ts';
+
+// Subprocess-boundary tests for the GitLab checkBranchProtected adapter (#465).
+// Drives the whole path including the `gitlabApiProtectedBranch` wrapper.
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  status?: number;
+}
+
+installChildProcessMock();
+
+const { checkBranchProtectedGitlab } = await import('./check-branch-protected-gitlab.ts');
+
+function expectOk(
+  r: AdapterResult<CheckBranchProtectedResponse>,
+): asserts r is { ok: true; data: CheckBranchProtectedResponse } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+const GITLAB_ORIGIN = 'https://gitlab.com/cwd-org/cwd-repo.git\n';
+
+beforeEach(() => {
+  resetExecMock();
+});
+
+describe('checkBranchProtectedGitlab — subprocess boundary', () => {
+  test('HTTP 200 ⇒ protected', async () => {
+    setExecMock((cmd: string) => {
+      if (cmd.includes('git remote get-url origin')) return GITLAB_ORIGIN;
+      if (cmd.includes('protected_branches')) return JSON.stringify({ name: 'main' });
+      return '';
+    });
+
+    const r = await checkBranchProtectedGitlab({ branch: 'main' });
+    expectOk(r);
+    expect(r.data.protected).toBe(true);
+  });
+
+  test('HTTP 404 ⇒ not protected', async () => {
+    setExecMock((cmd: string) => {
+      if (cmd.includes('git remote get-url origin')) return GITLAB_ORIGIN;
+      if (cmd.includes('protected_branches')) {
+        const e = new Error('nf') as ThrowableError;
+        e.stderr = '{"message":"404 Not Found"}';
+        e.status = 1;
+        throw e;
+      }
+      return '';
+    });
+
+    const r = await checkBranchProtectedGitlab({ branch: 'release/legacy' });
+    expectOk(r);
+    expect(r.data.protected).toBe(false);
+  });
+
+  test('non-404 failure ⇒ ok:false (does NOT collapse to unprotected)', async () => {
+    setExecMock((cmd: string) => {
+      if (cmd.includes('git remote get-url origin')) return GITLAB_ORIGIN;
+      if (cmd.includes('protected_branches')) {
+        const e = new Error('unauth') as ThrowableError;
+        e.stderr = '401 Unauthorized';
+        e.status = 1;
+        throw e;
+      }
+      return '';
+    });
+
+    const r = await checkBranchProtectedGitlab({ branch: 'main' });
+    expect('ok' in r && r.ok).toBe(false);
+    expect((r as { code: string }).code).toBe('glab_protection_check_failed');
+  });
+
+  test('URL-encodes an explicit slug into the protected_branches path', async () => {
+    let seen = '';
+    setExecMock((cmd: string) => {
+      if (cmd.includes('protected_branches')) {
+        seen = cmd;
+        return JSON.stringify({ name: 'main' });
+      }
+      if (cmd.includes('git remote get-url origin')) return GITLAB_ORIGIN;
+      return '';
+    });
+
+    const r = await checkBranchProtectedGitlab({ branch: 'main', repo: 'org/repo' });
+    expectOk(r);
+    expect(seen).toContain('projects/org%2Frepo/protected_branches/main');
+  });
+
+  test('rejects invalid branch characters (no exec)', async () => {
+    setExecMock(() => '');
+    const r = await checkBranchProtectedGitlab({ branch: 'bad; rm -rf /' });
+    expect('ok' in r && r.ok).toBe(false);
+    expect((r as { code: string }).code).toBe('invalid_branch');
+    expect(execCalls().length).toBe(0);
+  });
+});

--- a/lib/adapters/check-branch-protected-gitlab.test.ts
+++ b/lib/adapters/check-branch-protected-gitlab.test.ts
@@ -34,10 +34,10 @@ beforeEach(() => {
 });
 
 describe('checkBranchProtectedGitlab — subprocess boundary', () => {
-  test('HTTP 200 ⇒ protected', async () => {
+  test('exact-name entry in the list ⇒ protected', async () => {
     setExecMock((cmd: string) => {
       if (cmd.includes('git remote get-url origin')) return GITLAB_ORIGIN;
-      if (cmd.includes('protected_branches')) return JSON.stringify({ name: 'main' });
+      if (cmd.includes('protected_branches')) return JSON.stringify([{ name: 'main' }]);
       return '';
     });
 
@@ -46,24 +46,46 @@ describe('checkBranchProtectedGitlab — subprocess boundary', () => {
     expect(r.data.protected).toBe(true);
   });
 
-  test('HTTP 404 ⇒ not protected', async () => {
+  test('WILDCARD entry matches ⇒ protected (release/* covers release/0.0.1)', async () => {
     setExecMock((cmd: string) => {
       if (cmd.includes('git remote get-url origin')) return GITLAB_ORIGIN;
       if (cmd.includes('protected_branches')) {
-        const e = new Error('nf') as ThrowableError;
-        e.stderr = '{"message":"404 Not Found"}';
-        e.status = 1;
-        throw e;
+        return JSON.stringify([{ name: 'main' }, { name: 'release/*' }]);
       }
       return '';
     });
 
-    const r = await checkBranchProtectedGitlab({ branch: 'release/legacy' });
+    const r = await checkBranchProtectedGitlab({ branch: 'release/0.0.1' });
+    expectOk(r);
+    expect(r.data.protected).toBe(true);
+  });
+
+  test('empty list ⇒ not protected', async () => {
+    setExecMock((cmd: string) => {
+      if (cmd.includes('git remote get-url origin')) return GITLAB_ORIGIN;
+      if (cmd.includes('protected_branches')) return '[]';
+      return '';
+    });
+
+    const r = await checkBranchProtectedGitlab({ branch: 'develop' });
     expectOk(r);
     expect(r.data.protected).toBe(false);
   });
 
-  test('non-404 failure ⇒ ok:false (does NOT collapse to unprotected)', async () => {
+  test('no matching entry ⇒ not protected (glob does not over-match)', async () => {
+    setExecMock((cmd: string) => {
+      if (cmd.includes('git remote get-url origin')) return GITLAB_ORIGIN;
+      if (cmd.includes('protected_branches')) return JSON.stringify([{ name: 'release/*' }]);
+      return '';
+    });
+
+    // `release/*` must NOT match `feature/release-notes`.
+    const r = await checkBranchProtectedGitlab({ branch: 'feature/release-notes' });
+    expectOk(r);
+    expect(r.data.protected).toBe(false);
+  });
+
+  test('real API failure ⇒ ok:false (does NOT collapse to unprotected)', async () => {
     setExecMock((cmd: string) => {
       if (cmd.includes('git remote get-url origin')) return GITLAB_ORIGIN;
       if (cmd.includes('protected_branches')) {
@@ -80,12 +102,12 @@ describe('checkBranchProtectedGitlab — subprocess boundary', () => {
     expect((r as { code: string }).code).toBe('glab_protection_check_failed');
   });
 
-  test('URL-encodes an explicit slug into the protected_branches path', async () => {
+  test('URL-encodes an explicit slug into the protected_branches list path', async () => {
     let seen = '';
     setExecMock((cmd: string) => {
       if (cmd.includes('protected_branches')) {
         seen = cmd;
-        return JSON.stringify({ name: 'main' });
+        return JSON.stringify([{ name: 'main' }]);
       }
       if (cmd.includes('git remote get-url origin')) return GITLAB_ORIGIN;
       return '';
@@ -93,7 +115,7 @@ describe('checkBranchProtectedGitlab — subprocess boundary', () => {
 
     const r = await checkBranchProtectedGitlab({ branch: 'main', repo: 'org/repo' });
     expectOk(r);
-    expect(seen).toContain('projects/org%2Frepo/protected_branches/main');
+    expect(seen).toContain('projects/org%2Frepo/protected_branches');
   });
 
   test('rejects invalid branch characters (no exec)', async () => {

--- a/lib/adapters/check-branch-protected-gitlab.ts
+++ b/lib/adapters/check-branch-protected-gitlab.ts
@@ -1,0 +1,72 @@
+/**
+ * GitLab `checkBranchProtected` adapter implementation (#465).
+ *
+ * Sibling of `check-branch-protected-github.ts`. Delegates to the
+ * `gitlabApiProtectedBranch()` wrapper (in `lib/gitlab-api.ts`) which speaks
+ * `glab api projects/:id/protected_branches/<branch>` and maps 200 ⇒ protected,
+ * 404 ⇒ not protected. A non-404 failure propagates out of the wrapper and is
+ * bounded here into `{ok: false}` rather than being misreported as
+ * "not protected".
+ */
+
+import { execSync } from 'child_process';
+import { gitlabApiProtectedBranch } from '../gitlab-api.js';
+import type {
+  AdapterResult,
+  CheckBranchProtectedArgs,
+  CheckBranchProtectedResponse,
+} from './types.js';
+
+const GITLAB_REPO_SLUG = /^[A-Za-z0-9._-]+(\/[A-Za-z0-9._-]+)+$/;
+const BRANCH_CHARSET = /^[A-Za-z0-9._\-/]+$/;
+
+/** Split `owner/repo` (or nested `org/sub/repo`) into the opts shape the
+ * gitlab-api wrapper expects; the wrapper rejoins + URL-encodes the whole
+ * path, so a first-slash split preserves nested group depth. */
+function parseSlugOpts(
+  slug: string | undefined,
+): { owner?: string; repo?: string } | undefined {
+  if (slug === undefined) return undefined;
+  const idx = slug.indexOf('/');
+  if (idx <= 0 || idx === slug.length - 1) return undefined;
+  return { owner: slug.slice(0, idx), repo: slug.slice(idx + 1) };
+}
+
+export async function checkBranchProtectedGitlab(
+  args: CheckBranchProtectedArgs,
+): Promise<AdapterResult<CheckBranchProtectedResponse>> {
+  try {
+    if (!BRANCH_CHARSET.test(args.branch)) {
+      return {
+        ok: false,
+        code: 'invalid_branch',
+        error: `checkBranchProtectedGitlab: invalid branch ${JSON.stringify(args.branch)}`,
+      };
+    }
+    if (args.repo !== undefined && !GITLAB_REPO_SLUG.test(args.repo)) {
+      return {
+        ok: false,
+        code: 'invalid_repo',
+        error: `checkBranchProtectedGitlab: invalid repo slug ${JSON.stringify(args.repo)}`,
+      };
+    }
+
+    const isProtected = gitlabApiProtectedBranch(
+      args.branch,
+      parseSlugOpts(args.repo),
+      args.cwd,
+    );
+    return { ok: true, data: { protected: isProtected } };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'glab_protection_check_failed',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// `execSync` is intentionally re-imported above so that adapter-level test
+// files can `mock.module('child_process', ...)` and intercept this module's
+// subprocess calls.
+void execSync;

--- a/lib/adapters/check-branch-protected-gitlab.ts
+++ b/lib/adapters/check-branch-protected-gitlab.ts
@@ -2,11 +2,13 @@
  * GitLab `checkBranchProtected` adapter implementation (#465).
  *
  * Sibling of `check-branch-protected-github.ts`. Delegates to the
- * `gitlabApiProtectedBranch()` wrapper (in `lib/gitlab-api.ts`) which speaks
- * `glab api projects/:id/protected_branches/<branch>` and maps 200 ⇒ protected,
- * 404 ⇒ not protected. A non-404 failure propagates out of the wrapper and is
- * bounded here into `{ok: false}` rather than being misreported as
- * "not protected".
+ * `gitlabApiProtectedBranch()` wrapper (in `lib/gitlab-api.ts`) which LISTS
+ * `glab api projects/:id/protected_branches` and matches the branch name
+ * client-side against each entry's `name` — a wildcard-aware check so a branch
+ * protected only by a glob rule (e.g. `release/0.0.1` under `release/*`) is
+ * correctly reported as protected. A real API failure propagates out of the
+ * wrapper and is bounded here into `{ok: false}` rather than being misreported
+ * as "not protected".
  */
 
 import { execSync } from 'child_process';

--- a/lib/adapters/github.ts
+++ b/lib/adapters/github.ts
@@ -28,6 +28,8 @@ import { fetchPrStateGithub } from './fetch-pr-state-github.js';
 import { findExistingPrGithub } from './find-existing-pr-github.js';
 import { findMergedPrForBranchPrefixGithub } from './find-merged-pr-for-branch-prefix-github.js';
 import { resolveBranchShaGithub } from './resolve-branch-sha-github.js';
+import { resolveDefaultBranchGithub } from './resolve-default-branch-github.js';
+import { checkBranchProtectedGithub } from './check-branch-protected-github.js';
 import { labelCreateGithub } from './label-create-github.js';
 import { labelListGithub } from './label-list-github.js';
 import { prCommentGithub } from './pr-comment-github.js';
@@ -82,4 +84,6 @@ export const githubAdapter: PlatformAdapter = {
   createBranch: createBranchGithub,
   findExistingPr: findExistingPrGithub,
   fetchCiTrustSignal: fetchCiTrustSignalGithub,
+  resolveDefaultBranch: resolveDefaultBranchGithub,
+  checkBranchProtected: checkBranchProtectedGithub,
 };

--- a/lib/adapters/gitlab.ts
+++ b/lib/adapters/gitlab.ts
@@ -29,6 +29,8 @@ import { fetchPrStateGitlab } from './fetch-pr-state-gitlab.js';
 import { findExistingPrGitlab } from './find-existing-pr-gitlab.js';
 import { findMergedPrForBranchPrefixGitlab } from './find-merged-pr-for-branch-prefix-gitlab.js';
 import { resolveBranchShaGitlab } from './resolve-branch-sha-gitlab.js';
+import { resolveDefaultBranchGitlab } from './resolve-default-branch-gitlab.js';
+import { checkBranchProtectedGitlab } from './check-branch-protected-gitlab.js';
 import { labelCreateGitlab } from './label-create-gitlab.js';
 import { labelListGitlab } from './label-list-gitlab.js';
 import { prCommentGitlab } from './pr-comment-gitlab.js';
@@ -83,4 +85,6 @@ export const gitlabAdapter: PlatformAdapter = {
   createBranch: createBranchGitlab,
   findExistingPr: findExistingPrGitlab,
   fetchCiTrustSignal: fetchCiTrustSignalGitlab,
+  resolveDefaultBranch: resolveDefaultBranchGitlab,
+  checkBranchProtected: checkBranchProtectedGitlab,
 };

--- a/lib/adapters/pr-create-github.ts
+++ b/lib/adapters/pr-create-github.ts
@@ -11,6 +11,7 @@
 
 import { execSync } from 'child_process';
 import { runArgv, type RunResult } from '../shared/error-norm.js';
+import { resolveDefaultBranchGithubSync } from './resolve-default-branch-github.js';
 import type {
   AdapterResult,
   PrCreateArgs,
@@ -25,23 +26,6 @@ function getCurrentBranch(cwd: string): string {
   const result = runArgv(['git', 'branch', '--show-current'], cwd);
   if (result.exitCode !== 0) {
     throw new Error(`git branch --show-current failed: ${result.stderr.trim()}`);
-  }
-  return result.stdout.trim();
-}
-
-/**
- * Resolve the repo's default branch via `gh repo view`.
- * GitHub-specific path; mirror in `pr-create-gitlab.ts` uses `glab api projects/<encoded>`.
- */
-function getDefaultBranch(repo: string | undefined, cwd: string): string {
-  const cmd = ['gh', 'repo', 'view'];
-  if (repo !== undefined) cmd.push(repo);
-  cmd.push('--json', 'defaultBranchRef', '--jq', '.defaultBranchRef.name');
-  const result = runArgv(cmd, cwd);
-  if (result.exitCode !== 0 || result.stdout.trim().length === 0) {
-    throw new Error(
-      `failed to resolve GitHub default branch: ${result.stderr.trim() || 'empty response'}`,
-    );
   }
   return result.stdout.trim();
 }
@@ -102,7 +86,7 @@ export async function prCreateGithub(
     const head = args.head ?? getCurrentBranch(cwd);
     const base = args.base && args.base.length > 0
       ? args.base
-      : getDefaultBranch(args.repo, cwd);
+      : resolveDefaultBranchGithubSync(args.repo, cwd);
 
     const createCmd = [
       'gh', 'pr', 'create',

--- a/lib/adapters/pr-create-gitlab.ts
+++ b/lib/adapters/pr-create-gitlab.ts
@@ -17,6 +17,7 @@
 
 import { execSync } from 'child_process';
 import { runArgv } from '../shared/error-norm.js';
+import { resolveDefaultBranchGitlabSync } from './resolve-default-branch-gitlab.js';
 import type {
   AdapterResult,
   PrCreateArgs,
@@ -33,26 +34,6 @@ function getCurrentBranch(cwd: string): string {
     throw new Error(`git branch --show-current failed: ${result.stderr.trim()}`);
   }
   return result.stdout.trim();
-}
-
-/**
- * Resolve the repo's default branch via `glab api projects/<encoded>`.
- * Use `:id` as the project segment when no slug is provided — `glab` resolves
- * that from the cwd remote.
- */
-function getDefaultBranch(repo: string | undefined, cwd: string): string {
-  const project = repo !== undefined ? repo.replace(/\//g, '%2F') : ':id';
-  const result = runArgv(['glab', 'api', `projects/${project}`], cwd);
-  if (result.exitCode !== 0 || result.stdout.trim().length === 0) {
-    throw new Error(
-      `failed to resolve GitLab default branch: ${result.stderr.trim() || 'empty response'}`,
-    );
-  }
-  const parsed = JSON.parse(result.stdout) as { default_branch?: string };
-  if (typeof parsed.default_branch !== 'string' || parsed.default_branch.length === 0) {
-    throw new Error('default_branch missing or empty in glab api response');
-  }
-  return parsed.default_branch;
 }
 
 function projectSlugEncoded(repo: string | undefined): string {
@@ -110,7 +91,7 @@ export async function prCreateGitlab(
     const head = args.head ?? getCurrentBranch(cwd);
     const base = args.base && args.base.length > 0
       ? args.base
-      : getDefaultBranch(args.repo, cwd);
+      : resolveDefaultBranchGitlabSync(args.repo, cwd);
 
     const createCmd = [
       'glab', 'mr', 'create',

--- a/lib/adapters/resolve-default-branch-github.test.ts
+++ b/lib/adapters/resolve-default-branch-github.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+import {
+  installChildProcessMock,
+  onExec,
+  resetExecMock,
+  execCalls,
+} from '../test-support/mock-child-process.ts';
+import type { AdapterResult, ResolveDefaultBranchResponse } from './types.ts';
+
+// Subprocess-boundary tests for the GitHub resolveDefaultBranch adapter (#465).
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  status?: number;
+}
+
+installChildProcessMock();
+
+const { resolveDefaultBranchGithub, resolveDefaultBranchGithubSync } = await import(
+  './resolve-default-branch-github.ts'
+);
+
+function expectOk(
+  r: AdapterResult<ResolveDefaultBranchResponse>,
+): asserts r is { ok: true; data: ResolveDefaultBranchResponse } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+function findCall(needle: string): string {
+  const raw = execCalls().find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+  return unquote(raw);
+}
+
+beforeEach(() => {
+  resetExecMock();
+});
+
+describe('resolveDefaultBranchGithub — subprocess boundary', () => {
+  test('happy path — gh repo view --json defaultBranchRef → default branch', async () => {
+    onExec('gh repo view', 'main\n');
+
+    const r = await resolveDefaultBranchGithub({});
+    expectOk(r);
+    expect(r.data.default_branch).toBe('main');
+
+    const call = findCall('gh repo view');
+    expect(call).toContain('--json');
+    expect(call).toContain('defaultBranchRef');
+    expect(call).toContain('.defaultBranchRef.name');
+  });
+
+  test('passes an explicit slug through to gh repo view', async () => {
+    onExec('gh repo view', 'develop\n');
+
+    const r = await resolveDefaultBranchGithub({ repo: 'org/repo' });
+    expectOk(r);
+    expect(r.data.default_branch).toBe('develop');
+    expect(findCall('gh repo view')).toContain('org/repo');
+  });
+
+  test('ok:false when gh repo view fails', async () => {
+    onExec('gh repo view', () => {
+      const e = new Error('auth') as ThrowableError;
+      e.stderr = 'auth required';
+      e.status = 1;
+      throw e;
+    });
+
+    const r = await resolveDefaultBranchGithub({});
+    expect('ok' in r && r.ok).toBe(false);
+    expect((r as { error: string }).error).toContain('default branch');
+  });
+
+  test('sync core throws on empty output', () => {
+    onExec('gh repo view', '\n');
+    expect(() => resolveDefaultBranchGithubSync(undefined, '/tmp')).toThrow(/default branch/);
+  });
+});

--- a/lib/adapters/resolve-default-branch-github.ts
+++ b/lib/adapters/resolve-default-branch-github.ts
@@ -1,0 +1,69 @@
+/**
+ * GitHub `resolveDefaultBranch` adapter implementation (#465).
+ *
+ * Promotes the private `getDefaultBranch()` helper that `pr-create-github.ts`
+ * carried into a shared adapter method so `branch_guard` and `pr_create` read
+ * the live default branch from one place instead of two copies.
+ *
+ * Argv: `gh repo view [<slug>] --json defaultBranchRef --jq .defaultBranchRef.name`.
+ * `gh repo view` resolves the repo from the cwd remote when no slug is given.
+ *
+ * `resolveDefaultBranchGithubSync` is the throwing core (kept for the sync
+ * call-site inside `prCreateGithub`); the async `resolveDefaultBranchGithub`
+ * wraps it into the `AdapterResult` contract so adapter callers never
+ * try/catch.
+ */
+
+import { execSync } from 'child_process';
+import { runArgv } from '../shared/error-norm.js';
+import type {
+  AdapterResult,
+  ResolveDefaultBranchArgs,
+  ResolveDefaultBranchResponse,
+} from './types.js';
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+/**
+ * Resolve the repo's default branch via `gh repo view`. Throws on failure —
+ * the sync core used by `prCreateGithub` (which already runs inside a
+ * try/catch that bounds the throw into an `AdapterResult`).
+ */
+export function resolveDefaultBranchGithubSync(
+  repo: string | undefined,
+  cwd: string,
+): string {
+  const cmd = ['gh', 'repo', 'view'];
+  if (repo !== undefined) cmd.push(repo);
+  cmd.push('--json', 'defaultBranchRef', '--jq', '.defaultBranchRef.name');
+  const result = runArgv(cmd, cwd);
+  if (result.exitCode !== 0 || result.stdout.trim().length === 0) {
+    throw new Error(
+      `failed to resolve GitHub default branch: ${result.stderr.trim() || 'empty response'}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+export async function resolveDefaultBranchGithub(
+  args: ResolveDefaultBranchArgs,
+): Promise<AdapterResult<ResolveDefaultBranchResponse>> {
+  try {
+    const cwd = args.cwd ?? projectDir();
+    const default_branch = resolveDefaultBranchGithubSync(args.repo, cwd);
+    return { ok: true, data: { default_branch } };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'gh_default_branch_failed',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// `execSync` is intentionally re-imported above so that adapter-level test
+// files can `mock.module('child_process', ...)` and intercept this module's
+// subprocess calls.
+void execSync;

--- a/lib/adapters/resolve-default-branch-gitlab.test.ts
+++ b/lib/adapters/resolve-default-branch-gitlab.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+import {
+  installChildProcessMock,
+  onExec,
+  resetExecMock,
+  execCalls,
+} from '../test-support/mock-child-process.ts';
+import type { AdapterResult, ResolveDefaultBranchResponse } from './types.ts';
+
+// Subprocess-boundary tests for the GitLab resolveDefaultBranch adapter (#465).
+
+installChildProcessMock();
+
+const { resolveDefaultBranchGitlab, resolveDefaultBranchGitlabSync } = await import(
+  './resolve-default-branch-gitlab.ts'
+);
+
+function expectOk(
+  r: AdapterResult<ResolveDefaultBranchResponse>,
+): asserts r is { ok: true; data: ResolveDefaultBranchResponse } {
+  if (!('ok' in r) || !r.ok) {
+    throw new Error(`expected ok result, got ${JSON.stringify(r)}`);
+  }
+}
+
+function unquote(cmd: string): string {
+  return cmd.replace(/'([^']*)'/g, '$1');
+}
+
+function findCall(needle: string): string {
+  const raw = execCalls().find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
+  return unquote(raw);
+}
+
+beforeEach(() => {
+  resetExecMock();
+});
+
+describe('resolveDefaultBranchGitlab — subprocess boundary', () => {
+  test('happy path — glab api projects/:id → default_branch (no --jq)', async () => {
+    onExec('glab api', JSON.stringify({ id: 1, default_branch: 'main' }));
+
+    const r = await resolveDefaultBranchGitlab({});
+    expectOk(r);
+    expect(r.data.default_branch).toBe('main');
+
+    const call = findCall('glab api');
+    expect(call).toContain('projects/:id');
+    // glab 1.36.0 rejects --jq; the adapter parses JSON in-process.
+    expect(call).not.toContain('--jq');
+  });
+
+  test('URL-encodes an explicit slug into the projects path', async () => {
+    onExec('glab api', JSON.stringify({ default_branch: 'develop' }));
+
+    const r = await resolveDefaultBranchGitlab({ repo: 'org/repo' });
+    expectOk(r);
+    expect(r.data.default_branch).toBe('develop');
+    expect(findCall('glab api')).toContain('projects/org%2Frepo');
+  });
+
+  test('ok:false when default_branch missing from the response', async () => {
+    onExec('glab api', JSON.stringify({ id: 1 }));
+
+    const r = await resolveDefaultBranchGitlab({});
+    expect('ok' in r && r.ok).toBe(false);
+    expect((r as { error: string }).error).toContain('default_branch');
+  });
+
+  test('sync core throws when glab returns empty output', () => {
+    onExec('glab api', '\n');
+    expect(() => resolveDefaultBranchGitlabSync(undefined, '/tmp')).toThrow(/default branch/);
+  });
+});

--- a/lib/adapters/resolve-default-branch-gitlab.ts
+++ b/lib/adapters/resolve-default-branch-gitlab.ts
@@ -1,0 +1,66 @@
+/**
+ * GitLab `resolveDefaultBranch` adapter implementation (#465).
+ *
+ * Sibling of `resolve-default-branch-github.ts` — promotes the private
+ * `getDefaultBranch()` helper that `pr-create-gitlab.ts` carried into a shared
+ * adapter method.
+ *
+ * Argv: `glab api projects/<encoded>` → `{ default_branch }`. Use `:id` as the
+ * project segment when no slug is provided; `glab` resolves that from the cwd
+ * remote. No `--jq` flag (glab 1.36.0 rejects it) — parse the JSON in-process.
+ */
+
+import { execSync } from 'child_process';
+import { runArgv } from '../shared/error-norm.js';
+import type {
+  AdapterResult,
+  ResolveDefaultBranchArgs,
+  ResolveDefaultBranchResponse,
+} from './types.js';
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+/**
+ * Resolve the repo's default branch via `glab api projects/<encoded>`. Throws
+ * on failure — the sync core used by `prCreateGitlab`.
+ */
+export function resolveDefaultBranchGitlabSync(
+  repo: string | undefined,
+  cwd: string,
+): string {
+  const project = repo !== undefined ? repo.replace(/\//g, '%2F') : ':id';
+  const result = runArgv(['glab', 'api', `projects/${project}`], cwd);
+  if (result.exitCode !== 0 || result.stdout.trim().length === 0) {
+    throw new Error(
+      `failed to resolve GitLab default branch: ${result.stderr.trim() || 'empty response'}`,
+    );
+  }
+  const parsed = JSON.parse(result.stdout) as { default_branch?: string };
+  if (typeof parsed.default_branch !== 'string' || parsed.default_branch.length === 0) {
+    throw new Error('default_branch missing or empty in glab api response');
+  }
+  return parsed.default_branch;
+}
+
+export async function resolveDefaultBranchGitlab(
+  args: ResolveDefaultBranchArgs,
+): Promise<AdapterResult<ResolveDefaultBranchResponse>> {
+  try {
+    const cwd = args.cwd ?? projectDir();
+    const default_branch = resolveDefaultBranchGitlabSync(args.repo, cwd);
+    return { ok: true, data: { default_branch } };
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'glab_default_branch_failed',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// `execSync` is intentionally re-imported above so that adapter-level test
+// files can `mock.module('child_process', ...)` and intercept this module's
+// subprocess calls.
+void execSync;

--- a/lib/adapters/types.test.ts
+++ b/lib/adapters/types.test.ts
@@ -118,6 +118,9 @@ describe('PlatformAdapter contract', () => {
     'createBranch',
     'findExistingPr',
     'fetchCiTrustSignal',
+    // #465: branch_guard host queries — real implementations, not stubs.
+    'resolveDefaultBranch',
+    'checkBranchProtected',
   ]);
 
   test('still-stubbed methods return platform_unsupported', async () => {

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -920,9 +920,15 @@ export interface CiTrustSignal {
  *    never a cached `.claude-project.md` value).
  *
  *  - `checkBranchProtected` is the genuinely-new part: is a branch protected on
- *    the host? GitHub `gh api repos/<slug>/branches/<branch>/protection`; GitLab
- *    `glab api projects/:id/protected_branches/<branch>` — 200 ⇒ protected,
- *    404 ⇒ not protected on both.
+ *    the host? Protection is detected across BOTH the exact-name AND
+ *    wildcard/ruleset surfaces — not exact-name only:
+ *      - GitHub: classic `gh api repos/<slug>/branches/<branch>/protection`
+ *        (200 ⇒ protected) OR, on 404, the effective rulesets for the branch via
+ *        `gh api repos/<slug>/rules/branches/<branch>` (non-empty array ⇒
+ *        protected). Catches wildcard rulesets like `release/*`.
+ *      - GitLab: LIST `glab api projects/:id/protected_branches` and match the
+ *        branch name client-side against each entry's `name` (which may be a
+ *        glob like `release/*`). Catches wildcard protection entries.
  */
 export interface ResolveDefaultBranchArgs {
   repo?: string;

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -908,6 +908,43 @@ export interface CiTrustSignal {
   reason: string;
 }
 
+/**
+ * `branch_guard` host queries (#465). Two live probes that back the base/target
+ * mainline guard:
+ *
+ *  - `resolveDefaultBranch` promotes the private `getDefaultBranch()` helper
+ *    that both `pr-create-{github,gitlab}.ts` carried (GitHub:
+ *    `gh repo view --json defaultBranchRef`; GitLab: `glab api projects/:id` →
+ *    `default_branch`) into a shared method — removing the duplication and
+ *    giving `branch_guard` a LIVE default-branch source (never `origin/HEAD`,
+ *    never a cached `.claude-project.md` value).
+ *
+ *  - `checkBranchProtected` is the genuinely-new part: is a branch protected on
+ *    the host? GitHub `gh api repos/<slug>/branches/<branch>/protection`; GitLab
+ *    `glab api projects/:id/protected_branches/<branch>` — 200 ⇒ protected,
+ *    404 ⇒ not protected on both.
+ */
+export interface ResolveDefaultBranchArgs {
+  repo?: string;
+  /** Working directory for the gh|glab invocation; defaults to CLAUDE_PROJECT_DIR ?? process.cwd(). */
+  cwd?: string;
+}
+
+export interface ResolveDefaultBranchResponse {
+  default_branch: string;
+}
+
+export interface CheckBranchProtectedArgs {
+  branch: string;
+  repo?: string;
+  /** Working directory for the gh|glab invocation; defaults to CLAUDE_PROJECT_DIR ?? process.cwd(). */
+  cwd?: string;
+}
+
+export interface CheckBranchProtectedResponse {
+  protected: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // The interface
 // ---------------------------------------------------------------------------
@@ -980,6 +1017,14 @@ export interface PlatformAdapter {
   fetchCiTrustSignal(
     args: FetchCiTrustSignalArgs,
   ): Promise<AdapterResult<CiTrustSignal>>;
+
+  // branch_guard host queries (#465).
+  resolveDefaultBranch(
+    args: ResolveDefaultBranchArgs,
+  ): Promise<AdapterResult<ResolveDefaultBranchResponse>>;
+  checkBranchProtected(
+    args: CheckBranchProtectedArgs,
+  ): Promise<AdapterResult<CheckBranchProtectedResponse>>;
 }
 
 // ---------------------------------------------------------------------------
@@ -1026,6 +1071,8 @@ export const PLATFORM_ADAPTER_METHODS = [
   'createBranch',
   'findExistingPr',
   'fetchCiTrustSignal',
+  'resolveDefaultBranch',
+  'checkBranchProtected',
 ] as const;
 
 export type PlatformAdapterMethod = (typeof PLATFORM_ADAPTER_METHODS)[number];

--- a/lib/gitlab-api.ts
+++ b/lib/gitlab-api.ts
@@ -326,17 +326,31 @@ export function gitlabApiRepo(): GitlabRepo {
 }
 
 /**
+ * Convert a GitLab protected-branch name (which may be a glob like `release/*`)
+ * into an anchored regex that full-matches a concrete branch name. Every regex
+ * metachar is escaped; the glob `*` (GitLab's only wildcard) becomes `.*`.
+ */
+function protectedNameGlobToRegExp(glob: string): RegExp {
+  const escaped = glob.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = escaped.replace(/\\\*/g, '.*');
+  return new RegExp(`^${pattern}$`);
+}
+
+/**
  * Report whether a branch is protected on the host (#465).
  *
- * Endpoint: `GET /projects/:id/protected_branches/:name`
- *  - HTTP 200 ⇒ the branch is protected (returns the protection record).
- *  - HTTP 404 ⇒ the branch is not protected.
+ * Endpoint: `GET /projects/:id/protected_branches` (LIST) — matched client-side.
  *
- * `glab api` maps a 404 to a non-zero exit, which `execGlab` rethrows as a
- * `glab failed (…)` error whose message carries the stderr. We interpret a
- * 404 / "not found" message as "not protected" and return `false`; any other
- * failure (auth, network) propagates so callers can surface a real error
- * instead of silently reporting the branch as unprotected.
+ * GitLab's exact-name endpoint (`/protected_branches/:name`) 404s for a branch
+ * protected only by a WILDCARD entry (e.g. `release/0.0.1` guarded by a
+ * `release/*` rule) — the exact LTS-release false-negative this guard exists to
+ * catch. Instead we list every protection entry and full-match the branch name
+ * against each entry's `name` (converting a glob like `release/*` to an anchored
+ * regex). Exact entries still match. The list endpoint returns `[]` (HTTP 200)
+ * for a project with no protected branches, so a genuinely unprotected branch
+ * yields `false` without any error path. Real API failures (auth, network)
+ * propagate out of `execGlab` so callers surface them instead of silently
+ * reporting the branch as unprotected.
  */
 export function gitlabApiProtectedBranch(
   branch: string,
@@ -344,17 +358,9 @@ export function gitlabApiProtectedBranch(
   cwd?: string,
 ): boolean {
   const path = projectPath(opts, cwd);
-  try {
-    const raw = execGlab(
-      `glab api projects/${path}/protected_branches/${encodeURIComponent(branch)}`,
-      cwd,
-    );
-    // 200 returns the protection record; parse to fail loudly on garbage.
-    JSON.parse(raw);
-    return true;
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : '';
-    if (/404|not found/i.test(msg)) return false;
-    throw err;
-  }
+  const raw = execGlab(`glab api projects/${path}/protected_branches`, cwd);
+  const entries = JSON.parse(raw) as Array<{ name?: string }>;
+  return entries.some(
+    (e) => typeof e.name === 'string' && protectedNameGlobToRegExp(e.name).test(branch),
+  );
 }

--- a/lib/gitlab-api.ts
+++ b/lib/gitlab-api.ts
@@ -324,3 +324,37 @@ export function gitlabApiRepo(): GitlabRepo {
   const raw = execGlab(`glab api projects/${path}`);
   return JSON.parse(raw) as GitlabRepo;
 }
+
+/**
+ * Report whether a branch is protected on the host (#465).
+ *
+ * Endpoint: `GET /projects/:id/protected_branches/:name`
+ *  - HTTP 200 ⇒ the branch is protected (returns the protection record).
+ *  - HTTP 404 ⇒ the branch is not protected.
+ *
+ * `glab api` maps a 404 to a non-zero exit, which `execGlab` rethrows as a
+ * `glab failed (…)` error whose message carries the stderr. We interpret a
+ * 404 / "not found" message as "not protected" and return `false`; any other
+ * failure (auth, network) propagates so callers can surface a real error
+ * instead of silently reporting the branch as unprotected.
+ */
+export function gitlabApiProtectedBranch(
+  branch: string,
+  opts?: { owner?: string; repo?: string },
+  cwd?: string,
+): boolean {
+  const path = projectPath(opts, cwd);
+  try {
+    const raw = execGlab(
+      `glab api projects/${path}/protected_branches/${encodeURIComponent(branch)}`,
+      cwd,
+    );
+    // 200 returns the protection record; parse to fail loudly on garbage.
+    JSON.parse(raw);
+    return true;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : '';
+    if (/404|not found/i.test(msg)) return false;
+    throw err;
+  }
+}

--- a/tests/branch_guard.test.ts
+++ b/tests/branch_guard.test.ts
@@ -1,0 +1,228 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  installChildProcessMock,
+  onExec,
+  resetExecMock,
+  execCalls,
+} from '../lib/test-support/mock-child-process.ts';
+
+// branch_guard handler tests (#465). Drives the REAL adapters through the shared
+// child_process mock — same convention as tests/pr_create.test.ts. Each test
+// registers substring → responder mappings via `onExec`; an unmatched call
+// throws, so a missing stub (e.g. an unexpected protection query on a sandbox
+// branch) surfaces loudly as a failure.
+
+interface ThrowableError extends Error {
+  stderr?: string;
+  stdout?: string;
+  status?: number;
+}
+
+installChildProcessMock();
+
+const { default: handler } = await import('../handlers/branch_guard.ts');
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(result.content[0].text) as Record<string, unknown>;
+}
+
+function fail404(match: string): void {
+  onExec(match, () => {
+    const err = new Error('not found') as ThrowableError;
+    err.stderr = 'gh: Not Found (HTTP 404)';
+    err.status = 1;
+    throw err;
+  });
+}
+
+function failGlab404(match: string): void {
+  onExec(match, () => {
+    const err = new Error('nf') as ThrowableError;
+    err.stderr = '{"message":"404 Not Found"}';
+    err.status = 1;
+    throw err;
+  });
+}
+
+const GITHUB_ORIGIN = 'git@github.com:org/repo.git\n';
+const GITLAB_ORIGIN = 'git@gitlab.com:org/repo.git\n';
+
+beforeEach(() => resetExecMock());
+afterEach(() => resetExecMock());
+
+describe('branch_guard handler — shape', () => {
+  test('exports a valid HandlerDef', () => {
+    expect(handler.name).toBe('branch_guard');
+    expect(typeof handler.execute).toBe('function');
+  });
+
+  test('rejects missing role via schema (no subprocess)', async () => {
+    const data = parseResult(await handler.execute({}));
+    expect(data.ok).toBe(false);
+    expect(String(data.error)).toContain('role');
+    expect(execCalls().length).toBe(0);
+  });
+
+  test('rejects an invalid repo slug via schema (no subprocess)', async () => {
+    const data = parseResult(
+      await handler.execute({ role: 'target', branch: 'main', repo: 'not-a-slug' }),
+    );
+    expect(data.ok).toBe(false);
+    expect(String(data.error)).toContain('repo');
+    expect(execCalls().length).toBe(0);
+  });
+});
+
+describe('branch_guard verdicts — GitHub', () => {
+  test('default branch → pass', async () => {
+    onExec('git remote get-url origin', GITHUB_ORIGIN);
+    onExec('gh repo view', 'main\n');
+    onExec('branches/main/protection', JSON.stringify({ required_status_checks: { strict: true } }));
+
+    const data = parseResult(await handler.execute({ role: 'target', branch: 'main' }));
+    expect(data.ok).toBe(true);
+    expect(data.verdict).toBe('pass');
+    expect(data.default_branch).toBe('main');
+    expect(data.checked_branch).toBe('main');
+    expect(data.is_protected).toBe(true);
+    expect(data.is_sandbox).toBe(false);
+  });
+
+  test('kahuna/12-foo → pass (is_sandbox true, protection NOT queried)', async () => {
+    onExec('git remote get-url origin', GITHUB_ORIGIN);
+    onExec('gh repo view', 'main\n');
+    // No protection stub: if the handler queries it, the unmatched-call guard
+    // throws — asserting the sandbox carve-out short-circuits before the gate.
+
+    const data = parseResult(await handler.execute({ role: 'target', branch: 'kahuna/12-foo' }));
+    expect(data.ok).toBe(true);
+    expect(data.verdict).toBe('pass');
+    expect(data.is_sandbox).toBe(true);
+    expect(data.checked_branch).toBe('kahuna/12-foo');
+  });
+
+  test('unprotected non-default branch → pass', async () => {
+    onExec('git remote get-url origin', GITHUB_ORIGIN);
+    onExec('gh repo view', 'main\n');
+    fail404('branches/develop/protection');
+
+    const data = parseResult(await handler.execute({ role: 'target', branch: 'develop' }));
+    expect(data.ok).toBe(true);
+    expect(data.verdict).toBe('pass');
+    expect(data.is_protected).toBe(false);
+    expect(data.is_sandbox).toBe(false);
+  });
+
+  test('protected non-default non-kahuna branch → warn', async () => {
+    onExec('git remote get-url origin', GITHUB_ORIGIN);
+    onExec('gh repo view', 'main\n');
+    onExec('branches/release-1.0/protection', JSON.stringify({ required_status_checks: { strict: true } }));
+
+    const data = parseResult(await handler.execute({ role: 'target', branch: 'release-1.0' }));
+    expect(data.ok).toBe(true);
+    expect(data.verdict).toBe('warn');
+    expect(data.is_protected).toBe(true);
+    expect(data.is_sandbox).toBe(false);
+    expect(String(data.reason)).toContain('stale or renamed');
+  });
+
+  test('target with base omitted → the live default (pass)', async () => {
+    onExec('git remote get-url origin', GITHUB_ORIGIN);
+    onExec('gh repo view', 'main\n');
+    onExec('branches/main/protection', JSON.stringify({}));
+
+    const data = parseResult(await handler.execute({ role: 'target' }));
+    expect(data.ok).toBe(true);
+    expect(data.verdict).toBe('pass');
+    expect(data.checked_branch).toBe('main');
+  });
+});
+
+describe('branch_guard verdicts — GitLab', () => {
+  test('default branch → pass', async () => {
+    onExec('git remote get-url origin', GITLAB_ORIGIN);
+    onExec('projects/:id', JSON.stringify({ default_branch: 'main' }));
+    onExec('protected_branches/main', JSON.stringify({ name: 'main' }));
+
+    const data = parseResult(await handler.execute({ role: 'target', branch: 'main' }));
+    expect(data.ok).toBe(true);
+    expect(data.verdict).toBe('pass');
+    expect(data.default_branch).toBe('main');
+    expect(data.is_protected).toBe(true);
+  });
+
+  test('kahuna/9-foo → pass (is_sandbox true, protection NOT queried)', async () => {
+    onExec('git remote get-url origin', GITLAB_ORIGIN);
+    onExec('projects/:id', JSON.stringify({ default_branch: 'main' }));
+
+    const data = parseResult(await handler.execute({ role: 'target', branch: 'kahuna/9-foo' }));
+    expect(data.ok).toBe(true);
+    expect(data.verdict).toBe('pass');
+    expect(data.is_sandbox).toBe(true);
+  });
+
+  test('unprotected non-default branch → pass', async () => {
+    onExec('git remote get-url origin', GITLAB_ORIGIN);
+    onExec('projects/:id', JSON.stringify({ default_branch: 'main' }));
+    failGlab404('protected_branches/develop');
+
+    const data = parseResult(await handler.execute({ role: 'target', branch: 'develop' }));
+    expect(data.ok).toBe(true);
+    expect(data.verdict).toBe('pass');
+    expect(data.is_protected).toBe(false);
+  });
+
+  test('protected non-default non-kahuna branch → warn', async () => {
+    onExec('git remote get-url origin', GITLAB_ORIGIN);
+    onExec('projects/:id', JSON.stringify({ default_branch: 'main' }));
+    onExec('protected_branches/release-1.0', JSON.stringify({ name: 'release-1.0' }));
+
+    const data = parseResult(await handler.execute({ role: 'target', branch: 'release-1.0' }));
+    expect(data.ok).toBe(true);
+    expect(data.verdict).toBe('warn');
+    expect(data.is_protected).toBe(true);
+    expect(String(data.reason)).toContain('stale or renamed');
+  });
+});
+
+describe('branch_guard role=base — base detection via open PR', () => {
+  test('open PR base resolves to the live default → pass', async () => {
+    onExec('git remote get-url origin', GITHUB_ORIGIN);
+    onExec('gh repo view', 'main\n');
+    onExec('git branch --show-current', 'feature/465-branch-guard\n');
+    onExec(
+      'gh pr list',
+      JSON.stringify([
+        {
+          number: 5,
+          title: 't',
+          state: 'OPEN',
+          headRefName: 'feature/465-branch-guard',
+          baseRefName: 'main',
+          url: 'https://github.com/org/repo/pull/5',
+        },
+      ]),
+    );
+    onExec('branches/main/protection', JSON.stringify({ required_status_checks: { strict: true } }));
+
+    const data = parseResult(await handler.execute({ role: 'base' }));
+    expect(data.ok).toBe(true);
+    expect(data.verdict).toBe('pass');
+    expect(data.checked_branch).toBe('main');
+  });
+
+  test('no open PR → pass (base undetermined pre-PR, never a false warn)', async () => {
+    onExec('git remote get-url origin', GITHUB_ORIGIN);
+    onExec('gh repo view', 'main\n');
+    onExec('git branch --show-current', 'feature/465-branch-guard\n');
+    onExec('gh pr list', '[]');
+    // No protection stub: the no-PR path must early-return before any gate.
+
+    const data = parseResult(await handler.execute({ role: 'base' }));
+    expect(data.ok).toBe(true);
+    expect(data.verdict).toBe('pass');
+    expect(data.checked_branch).toBe('feature/465-branch-guard');
+    expect(data.is_protected).toBe(false);
+    expect(String(data.reason)).toContain('No open PR');
+  });
+});

--- a/tests/branch_guard.test.ts
+++ b/tests/branch_guard.test.ts
@@ -35,15 +35,6 @@ function fail404(match: string): void {
   });
 }
 
-function failGlab404(match: string): void {
-  onExec(match, () => {
-    const err = new Error('nf') as ThrowableError;
-    err.stderr = '{"message":"404 Not Found"}';
-    err.status = 1;
-    throw err;
-  });
-}
-
 const GITHUB_ORIGIN = 'git@github.com:org/repo.git\n';
 const GITLAB_ORIGIN = 'git@gitlab.com:org/repo.git\n';
 
@@ -105,6 +96,7 @@ describe('branch_guard verdicts — GitHub', () => {
     onExec('git remote get-url origin', GITHUB_ORIGIN);
     onExec('gh repo view', 'main\n');
     fail404('branches/develop/protection');
+    onExec('rules/branches/develop', '[]'); // no rulesets apply either
 
     const data = parseResult(await handler.execute({ role: 'target', branch: 'develop' }));
     expect(data.ok).toBe(true);
@@ -126,6 +118,22 @@ describe('branch_guard verdicts — GitHub', () => {
     expect(String(data.reason)).toContain('stale or renamed');
   });
 
+  test('branch protected ONLY by a wildcard ruleset → warn (LTS scenario)', async () => {
+    // No classic protection on release/0.0.1, but a `release/*` ruleset applies.
+    // Classic 404 → the effective-rules fallback returns a non-empty array.
+    onExec('git remote get-url origin', GITHUB_ORIGIN);
+    onExec('gh repo view', 'release/1.0.0\n');
+    fail404('branches/release/0.0.1/protection');
+    onExec('rules/branches/release/0.0.1', JSON.stringify([{ type: 'pull_request' }]));
+
+    const data = parseResult(await handler.execute({ role: 'target', branch: 'release/0.0.1' }));
+    expect(data.ok).toBe(true);
+    expect(data.verdict).toBe('warn');
+    expect(data.default_branch).toBe('release/1.0.0');
+    expect(data.is_protected).toBe(true);
+    expect(data.is_sandbox).toBe(false);
+  });
+
   test('target with base omitted → the live default (pass)', async () => {
     onExec('git remote get-url origin', GITHUB_ORIGIN);
     onExec('gh repo view', 'main\n');
@@ -142,7 +150,7 @@ describe('branch_guard verdicts — GitLab', () => {
   test('default branch → pass', async () => {
     onExec('git remote get-url origin', GITLAB_ORIGIN);
     onExec('projects/:id', JSON.stringify({ default_branch: 'main' }));
-    onExec('protected_branches/main', JSON.stringify({ name: 'main' }));
+    onExec('protected_branches', JSON.stringify([{ name: 'main' }]));
 
     const data = parseResult(await handler.execute({ role: 'target', branch: 'main' }));
     expect(data.ok).toBe(true);
@@ -164,7 +172,7 @@ describe('branch_guard verdicts — GitLab', () => {
   test('unprotected non-default branch → pass', async () => {
     onExec('git remote get-url origin', GITLAB_ORIGIN);
     onExec('projects/:id', JSON.stringify({ default_branch: 'main' }));
-    failGlab404('protected_branches/develop');
+    onExec('protected_branches', '[]');
 
     const data = parseResult(await handler.execute({ role: 'target', branch: 'develop' }));
     expect(data.ok).toBe(true);
@@ -175,13 +183,27 @@ describe('branch_guard verdicts — GitLab', () => {
   test('protected non-default non-kahuna branch → warn', async () => {
     onExec('git remote get-url origin', GITLAB_ORIGIN);
     onExec('projects/:id', JSON.stringify({ default_branch: 'main' }));
-    onExec('protected_branches/release-1.0', JSON.stringify({ name: 'release-1.0' }));
+    onExec('protected_branches', JSON.stringify([{ name: 'release-1.0' }]));
 
     const data = parseResult(await handler.execute({ role: 'target', branch: 'release-1.0' }));
     expect(data.ok).toBe(true);
     expect(data.verdict).toBe('warn');
     expect(data.is_protected).toBe(true);
     expect(String(data.reason)).toContain('stale or renamed');
+  });
+
+  test('branch protected ONLY by a wildcard entry → warn (LTS scenario)', async () => {
+    // release/0.0.1 is not listed by exact name, but a `release/*` entry covers
+    // it. The wildcard-aware list match reports it as protected.
+    onExec('git remote get-url origin', GITLAB_ORIGIN);
+    onExec('projects/:id', JSON.stringify({ default_branch: 'release/1.0.0' }));
+    onExec('protected_branches', JSON.stringify([{ name: 'release/*' }]));
+
+    const data = parseResult(await handler.execute({ role: 'target', branch: 'release/0.0.1' }));
+    expect(data.ok).toBe(true);
+    expect(data.verdict).toBe('warn');
+    expect(data.default_branch).toBe('release/1.0.0');
+    expect(data.is_protected).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

New `branch_guard` MCP tool. It resolves the default branch **live** from the git host and checks whether a base/target branch is **protected**, then warns when a base/target is a protected branch that isn't the current live default — e.g. an old `release/0.0.1` when the default has moved to `release/1.0.0`. `kahuna/*` sandboxes are exempt. Backs the guards wired into precheck/scp/mmr (claudecode-workflow#888).

## Changes

- `handlers/branch_guard.ts` — verdict order: sandbox → pass, then protected-gate, then default-equality
- lifted `resolveDefaultBranch()` into a shared adapter method (pr-create repointed off its private copy)
- `checkBranchProtected()` host query — detects classic protection **plus rulesets** (GitHub `rules/branches/<b>` fallback) and **wildcard** protected-branch entries (GitLab list + glob match), not exact-name only
- adapter-interface wiring (`PLATFORM_ADAPTER_METHODS`, github/gitlab assemblers) + tests

## Linked Issues

Closes #465

## Test Plan

`bun test` 2363 pass / 0 fail; `tsc --noEmit` clean. Verdict traced for the LTS scenario (live default `release/1.0.0`): target `release/0.0.1` protected via a `release/*` rule → **warn**; the default → pass; `kahuna/*` → pass; unprotected → pass. Wildcard/ruleset protection detection covered on both platforms (classic-404 → rulesets/list fallback; real API errors surface `ok:false`, never silently "unprotected"). Pre-existing HIGH dependency CVEs are tracked separately in #468.