### PR TITLE
feat(ops): deploy-freshness guard — warn when the running binary is behind its own release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 **BREAKING CHANGE (#363, Story 2.2):** `wave_finalize` no longer accepts `epic_id`. Callers must pass `plan_id`. The assembled kahuna→target MR title changes from `epic(#N): <slug> — kahuna to <target>` to `plan(#N): <slug> — kahuna to <target>`. No legacy-compat fallback; the old parameter name fails schema validation with a clear error. Part of the Plan/Phase/Epic taxonomy lock (cc-workflow#499).
 
 ### Features
+- **deploy-freshness check**: the `sdlc-server` binary now embeds its build commit SHA (via `bun build --define`) and, once at startup, emits a `warn`-level `deploy_freshness` log line when that commit is **behind** this repo's latest GitHub release — naming both and the remedy (`redeploy with ./install --mcps`). Uses GitHub's commit-compare API for an **exact** ancestry check, not a date heuristic. **Network-optional**: offline / unauthenticated / no-releases all degrade to silence; it never blocks startup, never spams, and never warns on a build that is newer than the latest release or on an uncompiled dev build. Motivated by a stale deploy that lagged the latest release by four merged fixes with no signal anywhere. [#447]
 - **work_item**: `type: "plan"` is now a first-class type, applying the `type::plan` label. `/issue plan` previously could not create a Plan issue at all — the enum had no `plan` — and callers worked around it with `type: "epic"` plus an explicit `type::plan` label. [#477]
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -47,6 +47,39 @@ Two CI gate-greps (`scripts/ci/gate-greps.sh`) enforce the dispatch model: Gate 
 
 3. **Restart Claude Code** to activate the server.
 
+### Staying current — the deploy-freshness warning (#447)
+
+The running binary and the latest release can silently drift apart. A stale
+deploy once lagged the latest release by four merged fixes with **no signal
+anywhere** — the only symptom was a confusing downstream failure miles from the
+root cause.
+
+To make that visible, the binary embeds its build commit SHA (via
+`bun build --define` in `scripts/ci/build.sh`) and, **once at startup**, asks
+GitHub whether that commit is behind this repo's latest release. If it is, it
+emits a single `warn` line to stderr:
+
+```json
+{"level":"warn","event":"deploy_freshness","binary_sha":"081433d…",
+ "latest_release":"v2.0.3","msg":"sdlc-server binary … is BEHIND the latest release v2.0.3 — redeploy with ./install --mcps"}
+```
+
+Seeing that line means: **redeploy.** Re-run the install command above (or
+`./install --mcps` from the kit) to pull the current release binary.
+
+Properties, by design:
+- **Exact, not a date guess** — it uses GitHub's commit-compare API, so a
+  same-day build that is genuinely current does not warn.
+- **Network-optional** — offline, unauthenticated, or no-releases all degrade to
+  **silence**. It never blocks startup and never spams.
+- **No false alarms** — a build that is *newer* than the latest release (a local
+  dev build) does not warn; neither does a dev build with no embedded SHA.
+- **Self-scoped** — it checks the server against *its own* releases, independent
+  of whichever project you are operating on.
+
+If you build locally with `scripts/ci/build.sh`, the SHA is your working-tree
+`HEAD`; a dev build ahead of the last release is silent, which is correct.
+
 ## Handler Registry
 
 Tools are auto-discovered at build time via a glob pattern over `handlers/`. To add a tool, drop a file in `handlers/` that exports a `HandlerDef` default. No other files need to change.

--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,8 @@ import { CallToolRequestSchema, ErrorCode, ListToolsRequestSchema, McpError } fr
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { handlers } from './handlers/_registry';
 import { log } from './logger';
+import { checkDeployFreshness } from './lib/deploy_freshness.js';
+import { ghFreshnessDeps } from './lib/deploy_freshness_gh.js';
 
 const SERVER_VERSION = '1.0.0';
 
@@ -42,3 +44,8 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
 const transport = new StdioServerTransport();
 await server.connect(transport);
 log.info('startup', { version: SERVER_VERSION, config: { handler_count: handlers.length } });
+
+// #447 — one-time deploy-freshness check. Fire-and-forget: it must not block the
+// transport, and it swallows every failure internally, so a bare .catch() here is
+// belt-and-suspenders against an unexpected throw.
+void checkDeployFreshness(ghFreshnessDeps).catch(() => {});

--- a/lib/deploy_freshness.test.ts
+++ b/lib/deploy_freshness.test.ts
@@ -1,0 +1,129 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  checkDeployFreshness,
+  getBuildInfo,
+  type CompareStatus,
+  type FreshnessDeps,
+} from './deploy_freshness.ts';
+
+const SHA = 'a'.repeat(40);
+
+function deps(over: Partial<FreshnessDeps> = {}): FreshnessDeps {
+  return {
+    fetchLatestReleaseTag: async () => 'v2.0.5',
+    compareRefs: async () => 'ahead',
+    ...over,
+  };
+}
+
+describe('deploy-freshness (#447)', () => {
+  // In the (uncompiled) test runtime the __BUILD_*__ defines are absent, so the
+  // build reads as 'dev'. That is itself the "skip a dev build" path — assert it.
+  test('a dev build (no embedded SHA) is skipped — never warns', async () => {
+    expect(getBuildInfo().sha).toBe('dev');
+    let compared = false;
+    const r = await checkDeployFreshness(
+      deps({ compareRefs: async () => { compared = true; return 'ahead'; } }),
+    );
+    expect(r).toBeNull();
+    expect(compared).toBe(false); // short-circuits before any network call
+  });
+
+  // The remaining cases need a REAL 40-hex SHA. getBuildInfo() reads the injected
+  // globals, so set them for the duration of the test.
+  function withBuildSha<T>(sha: string, fn: () => T): T {
+    (globalThis as Record<string, unknown>).__BUILD_SHA__ = sha;
+    (globalThis as Record<string, unknown>).__BUILD_REF__ = 'v2.0.1';
+    (globalThis as Record<string, unknown>).__BUILD_AT__ = '2026-05-14T02:39:00Z';
+    try {
+      return fn();
+    } finally {
+      delete (globalThis as Record<string, unknown>).__BUILD_SHA__;
+      delete (globalThis as Record<string, unknown>).__BUILD_REF__;
+      delete (globalThis as Record<string, unknown>).__BUILD_AT__;
+    }
+  }
+
+  test('binary BEHIND the latest release → warns, naming both and the remedy', async () => {
+    const r = await withBuildSha(SHA, () =>
+      checkDeployFreshness(deps({ compareRefs: async (base, head) => {
+        expect(base).toBe(SHA);   // base = binary
+        expect(head).toBe('v2.0.5'); // head = latest release
+        return 'ahead';           // release is ahead → binary behind
+      } })),
+    );
+    expect(r).not.toBeNull();
+    expect(r!.binary_sha).toBe(SHA);
+    expect(r!.latest_release).toBe('v2.0.5');
+  });
+
+  test('binary IDENTICAL to the latest release → no warning', async () => {
+    const r = await withBuildSha(SHA, () =>
+      checkDeployFreshness(deps({ compareRefs: async () => 'identical' })),
+    );
+    expect(r).toBeNull();
+  });
+
+  test('binary NEWER than the latest release (a dev build past the tag) → no warning', async () => {
+    // base=binary is ahead of head=release → status 'behind' → do not warn.
+    const r = await withBuildSha(SHA, () =>
+      checkDeployFreshness(deps({ compareRefs: async () => 'behind' })),
+    );
+    expect(r).toBeNull();
+  });
+
+  test('DIVERGED (built off a side branch) → no warning', async () => {
+    const r = await withBuildSha(SHA, () =>
+      checkDeployFreshness(deps({ compareRefs: async () => 'diverged' })),
+    );
+    expect(r).toBeNull();
+  });
+
+  test('offline / no releases (tag lookup fails) → silent, no compare attempted', async () => {
+    let compared = false;
+    const r = await withBuildSha(SHA, () =>
+      checkDeployFreshness(deps({
+        fetchLatestReleaseTag: async () => null,
+        compareRefs: async () => { compared = true; return 'ahead'; },
+      })),
+    );
+    expect(r).toBeNull();
+    expect(compared).toBe(false);
+  });
+
+  test('compare call fails (network blip) → silent', async () => {
+    const r = await withBuildSha(SHA, () =>
+      checkDeployFreshness(deps({ compareRefs: async () => null })),
+    );
+    expect(r).toBeNull();
+  });
+
+  test('a THROWING dep never propagates — the check must not disrupt startup', async () => {
+    const r = await withBuildSha(SHA, () =>
+      checkDeployFreshness(deps({
+        fetchLatestReleaseTag: async () => { throw new Error('boom'); },
+      })),
+    );
+    expect(r).toBeNull(); // swallowed, not thrown
+  });
+});
+
+describe('ghFreshnessDeps — the real IO boundary is non-throwing (#447)', () => {
+  // The unit tests above inject fakes, so they never exercise the real subprocess
+  // path — which is exactly where the "never disrupt the server" property lives.
+  // Point PATH at nothing so `gh` cannot be found (ENOENT), and assert the real
+  // deps resolve to null rather than throwing or hanging.
+  test('a missing `gh` resolves to null, never throws', async () => {
+    const { ghFreshnessDeps } = await import('./deploy_freshness_gh.ts');
+    const savedPath = process.env.PATH;
+    process.env.PATH = '/nonexistent-dir-for-freshness-test';
+    try {
+      const tag = await ghFreshnessDeps.fetchLatestReleaseTag();
+      const cmp = await ghFreshnessDeps.compareRefs('a'.repeat(40), 'v1.0.0');
+      expect(tag).toBeNull();
+      expect(cmp).toBeNull();
+    } finally {
+      process.env.PATH = savedPath;
+    }
+  });
+});

--- a/lib/deploy_freshness.ts
+++ b/lib/deploy_freshness.ts
@@ -1,0 +1,111 @@
+/**
+ * Deploy-freshness check (#447).
+ *
+ * "Fixed in source, stale in binary" cost the fleet real debugging time: a
+ * deployed `sdlc-server` binary lagged the latest release by four merged fixes,
+ * with no signal anywhere — the only symptom was a confusing downstream failure
+ * miles from the root cause. (It also fooled ME: I once reasoned from repo source
+ * that was five days ahead of the running binary and gave a teammate a confident
+ * wrong answer. See the ethos note at the bottom of #447.)
+ *
+ * This emits a one-time `warn` at startup when the RUNNING binary is behind the
+ * server's own latest GitHub release. It is:
+ *   - EXACT, not date-heuristic: it asks GitHub's compare API whether the build
+ *     commit is an ancestor of the latest release tag.
+ *   - NETWORK-OPTIONAL: any failure (offline, no `gh`, no auth, no releases)
+ *     degrades silently. It never blocks startup and never throws.
+ *   - self-scoped: the check is about the SERVER'S OWN repo (always the GitHub
+ *     repo below), independent of whatever project the server is operating on —
+ *     so there is no platform ambiguity.
+ */
+
+import { log } from '../logger.js';
+
+// The server's own home. The freshness question is always "is this binary behind
+// ITS OWN latest release", never about the project under operation.
+export const SELF_REPO = 'Wave-Engineering/mcp-server-sdlc';
+
+// Compile-time injected by scripts/ci/build.sh via `bun build --define`. Absent in
+// dev/test runs (uncompiled) — `typeof` keeps that reference safe, and a build that
+// carries no real SHA is treated as a dev build and skipped (a dev build is never
+// "stale" relative to a release).
+declare const __BUILD_SHA__: string;
+declare const __BUILD_REF__: string;
+declare const __BUILD_AT__: string;
+
+export interface BuildInfo {
+  sha: string;
+  ref: string;
+  builtAt: string;
+}
+
+const DEV_SENTINEL = 'dev';
+
+export function getBuildInfo(): BuildInfo {
+  return {
+    sha: typeof __BUILD_SHA__ === 'undefined' ? DEV_SENTINEL : __BUILD_SHA__,
+    ref: typeof __BUILD_REF__ === 'undefined' ? DEV_SENTINEL : __BUILD_REF__,
+    builtAt: typeof __BUILD_AT__ === 'undefined' ? DEV_SENTINEL : __BUILD_AT__,
+  };
+}
+
+/** A real, comparable build carries a 40-char commit SHA. */
+function isReleaseComparable(info: BuildInfo): boolean {
+  return /^[0-9a-f]{40}$/i.test(info.sha);
+}
+
+/** GitHub's `base...head` comparison verdict — `head` relative to `base`. */
+export type CompareStatus = 'ahead' | 'behind' | 'identical' | 'diverged';
+
+export interface FreshnessDeps {
+  /** Latest release tag name of SELF_REPO, or null on any failure. */
+  fetchLatestReleaseTag: () => Promise<string | null>;
+  /**
+   * GitHub compare status for `base...head`. `ahead` = head has commits base does
+   * not (base is behind head). null on any failure.
+   */
+  compareRefs: (base: string, head: string) => Promise<CompareStatus | null>;
+  now?: () => number;
+}
+
+/**
+ * Run the check. NEVER throws, NEVER blocks — designed to be called
+ * fire-and-forget at startup. Returns the emitted warning payload (or null when
+ * nothing was warned) purely so tests can assert without scraping stderr.
+ */
+export async function checkDeployFreshness(
+  deps: FreshnessDeps,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const info = getBuildInfo();
+
+    // A dev build (or any build without an embedded commit SHA) is never "behind"
+    // a release — there is nothing meaningful to compare. Skip silently.
+    if (!isReleaseComparable(info)) return null;
+
+    const tag = await deps.fetchLatestReleaseTag();
+    if (!tag) return null; // offline / no releases / no auth → silent
+
+    // base = the running binary's commit, head = the latest release tag.
+    // `ahead` means the release has commits the binary does not → binary is BEHIND.
+    const status = await deps.compareRefs(info.sha, tag);
+    if (status !== 'ahead') return null; // identical / behind (newer dev) / diverged / null → no warn
+
+    const payload = {
+      binary_sha: info.sha,
+      binary_ref: info.ref,
+      binary_built_at: info.builtAt,
+      latest_release: tag,
+      repo: SELF_REPO,
+    };
+    log.warn(
+      'deploy_freshness',
+      payload,
+      `sdlc-server binary (${info.sha.slice(0, 8)}, built ${info.builtAt}) is BEHIND the latest release ${tag} — redeploy with ./install --mcps`,
+    );
+    return payload;
+  } catch {
+    // Freshness is a courtesy signal; it must never disrupt the server.
+    return null;
+  }
+}

--- a/lib/deploy_freshness_gh.ts
+++ b/lib/deploy_freshness_gh.ts
@@ -1,0 +1,64 @@
+/**
+ * The real GitHub-backed FreshnessDeps for #447. Kept apart from the pure logic
+ * in deploy_freshness.ts so the logic is testable without touching a subprocess.
+ *
+ * TRULY ASYNC, and this matters. The check fires at startup, in the same window
+ * the MCP client sends `initialize`. The rest of the server shells out with the
+ * SYNCHRONOUS `execSync` (fine inside a tool call, which is already blocking), but
+ * here that would freeze the event loop across two `gh api` round-trips and stall
+ * the handshake — and with no timeout, a black-holed network would hang the server
+ * for as long as the OS lets a TCP connect stall. So this uses `execFile` (async,
+ * no shell) with a bounded timeout: the event loop keeps turning, and every
+ * failure — missing `gh`, non-zero exit, timeout, offline — resolves to null.
+ */
+
+import * as childProcess from 'node:child_process';
+import { promisify } from 'node:util';
+import type { CompareStatus, FreshnessDeps } from './deploy_freshness.js';
+import { SELF_REPO } from './deploy_freshness.js';
+
+// Bound each call so a hung network cannot delay the server indefinitely.
+const GH_TIMEOUT_MS = 5000;
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+}
+
+/** Run `gh <args>` async; null on ANY failure (exit≠0, timeout, ENOENT, …). */
+async function ghApi(args: string[]): Promise<string | null> {
+  try {
+    const execFileAsync = promisify(childProcess.execFile);
+    const { stdout } = await execFileAsync('gh', args, {
+      cwd: projectDir(),
+      timeout: GH_TIMEOUT_MS,
+      encoding: 'utf8',
+    });
+    const out = stdout.trim();
+    return out.length > 0 ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+const VALID_STATUS = new Set<CompareStatus>([
+  'ahead',
+  'behind',
+  'identical',
+  'diverged',
+]);
+
+export const ghFreshnessDeps: FreshnessDeps = {
+  async fetchLatestReleaseTag(): Promise<string | null> {
+    return ghApi(['api', `repos/${SELF_REPO}/releases/latest`, '--jq', '.tag_name']);
+  },
+
+  async compareRefs(base: string, head: string): Promise<CompareStatus | null> {
+    // encodeURIComponent guards the path even though both args are our own
+    // (a 40-hex SHA and a release tag) — defense at the boundary.
+    const range = `${encodeURIComponent(base)}...${encodeURIComponent(head)}`;
+    const status = await ghApi(['api', `repos/${SELF_REPO}/compare/${range}`, '--jq', '.status']);
+    return status !== null && VALID_STATUS.has(status as CompareStatus)
+      ? (status as CompareStatus)
+      : null;
+  },
+};

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -13,6 +13,14 @@ cd "$(dirname "$0")/../.."
 
 mkdir -p dist
 
+# #447 — embed build provenance so a running binary can tell whether it is behind
+# its own latest release. `bun build --define` replaces these identifiers at compile
+# time; in dev/test (uncompiled) they are absent and the freshness check treats the
+# build as a dev build and skips. Degrade gracefully if git metadata is unavailable.
+BUILD_SHA="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+BUILD_REF="$(git describe --tags --always --dirty 2>/dev/null || echo unknown)"
+BUILD_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
 TARGETS=("${1:-}")
 if [[ -z "${1:-}" ]]; then
     TARGETS=(bun-linux-x64 bun-darwin-arm64 bun-darwin-x64)
@@ -20,6 +28,9 @@ fi
 
 for TARGET in "${TARGETS[@]}"; do
     SUFFIX="${TARGET#bun-}"
-    bun build --compile --target="$TARGET" index.ts --outfile "dist/sdlc-server-${SUFFIX}"
+    bun build --compile --target="$TARGET" index.ts --outfile "dist/sdlc-server-${SUFFIX}" \
+        --define "__BUILD_SHA__=\"${BUILD_SHA}\"" \
+        --define "__BUILD_REF__=\"${BUILD_REF}\"" \
+        --define "__BUILD_AT__=\"${BUILD_AT}\""
     echo "Built dist/sdlc-server-${SUFFIX}"
 done


### PR DESCRIPTION
## Summary

"Fixed in source, stale in binary" silently cost the fleet real debugging time: a deployed `sdlc-server` binary lagged the latest release by four merged fixes, with **no signal anywhere** — the only symptom was a confusing downstream failure miles from the root cause. It fooled me too, tonight: I reasoned from repo source that was five days ahead of the **running** binary and gave a teammate a confident wrong answer.

The binary now embeds its build commit SHA at compile time (`bun build --define` in `scripts/ci/build.sh`) and, **once at startup**, asks GitHub's compare API whether that commit is behind `sdlc-server`'s own latest release. If so it emits a single `warn`-level `deploy_freshness` log line naming both and the remedy.

## Properties, by design

- **Exact, not a date heuristic** — GitHub commit-compare (`base=binary SHA ... head=release tag`); warn only on status `ahead` (release ahead of binary = binary behind).
- **Network-optional** — offline / no `gh` / unauthenticated / no releases all degrade to **silence**. Never blocks startup, never spams.
- **No false alarms** — a build *newer* than the latest release (local dev build) does not warn; neither does an uncompiled dev build with no embedded SHA.
- **Self-scoped** — checks the server against **its own** releases, independent of whichever project it is operating on, so there is no platform ambiguity.

## Verified end-to-end (not just unit tests — this is #447's whole ethos)

- Compiled a binary; confirmed the real HEAD SHA is embedded and `__BUILD_SHA__` is fully replaced.
- Ran it → clean startup, no warn (HEAD not behind).
- Built one pinned to an **old ancestor SHA** → it emitted the `deploy_freshness` warn naming `latest_release: v2.0.3`. Cross-checked `gh api compare/OLD...v2.0.3 → ahead` on the live API.

## Review finding (fixed)

The `gh`-backed deps were declared `async` but ran `execSync` with no prior `await` — so they **blocked the event loop** across two `gh` round-trips during the startup handshake, with **no timeout** (a black-holed network would hang the server for minutes). The "NEVER blocks" claim was false, and the async test doubles masked it.

Rewrote to genuinely-async `execFile` + a 5s timeout, and **proved it**: the compiled server answers `initialize` in **~150ms while the `gh` calls run**. Added a real-IO-boundary test (missing `gh` → null, not throw). `promisify` is called lazily inside the guarded `try` so the repo's `child_process` test mock cannot turn a load-order quirk into a module-load throw.

## Docs

README "Staying current" section + CHANGELOG.

## Linked Issues

Closes #447

## Test Plan

- `bun test` → **2397 passed, 0 failed**. `tsc --noEmit` clean.
- Compiled-binary end-to-end verification (embed / warn-when-stale / silent-when-current / non-blocking handshake), re-run after every change because `bun test` and the compiled binary resolve `child_process` differently.
- trivy: 3 pre-existing HIGH transitive findings (`fast-uri`, `hono`) — **this branch adds no dependencies**; deferred for a separate dependency-hygiene pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CSEY5TUixZARAmHrjYTYX
