### PR TITLE
fix(wave-engine): resolve live default, not hardcoded 'main'

### DIFF
--- a/handlers/wave_finalize.ts
+++ b/handlers/wave_finalize.ts
@@ -1,7 +1,10 @@
 // KAHUNA epic-final gate: opens (or returns) the kahuna → target_branch MR.
-// Idempotent on (kahuna_branch, target_branch). Platform-agnostic dispatcher
-// — `findExistingPr` + `prCreate` go through `getAdapter()`; body composition
-// and SHA hashing live in `lib/wave-finalize.ts`. Story 2.23 (#317).
+// Idempotent on (kahuna_branch, target_branch). `target_branch` defaults to the
+// repo's LIVE default branch (resolved via the adapter) when the caller omits
+// it — never a hardcoded 'main' (#472). Platform-agnostic dispatcher —
+// `findExistingPr` + `prCreate` + `resolveDefaultBranch` go through
+// `getAdapter()`; body composition and SHA hashing live in `lib/wave-finalize.ts`.
+// Story 2.23 (#317).
 
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
@@ -17,7 +20,9 @@ const inputSchema = z.object({
   root: z.string().optional(),
   plan_id: z.number().int().positive(),
   kahuna_branch: z.string().min(1),
-  target_branch: z.string().min(1).default('main'),
+  // Optional: an explicit target wins; when omitted the handler resolves the
+  // repo's LIVE default branch (never hardcode 'main' — #472).
+  target_branch: z.string().min(1).optional(),
   body_artifacts_dir: z.string().optional(),
 });
 
