### PR TITLE
fix(work_item): add type 'plan'; stop leaking type::epic onto Plans on GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 **BREAKING CHANGE (#363, Story 2.2):** `wave_finalize` no longer accepts `epic_id`. Callers must pass `plan_id`. The assembled kahuna→target MR title changes from `epic(#N): <slug> — kahuna to <target>` to `plan(#N): <slug> — kahuna to <target>`. No legacy-compat fallback; the old parameter name fails schema validation with a clear error. Part of the Plan/Phase/Epic taxonomy lock (cc-workflow#499).
 
 ### Features
+- **work_item**: `type: "plan"` is now a first-class type, applying the `type::plan` label. `/issue plan` previously could not create a Plan issue at all — the enum had no `plan` — and callers worked around it with `type: "epic"` plus an explicit `type::plan` label. [#477]
+
+### Fixes
+- **work_item**: the automatic `type::<type>` label is now **suppressed when the caller supplies any `type::*` label of their own**, on both platforms. It was previously prepended unconditionally, which was safe only **by accident** on GitLab: `type::epic` and `type::plan` share the `type::` scope key, GitLab's scoped labels are mutually exclusive, and the caller's later label evicted ours. **GitHub has no scoped labels**, so the identical call produced an issue carrying **both** — a Plan mislabelled as an Epic, which the pipeline is specified never to read (Dev Spec R-19). Relying on the target platform to clean up after us is not a contract. Caller labels are also trimmed before they reach the platform (`gh` matches label names exactly and rejects an untrimmed one outright; GitLab would mint a junk label). A missing-label failure on GitHub now names the remedy (`label_create` first — GitHub does not create labels implicitly, GitLab does). [#477]
+
 - **plan_load_dod**: New MCP tool to fetch Plan tracking-issue and extract Definition of Done structure — both Plan-level DoD checkboxes and per-Phase DoD checklists with [R-XX] refs. Returns parsed view including Dev Spec path from References section. Part of the Plan DoD workflow family. [#388]
 - **wave_reconcile**: New Prime(post-wave) reconciliation handler emitting canonical `[drift-halt]` comments on Category B drift per Dev Spec §5.4.1. [#366, Story 2.5]
 - **devspec_finalize**: Require `depends_on` field on every Story in `phases-waves.json` (may be empty array); finalization fails with a named list of offenders otherwise. [#367, Story 2.6]

--- a/handlers/work_item.ts
+++ b/handlers/work_item.ts
@@ -16,7 +16,7 @@ import { getAdapter } from '../lib/adapters/index.js';
 import { repoOptionalSchema } from '../lib/schemas/repo.js';
 
 const inputSchema = z.object({
-  type: z.enum(['epic', 'story', 'feature', 'bug', 'chore', 'docs', 'fix', 'pr', 'mr']),
+  type: z.enum(['plan', 'epic', 'story', 'feature', 'bug', 'chore', 'docs', 'fix', 'pr', 'mr']),
   title: z.string().min(1, 'title must be a non-empty string'),
   body: z.string().optional(),
   labels: z.array(z.string()).optional(),

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -659,6 +659,7 @@ export interface LabelListResponse {
  * carry `size::*` / `priority::*` etc. via the caller's explicit labels list).
  */
 export type WorkItemType =
+  | 'plan'
   | 'epic'
   | 'story'
   | 'feature'

--- a/lib/adapters/work-item-github.test.ts
+++ b/lib/adapters/work-item-github.test.ts
@@ -202,3 +202,100 @@ describe('workItemGithub — subprocess boundary', () => {
     expect(call).toContain(`'it'\\''s a story'`);
   });
 });
+
+describe('type::plan + the platform-independent auto-label (#477)', () => {
+  test('type: "plan" applies type::plan', async () => {
+    onExec('gh issue create', 'https://github.com/org/repo/issues/167');
+    const r = await workItemGithub({ type: 'plan', title: 'Plan: X' });
+    if (!('ok' in r) || !r.ok) throw new Error(`expected ok, got ${JSON.stringify(r)}`);
+    const call = execCalls().join(' ');
+    expect(call).toContain('type::plan');
+    expect(call).not.toContain('type::epic');
+  });
+
+  test('THE TAXONOMY LEAK: a caller-supplied type:: label SUPPRESSES the auto-label', async () => {
+    // Before #477, work_item unconditionally PREPENDED type::<type>. On GitLab
+    // that was invisible — scoped labels are mutually exclusive within `type::`,
+    // so the caller's later label evicted ours. GitHub has NO scoped labels, so
+    // the issue carried BOTH type::epic and type::plan — a Plan mislabelled as an
+    // Epic, which the pipeline is specified never to read (Dev Spec R-19).
+    //
+    // Safe-by-accident on one platform is not safe. Never let the target platform
+    // clean up after us.
+    onExec('gh issue create', 'https://github.com/org/repo/issues/167');
+    const r = await workItemGithub({
+      type: 'epic',
+      title: 'Plan: X',
+      labels: ['type::plan', 'priority::critical'],
+    });
+    if (!('ok' in r) || !r.ok) throw new Error('expected ok');
+
+    const call = execCalls().join(' ');
+    expect(call).toContain('type::plan');
+    expect(call).toContain('priority::critical');
+    expect(call).not.toContain('type::epic'); // the leak
+  });
+
+  test('the auto-label still applies when the caller supplies NO type:: label', async () => {
+    onExec('gh issue create', 'https://github.com/org/repo/issues/9');
+    const r = await workItemGithub({
+      type: 'bug',
+      title: 'x',
+      labels: ['priority::high'],
+    });
+    if (!('ok' in r) || !r.ok) throw new Error('expected ok');
+    const call = execCalls().join(' ');
+    expect(call).toContain('type::bug');
+    expect(call).toContain('priority::high');
+  });
+});
+
+describe('#477 — suppression edges', () => {
+  test('a NON-type scoped label must NOT suppress the auto-label', async () => {
+    // Guards against someone loosening the check to `.includes('::')`, which would
+    // silently kill the auto-label on every `/issue <type> --epic N` call while
+    // every other test stayed green.
+    onExec('gh issue create', 'https://github.com/org/repo/issues/12');
+    const r = await workItemGithub({
+      type: 'feature',
+      title: 'x',
+      labels: ['epic::12', 'priority::high'],
+    });
+    if (!('ok' in r) || !r.ok) throw new Error('expected ok');
+    const call = execCalls().join(' ');
+    expect(call).toContain('type::feature'); // auto-label still applied
+    expect(call).toContain('epic::12');
+  });
+
+  test('messy caller labels are normalized before they reach the platform', async () => {
+    // ' type::plan ' must both (a) suppress the auto-label and (b) be TRIMMED —
+    // gh matches label names exactly and would reject the create outright.
+    onExec('gh issue create', 'https://github.com/org/repo/issues/13');
+    const r = await workItemGithub({
+      type: 'epic',
+      title: 'x',
+      labels: [' Type::Plan ', '', '  priority::high'],
+    });
+    if (!('ok' in r) || !r.ok) throw new Error('expected ok');
+    const call = execCalls().join(' ');
+    expect(call).not.toContain('type::epic'); // suppressed despite the mess
+    expect(call).toContain('Type::Plan'); // trimmed, not passed with spaces
+    expect(call).not.toContain(' Type::Plan '); // the untrimmed form never ships
+    expect(call).toContain('priority::high');
+  });
+
+  test('a missing label yields an ACTIONABLE error, not a bare gh dump', async () => {
+    // gh issue create --label X FAILS (and creates nothing) if X does not exist.
+    // GitLab mints labels implicitly; GitHub does not. The server should say so.
+    onExec('gh issue create', () => {
+      const err = new Error('boom') as ThrowableError;
+      err.stderr = "could not add label: 'type::plan' not found";
+      err.status = 1;
+      throw err;
+    });
+    const r = await workItemGithub({ type: 'plan', title: 'Plan: X' });
+    expectErr(r);
+    expect(r.error).toMatch(/label_create/);
+    expect(r.error).toMatch(/does not create labels implicitly|not create labels/i);
+  });
+});

--- a/lib/adapters/work-item-github.ts
+++ b/lib/adapters/work-item-github.ts
@@ -13,11 +13,12 @@
  *     pre-migration bug that #281 tracked).
  *
  * Argv composition:
- *   Issue types (epic | story | bug | chore | docs | feature | fix):
+ *   Issue types (plan | epic | story | bug | chore | docs | feature | fix):
  *     gh issue create
  *       --title <title>
  *       --body <body>
- *       [--label <label>]...          // repeated; includes auto `type::<type>`
+ *       [--label <label>]...          // auto `type::<type>` UNLESS the caller
+ *       //                               supplied a type::* label of their own
  *       [--repo <owner/repo>]
  *
  *   `type: 'pr'`:
@@ -44,6 +45,7 @@ function projectDir(): string {
 }
 
 const ISSUE_TYPE_LABELS: Record<string, string | null> = {
+  plan: 'type::plan',
   epic: 'type::epic',
   story: 'type::story',
   feature: 'type::feature',
@@ -54,6 +56,33 @@ const ISSUE_TYPE_LABELS: Record<string, string | null> = {
   pr: null,
   mr: null,
 };
+
+/**
+ * The auto `type::<type>` label, UNLESS the caller already supplied one.
+ *
+ * The auto-label used to be prepended unconditionally. That was only ever safe by
+ * ACCIDENT, and only on GitLab: `type::epic` and `type::plan` share the `type::`
+ * scope key, GitLab's scoped labels are mutually exclusive, and the caller's later
+ * label evicted ours. GitHub has NO scoped labels — so the same call produced an
+ * issue carrying BOTH, which is precisely the taxonomy leak Dev Spec R-19 forbids
+ * (a Plan is a pipeline artifact; an Epic is a PM-layer grouping the pipeline never
+ * reads).
+ *
+ * Relying on the target platform to clean up after us is not a contract. If the
+ * caller has stated the type explicitly, we do not second-guess it — on either
+ * platform.
+ */
+function autoTypeLabel(
+  type: string,
+  callerLabels: string[] | undefined,
+): string | null {
+  const auto = ISSUE_TYPE_LABELS[type];
+  if (!auto) return null;
+  const callerSetType = (callerLabels ?? []).some((l) =>
+    l.trim().toLowerCase().startsWith('type::'),
+  );
+  return callerSetType ? null : auto;
+}
 
 function isIssueType(type: string): boolean {
   return type !== 'pr' && type !== 'mr';
@@ -90,8 +119,15 @@ export async function workItemGithub(
 
     if (isIssueType(args.type)) {
       const cmd = ['gh', 'issue', 'create', '--title', args.title, '--body', body];
-      const autoLabel = ISSUE_TYPE_LABELS[args.type];
-      const labels = autoLabel ? [autoLabel, ...(args.labels ?? [])] : [...(args.labels ?? [])];
+      // Normalize ONCE, then feed BOTH the suppression check and the argv. If we
+      // only trim for detection, ' type::plan ' suppresses the auto-label and then
+      // goes to the platform verbatim — gh matches label names exactly and rejects
+      // the create, and GitLab happily mints a junk label. Handing the mess to the
+      // platform after taking responsibility for it is the very thing this function
+      // exists to stop.
+      const callerLabels = (args.labels ?? []).map((l) => l.trim()).filter(Boolean);
+      const autoLabel = autoTypeLabel(args.type, callerLabels);
+      const labels = autoLabel ? [autoLabel, ...callerLabels] : callerLabels;
       for (const label of labels) {
         cmd.push('--label', label);
       }
@@ -99,10 +135,18 @@ export async function workItemGithub(
 
       const result = runArgv(cmd, cwd);
       if (result.exitCode !== 0) {
+        const stderr = result.stderr.trim() || result.stdout.trim();
+        // `gh issue create --label X` FAILS (and creates nothing) when X does not
+        // already exist on the repo — unlike GitLab, which mints labels implicitly.
+        // Carry the remedy in the server rather than relying on every skill to
+        // remember it.
+        const missingLabel = /could not add label/i.test(stderr)
+          ? ` — the label must already exist on the repo: call label_create for it first (GitHub does not create labels implicitly; GitLab does)`
+          : '';
         return {
           ok: false,
           code: 'gh_issue_create_failed',
-          error: `gh issue create failed: ${result.stderr.trim() || result.stdout.trim()}`,
+          error: `gh issue create failed: ${stderr}${missingLabel}`,
         };
       }
       return { ok: true, data: parseGhOutput(result.stdout) };

--- a/lib/adapters/work-item-gitlab.test.ts
+++ b/lib/adapters/work-item-gitlab.test.ts
@@ -182,3 +182,31 @@ describe('workItemGitlab — subprocess boundary', () => {
     expect(result.code).toBe('glab_mr_create_failed');
   });
 });
+
+describe('type::plan + the platform-independent auto-label (#477)', () => {
+  test('type: "plan" applies type::plan', async () => {
+    onExec('glab issue create', 'https://gitlab.com/org/repo/-/issues/167');
+    const r = await workItemGitlab({ type: 'plan', title: 'Plan: X' });
+    if (!('ok' in r) || !r.ok) throw new Error(`expected ok, got ${JSON.stringify(r)}`);
+    expect(execCalls().join(' ')).toContain('type::plan');
+  });
+
+  test('a caller-supplied type:: label suppresses the auto-label HERE TOO', async () => {
+    // GitLab hid this bug: scoped labels are mutually exclusive within the
+    // `type::` key, so the caller's later type::plan evicted our type::epic and
+    // nobody noticed. We now suppress it explicitly on BOTH platforms rather than
+    // depending on GitLab to clean up after us — the same call on GitHub carried
+    // both labels.
+    onExec('glab issue create', 'https://gitlab.com/org/repo/-/issues/167');
+    const r = await workItemGitlab({
+      type: 'epic',
+      title: 'Plan: X',
+      labels: ['type::plan'],
+    });
+    if (!('ok' in r) || !r.ok) throw new Error('expected ok');
+
+    const call = execCalls().join(' ');
+    expect(call).toContain('type::plan');
+    expect(call).not.toContain('type::epic');
+  });
+});

--- a/lib/adapters/work-item-gitlab.ts
+++ b/lib/adapters/work-item-gitlab.ts
@@ -13,11 +13,12 @@
  *     pre-migration bug — `createGithubPR` ran against a GitLab origin).
  *
  * Argv composition:
- *   Issue types (epic | story | bug | chore | docs | feature | fix):
+ *   Issue types (plan | epic | story | bug | chore | docs | feature | fix):
  *     glab issue create
  *       --title <title>
  *       --description <body>
- *       [--label <csv>]               // glab takes a comma-separated list
+ *       [--label <csv>]               // glab takes a comma-separated list; auto
+ *       //                               `type::<type>` unless the caller set one
  *       [-R <owner/repo>]             // glab uses short `-R`, NOT `--repo`
  *
  *   `type: 'mr'`:
@@ -47,6 +48,7 @@ function projectDir(): string {
 }
 
 const ISSUE_TYPE_LABELS: Record<string, string | null> = {
+  plan: 'type::plan',
   epic: 'type::epic',
   story: 'type::story',
   feature: 'type::feature',
@@ -57,6 +59,33 @@ const ISSUE_TYPE_LABELS: Record<string, string | null> = {
   pr: null,
   mr: null,
 };
+
+/**
+ * The auto `type::<type>` label, UNLESS the caller already supplied one.
+ *
+ * The auto-label used to be prepended unconditionally. That was only ever safe by
+ * ACCIDENT, and only on GitLab: `type::epic` and `type::plan` share the `type::`
+ * scope key, GitLab's scoped labels are mutually exclusive, and the caller's later
+ * label evicted ours. GitHub has NO scoped labels — so the same call produced an
+ * issue carrying BOTH, which is precisely the taxonomy leak Dev Spec R-19 forbids
+ * (a Plan is a pipeline artifact; an Epic is a PM-layer grouping the pipeline never
+ * reads).
+ *
+ * Relying on the target platform to clean up after us is not a contract. If the
+ * caller has stated the type explicitly, we do not second-guess it — on either
+ * platform.
+ */
+function autoTypeLabel(
+  type: string,
+  callerLabels: string[] | undefined,
+): string | null {
+  const auto = ISSUE_TYPE_LABELS[type];
+  if (!auto) return null;
+  const callerSetType = (callerLabels ?? []).some((l) =>
+    l.trim().toLowerCase().startsWith('type::'),
+  );
+  return callerSetType ? null : auto;
+}
 
 function isIssueType(type: string): boolean {
   return type !== 'pr' && type !== 'mr';
@@ -93,8 +122,15 @@ export async function workItemGitlab(
 
     if (isIssueType(args.type)) {
       const cmd = ['glab', 'issue', 'create', '--title', args.title, '--description', body];
-      const autoLabel = ISSUE_TYPE_LABELS[args.type];
-      const labels = autoLabel ? [autoLabel, ...(args.labels ?? [])] : [...(args.labels ?? [])];
+      // Normalize ONCE, then feed BOTH the suppression check and the argv. If we
+      // only trim for detection, ' type::plan ' suppresses the auto-label and then
+      // goes to the platform verbatim — gh matches label names exactly and rejects
+      // the create, and GitLab happily mints a junk label. Handing the mess to the
+      // platform after taking responsibility for it is the very thing this function
+      // exists to stop.
+      const callerLabels = (args.labels ?? []).map((l) => l.trim()).filter(Boolean);
+      const autoLabel = autoTypeLabel(args.type, callerLabels);
+      const labels = autoLabel ? [autoLabel, ...callerLabels] : callerLabels;
       if (labels.length > 0) {
         cmd.push('--label', labels.join(','));
       }


### PR DESCRIPTION
## Summary

Two changes, one of which is a real taxonomy bug.

**1. `type: "plan"` is now a first-class type**, applying `type::plan`. The enum had no `plan`, so `/issue plan` could not create a Plan issue at all — documented as supported, impossible in practice. Callers worked around it with `type: "epic"` plus an explicit `type::plan` label.

**2. That workaround was safe only BY ACCIDENT, and only on GitLab.**

`work_item` *prepended* the auto `type::<type>` label unconditionally. On GitLab, `type::epic` and `type::plan` share the `type::` scope key and **scoped labels are mutually exclusive**, so the caller's later `type::plan` **evicted** our `type::epic` — and nobody noticed. **GitHub has no scoped labels.** The identical call produced an issue carrying **both**: a Plan mislabelled as an Epic.

Dev Spec **R-19** is explicit that the pipeline must never read `type::epic` / `epic::N` — a Plan is a pipeline artifact, an Epic is a PM-layer grouping the pipeline ignores. Relying on the target platform to clean up after us is not a contract.

The auto-label is now **suppressed whenever the caller supplies any `type::*` label, on both platforms.**

Reported by **deep-thought** (bs) after `/issue plan` failed. The *absent* `type::epic` on his Plan #167 was GitLab quietly covering for us.

## Also, from review

- **Caller labels are normalized once**, and the same values feed both the suppression check and the argv. Previously the check trimmed/lowercased and the argv did not — so `' type::plan '` would suppress correctly and then be **rejected outright by `gh`** (which matches label names exactly), or mint a junk label on GitLab. Taking responsibility for the messy input and then handing the mess to the platform is precisely what this function exists to stop.
- **A GitHub missing-label failure now names the remedy.** `gh issue create --label X` fails (creating nothing) when `X` does not exist; GitLab mints labels implicitly. The server carries that knowledge instead of every skill remembering to call `label_create` first.
- Header contracts + CHANGELOG updated — they asserted the exact behavior this PR removes.

## Linked Issues

Closes #477

## Test Plan

- `bun test` → **2383 passed, 0 failed**. `tsc --noEmit` clean.
- **Leak guard mutation-tested:** restoring the unconditional prepend turns it red.
- **Negative guard:** a non-type scoped label (`epic::12`) must **not** suppress the auto-label — without it, loosening the check to `.includes("::")` would silently kill the auto-label on every `/issue <type> --epic N` call with the whole suite still green.
- Edge coverage: `" Type::Plan "` both suppresses *and* is trimmed before it reaches the platform; empty-string labels are dropped (they would produce `type::plan,,foo` in GitLab's CSV).

## Note for follow-up

The adapter still lets `type: "story"` + `labels: ["type::bug"]` through silently. That leniency is **load-bearing today** — it is what keeps `/issue`'s existing workaround producing correct issues. Once cc-workflow passes `type: "plan"` directly, that mismatch should become an error rather than being silently honoured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CSEY5TUixZARAmHrjYTYX