@@ -30,7 +35,8 @@ const waveFinalizeHandler: HandlerDef = {
   name: 'wave_finalize',
   description:
     'Open (or return the existing) kahuna→target_branch MR for a KAHUNA epic. ' +
-    'Idempotent on (kahuna_branch, target_branch). The MR body is assembled from wavebus artifacts under `body_artifacts_dir` (default: /tmp/wavemachine/<slug>/); ' +
+    'Idempotent on (kahuna_branch, target_branch). `target_branch` defaults to the repo\'s live default branch when omitted. ' +
+    'The MR body is assembled from wavebus artifacts under `body_artifacts_dir` (default: /tmp/wavemachine/<slug>/); ' +
     'when those are absent (e.g. wave_complete cleanup wiped them on the last wave), the handler falls back to durable wave-status state ' +
     '(`<project>/.claude/status/{phases-waves.json,state.json}`) to re-derive the body from plan + recorded mr_urls. ' +
     'Returns kahuna_branch_not_found if the branch is absent on the remote; no_artifacts if neither the bus nor durable state yields any issues. ' +
@@ -44,18 +50,31 @@ const waveFinalizeHandler: HandlerDef = {
       const cwd = projectDir(args.root);
       const resolved = resolveArtifactsDir(args.body_artifacts_dir, defaultArtifactsDir(args.kahuna_branch), cwd);
       if (!resolved.ok) return envelope({ ok: false, error: resolved.error });
+      const adapter = getAdapter();
+      // target_branch: an explicit caller value wins; otherwise resolve the LIVE
+      // default branch from the host (never hardcode 'main' — a repo whose
+      // default is e.g. release/1.0.0 must finalize to release/1.0.0, not main).
+      const explicitTarget = args.target_branch;
+      let targetBranch: string;
+      if (explicitTarget !== undefined) {
+        targetBranch = explicitTarget;
+      } else {
+        const defRes = await adapter.resolveDefaultBranch({ cwd });
+        if ('platform_unsupported' in defRes) return envelope({ ok: false, error: `default-branch resolution unsupported: ${defRes.hint}` });
+        if (!defRes.ok) return envelope({ ok: false, error: defRes.error });
+        targetBranch = defRes.data.default_branch;
+      }
       // Try the bus first; fall back to durable wave-status state when the
       // bus has been cleaned up (#415). assembleBodyFromState consults
       // `<project>/.claude/status/{phases-waves.json,state.json}`.
       const composeBody = async () => {
-        const fromBus = await assembleBody(resolved.path, args.plan_id, args.kahuna_branch, args.target_branch);
+        const fromBus = await assembleBody(resolved.path, args.plan_id, args.kahuna_branch, targetBranch);
         if (fromBus.issueCount > 0) return fromBus;
-        return await assembleBodyFromState(cwd, args.plan_id, args.kahuna_branch, args.target_branch);
+        return await assembleBodyFromState(cwd, args.plan_id, args.kahuna_branch, targetBranch);
       };
-      const adapter = getAdapter();
       // Idempotency first (per devspec §5.1.1 step 1). Covers the post-merge
       // edge case where the kahuna branch was deleted after the MR was opened.
-      const existing = await adapter.findExistingPr({ head: args.kahuna_branch, base: args.target_branch, state: 'open', cwd });
+      const existing = await adapter.findExistingPr({ head: args.kahuna_branch, base: targetBranch, state: 'open', cwd });
       if ('platform_unsupported' in existing) return envelope({ ok: false, error: `findExistingPr unsupported: ${existing.hint}` });
       if (!existing.ok) return envelope({ ok: false, error: existing.error });
       if (existing.data !== null) {
@@ -67,15 +86,15 @@ const waveFinalizeHandler: HandlerDef = {
         emitStateEvent(cwd, 'step', {
           action: 'promote',
           label: 'wave_finalize',
-          detail: { number: existing.data.number, plan_id: args.plan_id, target: args.target_branch, created: false },
+          detail: { number: existing.data.number, plan_id: args.plan_id, target: targetBranch, created: false },
         });
         return envelope({ ok: true, number: existing.data.number, url: existing.data.url, state: 'open', created: false, body_sha: issueCount > 0 ? hashBody(body) : '' });
       }
       if (!branchExistsOnRemote(cwd, args.kahuna_branch)) return envelope({ ok: false, error: 'kahuna_branch_not_found' });
       const { body, issueCount } = await composeBody();
       if (issueCount === 0) return envelope({ ok: false, error: 'no_artifacts' });
-      const title = `plan(#${args.plan_id}): ${epicSlugFromBranch(args.kahuna_branch)} — kahuna to ${args.target_branch}`;
-      const created = await adapter.prCreate({ title, body, base: args.target_branch, head: args.kahuna_branch, cwd });
+      const title = `plan(#${args.plan_id}): ${epicSlugFromBranch(args.kahuna_branch)} — kahuna to ${targetBranch}`;
+      const created = await adapter.prCreate({ title, body, base: targetBranch, head: args.kahuna_branch, cwd });
       if ('platform_unsupported' in created) return envelope({ ok: false, error: `prCreate unsupported: ${created.hint}` });
       if (!created.ok) return envelope({ ok: false, error: created.error });
       // FlightDeck emit (S1.5, additive) — promote step for the newly-opened
@@ -85,13 +104,13 @@ const waveFinalizeHandler: HandlerDef = {
       emitStateEvent(cwd, 'step', {
         action: 'promote',
         label: 'wave_finalize',
-        detail: { number: created.data.number, plan_id: args.plan_id, target: args.target_branch, created: true },
+        detail: { number: created.data.number, plan_id: args.plan_id, target: targetBranch, created: true },
       });
       emitStateEvent(cwd, 'concern', {
         concernKind: 'self-approval',
         source: 'coded',
         label: 'kahuna epic-final MR opened',
-        detail: { number: created.data.number, plan_id: args.plan_id, target: args.target_branch },
+        detail: { number: created.data.number, plan_id: args.plan_id, target: targetBranch },
       });
       return envelope({ ok: true, number: created.data.number, url: created.data.url, state: 'open', created: true, body_sha: hashBody(body) });
     } catch (err) {

--- a/handlers/wave_init.ts
+++ b/handlers/wave_init.ts
@@ -71,7 +71,7 @@ const waveInitHandler: HandlerDef = {
   description:
     'Initialize a wave plan from structured JSON; supports --extend mode. ' +
     'Optional `kahuna` argument bootstraps a `kahuna/<plan_id>-<slug>` branch ' +
-    'off the plan\'s base_branch (default `main`) and records it in wave state. ' +
+    'off the plan\'s base_branch (default: the repo\'s live default branch) and records it in wave state. ' +
     'Atomic across kahuna bootstrap + plan persist (#378): kahuna failure does ' +
     'not persist the plan; plan-persist failure leaves the branch claimable on retry.',
   inputSchema,
@@ -96,12 +96,27 @@ const waveInitHandler: HandlerDef = {
       let kahunaPreviouslyRecorded = false;
       if (args.kahuna !== undefined) {
         const slug = args.repo ?? parseRepoSlug() ?? undefined;
-        const baseBranch = typeof plan.base_branch === 'string' && plan.base_branch.length > 0 ? plan.base_branch : 'main';
+        const adapter = getAdapter({ repo: slug });
+        // Base branch: the plan's explicit base_branch wins; otherwise resolve
+        // the LIVE default branch from the host (never hardcode 'main' — a repo
+        // whose default is e.g. release/1.0.0 would otherwise cut the kahuna
+        // branch from the wrong place). Mirrors how pr_create defaults its base.
+        let baseBranch: string;
+        if (typeof plan.base_branch === 'string' && plan.base_branch.length > 0) {
+          baseBranch = plan.base_branch;
+        } else {
+          const defRes = await adapter.resolveDefaultBranch({ repo: slug, cwd });
+          if ('platform_unsupported' in defRes) {
+            return envelope({ ok: false, error: `default-branch resolution unsupported: ${defRes.hint}` });
+          }
+          if (!defRes.ok) return envelope({ ok: false, error: defRes.error });
+          baseBranch = defRes.data.default_branch;
+        }
         const statePath = join(await statusDir(cwd), 'state.json');
         const remote = await bootstrapKahunaBranchRemote(cwd, args.kahuna, baseBranch,
           () => readStateOrDefault(statePath),
           {
-            adapter: getAdapter({ repo: slug }), slug,
+            adapter, slug,
             branchPresentOnRemote: (b) => branchExistsOnRemote(cwd, b),
           });
         if (!remote.ok) return envelope({ ok: false, error: remote.error });

--- a/lib/adapters/fetch-ci-trust-signal-github.test.ts
+++ b/lib/adapters/fetch-ci-trust-signal-github.test.ts
@@ -62,6 +62,7 @@ describe('fetchCiTrustSignalGithubSync — subprocess boundary', () => {
       if (cmd.includes('/rulesets/1')) {
         return JSON.stringify({ rules: [{ type: 'other_rule' }] });
       }
+      if (cmd.includes('defaultBranchRef')) return 'main';
       if (cmd.includes('/branches/main/protection')) {
         return JSON.stringify({ required_status_checks: { strict: true } });
       }
@@ -72,11 +73,33 @@ describe('fetchCiTrustSignalGithubSync — subprocess boundary', () => {
     expect(signal.reason).toContain('strict');
   });
 
+  test('probes the LIVE default branch protection, not a hardcoded main (#472)', () => {
+    let protectionCmd = '';
+    setExecMock((cmd: string) => {
+      if (cmd.includes('/rulesets') && !cmd.match(/rulesets\/\d+/)) {
+        return JSON.stringify([]);
+      }
+      if (cmd.includes('defaultBranchRef')) return 'release/1.0.0';
+      if (cmd.includes('/protection')) {
+        protectionCmd = cmd;
+        return JSON.stringify({ required_status_checks: { strict: true } });
+      }
+      return '{}';
+    });
+    const signal = fetchCiTrustSignalGithubSync('org/repo');
+    expect(signal.level).toBe('pre_merge_authoritative');
+    // The protection probe targets the resolved default, NOT `main`.
+    expect(protectionCmd).toContain('branches/release/1.0.0/protection');
+    expect(protectionCmd).not.toContain('branches/main/protection');
+    expect(signal.reason).toContain('release/1.0.0');
+  });
+
   test('branch protection without strict → post_merge_required', () => {
     setExecMock((cmd: string) => {
       if (cmd.includes('/rulesets') && !cmd.match(/rulesets\/\d+/)) {
         return JSON.stringify([]);
       }
+      if (cmd.includes('defaultBranchRef')) return 'main';
       if (cmd.includes('/branches/main/protection')) {
         return JSON.stringify({ required_status_checks: { strict: false } });
       }
@@ -91,6 +114,7 @@ describe('fetchCiTrustSignalGithubSync — subprocess boundary', () => {
       if (cmd.includes('/rulesets') && !cmd.match(/rulesets\/\d+/)) {
         return JSON.stringify([]);
       }
+      if (cmd.includes('defaultBranchRef')) return 'main';
       if (cmd.includes('/branches/main/protection')) {
         return JSON.stringify({});
       }
@@ -105,6 +129,7 @@ describe('fetchCiTrustSignalGithubSync — subprocess boundary', () => {
       if (cmd.includes('/rulesets') && !cmd.match(/rulesets\/\d+/)) {
         throw new Error('gh api: 403');
       }
+      if (cmd.includes('defaultBranchRef')) return 'main';
       if (cmd.includes('/branches/main/protection')) {
         return JSON.stringify({ required_status_checks: { strict: true } });
       }
@@ -153,6 +178,7 @@ describe('fetchCiTrustSignalGithub — AdapterResult wrapper', () => {
       if (cmd.includes('/rulesets') && !cmd.match(/rulesets\/\d+/)) {
         return JSON.stringify([]);
       }
+      if (cmd.includes('defaultBranchRef')) return 'main';
       if (cmd.includes('/branches/main/protection')) {
         return JSON.stringify({ required_status_checks: { strict: true } });
       }

--- a/lib/adapters/fetch-ci-trust-signal-github.ts
+++ b/lib/adapters/fetch-ci-trust-signal-github.ts
@@ -10,22 +10,32 @@
  * Two-step dispatch:
  *   1. `gh api repos/<slug>/rulesets` — merge queue lives in a ruleset; a
  *      `merge_queue` rule flips the signal to `pre_merge_authoritative`.
- *   2. `gh api repos/<slug>/branches/main/protection` — `required_status_checks.strict`
- *      on main is the secondary pre-merge-authoritative signal; any other
- *      branch-protection shape is `post_merge_required`.
+ *   2. `gh api repos/<slug>/branches/<default>/protection` — the LIVE default
+ *      branch's `required_status_checks.strict` is the secondary
+ *      pre-merge-authoritative signal; any other branch-protection shape is
+ *      `post_merge_required`. The default branch is resolved via
+ *      `resolveDefaultBranchGithubSync` (never hardcoded 'main' — #472: a repo
+ *      whose default is e.g. release/1.0.0 would otherwise read the wrong
+ *      branch's protection).
  *
- * A subprocess failure on the branch-protection call surfaces as
- * `{ok: false, …}` — the handler folds that into `level: 'unknown'`.
- * A clean rulesets fetch followed by a failed protection fetch is the only
- * real "API error" path we preserve from the pre-migration handler.
+ * A subprocess failure on the default-branch resolution or the branch-protection
+ * call surfaces as `{ok: false, …}` — the handler folds that into
+ * `level: 'unknown'`. A clean rulesets fetch followed by a failed protection
+ * fetch is the only real "API error" path we preserve from the pre-migration
+ * handler.
  */
 
 import { execSync } from 'child_process';
+import { resolveDefaultBranchGithubSync } from './resolve-default-branch-github.js';
 import type {
   AdapterResult,
   CiTrustSignal,
   FetchCiTrustSignalArgs,
 } from './types.js';
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
 
 // Same charset as fetch-pr-state-github / fetch-issue-closure-github —
 // GitHub's owner/repo grammar. Defended at the adapter boundary.
@@ -84,14 +94,17 @@ function probeRulesets(slug: string): CiTrustSignal | null {
 }
 
 function probeBranchProtection(slug: string): CiTrustSignal {
-  const raw = execSync(`gh api repos/${slug}/branches/main/protection`, {
+  // Resolve the LIVE default branch first — the CI-trust signal must read the
+  // default branch's protection, which is not necessarily `main` (#472).
+  const defaultBranch = resolveDefaultBranchGithubSync(slug, projectDir());
+  const raw = execSync(`gh api repos/${slug}/branches/${defaultBranch}/protection`, {
     encoding: 'utf8',
   });
   const prot = JSON.parse(raw) as GhBranchProtection;
   if (prot.required_status_checks?.strict === true) {
     return {
       level: 'pre_merge_authoritative',
-      reason: 'github branch protection strict=true on main',
+      reason: `github branch protection strict=true on ${defaultBranch}`,
     };
   }
   return {

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -882,8 +882,9 @@ export interface FindMergedPrForBranchPrefixArgs {
  * Two-step dispatch diverges per platform:
  * - GitHub: `gh api repos/<slug>/rulesets` is queried first (merge queue
  *   lives in a ruleset); on cache miss the adapter falls back to
- *   `gh api repos/<slug>/branches/main/protection` and checks the
- *   `required_status_checks.strict` flag.
+ *   `gh api repos/<slug>/branches/<default>/protection` — the LIVE default
+ *   branch resolved via `resolveDefaultBranch` (never hardcoded 'main', #472) —
+ *   and checks the `required_status_checks.strict` flag.
  * - GitLab: `glab api projects/<path>` via `gitlabApiRepo()` (imported from
  *   `lib/gitlab-api.ts`); `merge_trains_enabled` is the lone
  *   pre-merge-authoritative signal — merge pipelines alone are not sufficient

--- a/tests/flightdeck-emit.suite.ts
+++ b/tests/flightdeck-emit.suite.ts
@@ -811,6 +811,7 @@ describe('handler_emit (wired handlers → emit)', () => {
       const headRef = 'kahuna/42-demo';
       setExecMock((cmd) => {
         const c = unquote(cmd);
+        if (c.includes('defaultBranchRef')) return 'main'; // #472: target_branch resolves to live default
         if (c.includes('ls-remote')) return `abc123\trefs/heads/${headRef}`;
         if (c.includes('pr list')) return '[]'; // no existing PR
         if (c.includes('pr create')) return 'https://github.com/o/r/pull/555';

--- a/tests/wave_ci_trust_level.test.ts
+++ b/tests/wave_ci_trust_level.test.ts
@@ -56,6 +56,7 @@ describe('wave_ci_trust_level handler', () => {
       if (cmd.includes('rulesets') && !cmd.match(/rulesets\/\d+/)) {
         return JSON.stringify([]);
       }
+      if (cmd.includes('defaultBranchRef')) return 'main'; // #472: default-branch resolve
       if (cmd.includes('branches/main/protection')) {
         return JSON.stringify({ required_status_checks: { strict: true } });
       }
@@ -75,6 +76,7 @@ describe('wave_ci_trust_level handler', () => {
       if (cmd.includes('rulesets') && !cmd.match(/rulesets\/\d+/)) {
         return JSON.stringify([]);
       }
+      if (cmd.includes('defaultBranchRef')) return 'main'; // #472: default-branch resolve
       if (cmd.includes('branches/main/protection')) {
         return JSON.stringify({ required_status_checks: { strict: false } });
       }

--- a/tests/wave_finalize.plan_id.test.ts
+++ b/tests/wave_finalize.plan_id.test.ts
@@ -47,6 +47,9 @@ beforeEach(() => {
   resetExecMock();
   tmpRoot = makeTmpRoot();
   onExec('git remote get-url origin', () => 'git@github.com:o/r.git');
+  // #472: target_branch resolves to the live default when omitted. Stub the
+  // GitHub default-branch lookup to 'main' so title/base assertions still hold.
+  onExec('defaultBranchRef', 'main');
 });
 
 afterEach(() => {

--- a/tests/wave_finalize.test.ts
+++ b/tests/wave_finalize.test.ts
@@ -60,6 +60,16 @@ beforeEach(() => {
       ? 'git@gitlab.com:o/r.git'
       : 'git@github.com:o/r.git',
   );
+  // #472: target_branch now resolves to the LIVE default branch when omitted
+  // (previously a static zod .default('main')). Stub both platforms' default
+  // lookup to 'main' so the existing "default → main" assertions still hold.
+  // GitHub: `gh repo view --json defaultBranchRef ...` (runArgv-escaped, matched
+  // on the unique field token). GitLab: `glab api projects/:id`.
+  onExec('defaultBranchRef', 'main');
+  // Quote-bounded token so this matches ONLY `glab api projects/:id` (the
+  // default-branch resolve) and NOT `projects/:id/merge_requests?...` (the
+  // prCreate post-create lookup, which uses the same `:id` placeholder).
+  onExec("'projects/:id'", JSON.stringify({ default_branch: 'main' }));
 });
 
 afterEach(() => {

--- a/tests/wave_init.plan_id.test.ts
+++ b/tests/wave_init.plan_id.test.ts
@@ -63,6 +63,10 @@ function setExecRoutes(routes: Array<{ match: string; respond: string | (() => s
         return typeof r.respond === 'function' ? r.respond() : r.respond;
       }
     }
+    // #472: kahuna path resolves the live default branch when base_branch is
+    // omitted — answer the default-branch lookup with 'main' so the existing
+    // `heads/main` SHA route still hits.
+    if (flat.includes('defaultBranchRef')) return 'main';
     return 'wave plan initialized\n';
   });
 }

--- a/tests/wave_init.test.ts
+++ b/tests/wave_init.test.ts
@@ -296,6 +296,12 @@ describe('wave_init handler', () => {
           return typeof r.respond === 'function' ? r.respond() : r.respond;
         }
       }
+      // #472: when the plan omits base_branch, the kahuna path now resolves the
+      // LIVE default branch (previously hardcoded 'main'). Answer both platforms'
+      // default-branch lookup with 'main' — unless a test overrides it via an
+      // explicit route above — so the existing `heads/main` SHA routes still hit.
+      if (flat.includes('defaultBranchRef')) return 'main';                          // github: gh repo view
+      if (/glab api projects\/[^/]+$/.test(flat)) return JSON.stringify({ default_branch: 'main' }); // gitlab: bare projects/<id>
       return 'wave plan initialized\n';
     });
   }


### PR DESCRIPTION
## Summary

Three wave-engine spots hardcoded `'main'` as the mainline instead of resolving the live default branch — the same "assume main" bug behind #888 / #465 / #470. In a repo whose default is `release/1.0.0`, a wave cut its kahuna branch from the wrong place, finalized to the wrong target, and read the wrong branch's protection for CI-trust. All three now route through `resolveDefaultBranch`; explicit caller values still win.

## Changes

- `handlers/wave_init.ts` — when the plan omits `base_branch`, resolve the live default via `getAdapter({repo}).resolveDefaultBranch` instead of `'main'`.
- `handlers/wave_finalize.ts` — dropped the static `z…default('main')`; `target_branch` is optional and resolved from the host when omitted.
- `lib/adapters/fetch-ci-trust-signal-github.ts` — `probeBranchProtection` resolves the default and probes `branches/<default>/protection` (was hardcoded `main`).
- Tests: new case proving fetch-ci-trust targets a non-`main` default (`release/1.0.0`); wave mocks updated to answer `'main'` for the default lookup, preserving every existing assertion.

Out of scope: `resolveProtectedBranch` (4th spot) → #466, gated on branch 457.

## Linked Issues

Closes #472

## Test Plan

`bun test` **2348 pass / 0 fail**, `tsc --noEmit` clean, zero residual hardcoded-`main` mainline defaults in the three files. **Live E2E:** `resolveDefaultBranch("bakeb7j0/branch-guard-smoke")` (a repo whose default is `release/1.0.0`) returns `release/1.0.0` — real `gh` call, no mock.