### PR TITLE
chore(release): v2.1.0 prep — CVE bumps, branch_guard guard, version/CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,48 +1,29 @@
 # Changelog
 
-## Unreleased
+Release notes for `mcp-server-sdlc` live on the **GitHub Releases** page, generated
+from merged PR titles at tag time (`gh release create --generate-notes`):
 
-**BREAKING CHANGE (#362, Story 2.1):** `wave_init` no longer accepts `kahuna: { epic_id, slug }`. Callers must pass `kahuna: { plan_id, slug }` instead. The generated branch name is now `kahuna/<plan_id>-<slug>` and the wave-state schema (`KahunaBranchHistoryEntrySchema` in `lib/wave_state.ts`) renames `epic_id` → `plan_id` on each history entry. No legacy-compat fallback is provided — the legacy shape fails schema validation with a clear error. Part of the Plan/Phase/Epic taxonomy lock (cc-workflow#499): "Plan" is the pipeline's tracking-issue unit; "Epic" is now an optional PM label the pipeline ignores.
+> https://github.com/Wave-Engineering/mcp-server-sdlc/releases
 
-**BREAKING CHANGE (#363, Story 2.2):** `wave_finalize` no longer accepts `epic_id`. Callers must pass `plan_id`. The assembled kahuna→target MR title changes from `epic(#N): <slug> — kahuna to <target>` to `plan(#N): <slug> — kahuna to <target>`. No legacy-compat fallback; the old parameter name fails schema validation with a clear error. Part of the Plan/Phase/Epic taxonomy lock (cc-workflow#499).
+## Policy (#459)
 
-### Features
-- **deploy-freshness check**: the `sdlc-server` binary now embeds its build commit SHA (via `bun build --define`) and, once at startup, emits a `warn`-level `deploy_freshness` log line when that commit is **behind** this repo's latest GitHub release — naming both and the remedy (`redeploy with ./install --mcps`). Uses GitHub's commit-compare API for an **exact** ancestry check, not a date heuristic. **Network-optional**: offline / unauthenticated / no-releases all degrade to silence; it never blocks startup, never spams, and never warns on a build that is newer than the latest release or on an uncompiled dev build. Motivated by a stale deploy that lagged the latest release by four merged fixes with no signal anywhere. [#447]
-- **work_item**: `type: "plan"` is now a first-class type, applying the `type::plan` label. `/issue plan` previously could not create a Plan issue at all — the enum had no `plan` — and callers worked around it with `type: "epic"` plus an explicit `type::plan` label. [#477]
+The in-repo changelog is **retired as of v2.1.0**. The release workflow is
+tag-triggered and never read this file, so its `## Unreleased` section drifted across
+several shipped tags (v2.0.0–v2.0.3) while still claiming `v1.0.2` was the latest cut —
+a false picture of release state. Rather than hand-maintain a second, drift-prone
+source of truth, releases are now described solely by the auto-generated GitHub notes.
 
-### Fixes
-- **ci_wait_run**: the `expected_sha` first-appearance window is now **bounded** (~180s) instead of coupled to the full `timeout_sec`. Previously, passing `expected_sha` set the "no run has appeared yet" grace window to the *entire* timeout (typically 1800s), so a transient first-poll miss made the tool spin **silently for 30 minutes** with zero partial output (diagnosed live by wintermute on a `/scpmmr` post-merge wait). The `require_merge_result` path keeps its full-timeout appearance window — a GitLab merged-results pipeline is created asynchronously and can take minutes to appear, so bounding *that* would spuriously HOLD every wave (#452 in reverse). Phase 2 (polling a run that has appeared) still honors the full `timeout_sec`. [#483]
-- **ibm**: now accepts an optional `repo`, and **refuses rather than guesses** when asked about a branch that is not the one checked out in the server's cwd without one (#475). Previously `ibm` resolved the repo from the process cwd only: an agent working in a different repo — passing a branch from that repo — had the issue number parsed out of the branch and looked up in the **cwd's** repo, where a same-numbered but entirely unrelated issue would match and `ibm` would report "branch is correctly linked". That is a **false pass on the first gate of `/precheck`**, a mandatory compliance check that only looked like it was enforcing. The verdict envelope now also echoes the `repo` actually checked. [#475]
-- **work_item**: the automatic `type::<type>` label is now **suppressed when the caller supplies any `type::*` label of their own**, on both platforms. It was previously prepended unconditionally, which was safe only **by accident** on GitLab: `type::epic` and `type::plan` share the `type::` scope key, GitLab's scoped labels are mutually exclusive, and the caller's later label evicted ours. **GitHub has no scoped labels**, so the identical call produced an issue carrying **both** — a Plan mislabelled as an Epic, which the pipeline is specified never to read (Dev Spec R-19). Relying on the target platform to clean up after us is not a contract. Caller labels are also trimmed before they reach the platform (`gh` matches label names exactly and rejects an untrimmed one outright; GitLab would mint a junk label). A missing-label failure on GitHub now names the remedy (`label_create` first — GitHub does not create labels implicitly, GitLab does). [#477]
+The binary self-reports its build tag at startup (`version`, injected from
+`git describe --tags` — see `index.ts` / `scripts/ci/build.sh`), and #447's
+deploy-freshness guard warns when a running binary is behind the latest release.
+Together those answer "what's running?" without a checked-in changelog.
 
-- **plan_load_dod**: New MCP tool to fetch Plan tracking-issue and extract Definition of Done structure — both Plan-level DoD checkboxes and per-Phase DoD checklists with [R-XX] refs. Returns parsed view including Dev Spec path from References section. Part of the Plan DoD workflow family. [#388]
-- **wave_reconcile**: New Prime(post-wave) reconciliation handler emitting canonical `[drift-halt]` comments on Category B drift per Dev Spec §5.4.1. [#366, Story 2.5]
-- **devspec_finalize**: Require `depends_on` field on every Story in `phases-waves.json` (may be empty array); finalization fails with a named list of offenders otherwise. [#367, Story 2.6]
+## Recovering pre-v2.1.0 hand-written history
 
-### Docs
-- **wave-finalize**: correct stale `<epic_id>` → `<plan_id>` comment at `lib/wave-finalize.ts:70`. [#365, Story 2.4]
+Earlier releases carried hand-written notes here, including the `wave_init` /
+`wave_finalize` breaking-change migration guidance (#362, #363) and the v1.0.0–v1.0.2
+runtime-registry fix story. That prose is preserved in this file's git history:
 
-### Fixes
-- **wave_finalize**: `root` now roots the entire operation — the PR find/create adapter calls honor it too, not just the wave-status read + branch probe. Optional `cwd?` threaded through `PrCreateArgs`/`FindExistingPrArgs`, both platform adapters, and the GitLab slug-resolution path (`parse-repo-slug`, `gitlab-api`); byte-identical when omitted. A cross-repo wave (`root` ≠ session) no longer find/opens the PR against the wrong repo. [#453]
-- **test(ci)**: isolate the real-CLI integration tests from the adapter `mock.module('child_process')` mocks — they run in their own process (`--path-ignore-patterns` excludes them from the mixed unit run). Partial mitigation for the load-order CI flake tracked in [#455]; the unit-level victims need the full mock-isolation refactor (a static ESM-import binding makes a test-level fix impossible).
-- **ibm**: `BRANCH_PATTERN` now accepts the canonical singular `doc/` and the missing `bug/` and `kahuna/` prefixes. Previous pattern required plural `docs/` and rejected `kahuna/<N>-<slug>` integration branches outright, forcing rename-then-platform-rejection loops. [#381]
-- **gitlab-api**: `execGlab` now surfaces non-zero exit codes with stderr context, and rejects zero-exit-empty-stdout with a named error instead of letting `JSON.parse('')` produce a cryptic `Unexpected EOF`. [#382]
-- **pr_create (gitlab)**: replaced the post-create lookup `glab mr view <head> -F json` with `glab api projects/.../merge_requests?source_branch=<head>&state=opened`. The `-F` flag does not exist on glab 1.36.0, so every successful create was being followed by a failed lookup, the handler reported `glab_mr_view_failed`, and callers fell back into a 409 conflict. The mock-based test suite missed it (same family as `lesson_pr_wait_ci_broken.md`). [#383]
-
-## v1.0.2 — 2026-04-07
-
-**Critical fix:** the v1.0.0 / v1.0.1 binaries shipped with a broken handler registry — `index.ts` used `import.meta.glob('./handlers/*.ts', { eager: true })`, which is a Vite-only feature unsupported by Bun. Result: the server crashed at startup whenever a client called `tools/list`. The `work_item` and `ibm` tools existed in the bundle but were never reachable.
-
-Replaced with a pre-build codegen pipeline. `scripts/ci/codegen-handlers.sh` scans `handlers/*.ts` and emits `handlers/_registry.ts` with explicit imports; `index.ts` and tests both import from there. The generated file is gitignored. Codegen runs as the first step of `validate.sh` and `build.sh`.
-
-Also added a runtime smoke test (`scripts/ci/smoke.sh`) that builds the binary, sends a real `tools/list` request via stdio MCP protocol, and asserts a non-empty response. This is the institutional discipline that catches the class of bug that shipped in v1.0.0/v1.0.1 — type checks and isolated unit tests aren't enough; actually run the binary.
-
-Removed `bun.d.ts` (it contained a false `ImportMeta.glob` type declaration).
-
-## v1.0.1 — 2026-04-07
-
-ETXTBSY-safe install. `scripts/install-remote.sh` now downloads to a temp file and `mv -f`s into place, surviving the case where the binary is already running as an MCP subprocess.
-
-## v1.0.0 — 2026-04-07
-
-Initial release. Two tools: `work_item` (unified GitHub/GitLab work item creation) and `ibm` (issue/branch/PR workflow compliance check). **NOTE:** broken at runtime — see v1.0.2 for the fix. Do not use v1.0.0.
+```sh
+git log -p -- CHANGELOG.md
+```

--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ Properties, by design:
 If you build locally with `scripts/ci/build.sh`, the SHA is your working-tree
 `HEAD`; a dev build ahead of the last release is silent, which is correct.
 
+### Changelog (#459)
+
+There is no maintained in-repo changelog. Release notes are auto-generated from
+merged PR titles on the **[GitHub Releases](https://github.com/Wave-Engineering/mcp-server-sdlc/releases)**
+page at tag time (`gh release create --generate-notes`), and the binary's startup
+`version` reports the release tag it was built at. `CHANGELOG.md` is retired to a
+pointer; pre-v2.1.0 hand-written history (including breaking-change migration notes)
+lives in that file's git history.
+
 ## Handler Registry
 
 Tools are auto-discovered at build time via a glob pattern over `handlers/`. To add a tool, drop a file in `handlers/` that exports a `HandlerDef` default. No other files need to change.

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,10 @@
       },
     },
   },
+  "overrides": {
+    "fast-uri": "^3.1.2",
+    "hono": "^4.12.25",
+  },
   "packages": {
     "@hono/node-server": ["@hono/node-server@1.19.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw=="],
 
@@ -82,7 +86,7 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+    "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
@@ -102,7 +106,7 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
-    "hono": ["hono@4.12.11", "", {}, "sha512-r4xbIa3mGGGoH9nN4A14DOg2wx7y2oQyJEb5O57C/xzETG/qx4c7CVDQ5WMeKHZ7ORk2W0hZ/sQKXTav3cmYBA=="],
+    "hono": ["hono@4.12.30", "", {}, "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 

--- a/handlers/branch_guard.ts
+++ b/handlers/branch_guard.ts
@@ -62,6 +62,23 @@ const branchGuardHandler: HandlerDef = {
     const adapter = getAdapter({ repo: args.repo });
     const cwd = projectDir();
 
+    // #480: base-role with a foreign `repo` but no `branch`. The base-resolution
+    // path below reads the cwd's current branch and looks it up in `args.repo` —
+    // but the cwd branch may not belong to that repo (the same trap #475 fixed in
+    // `ibm`). If you name the repo, name the branch; do not let us infer one from
+    // the cwd and pair it with a repository it may not belong to. `target` role is
+    // exempt: an omitted target defaults to the repo's OWN default branch, never
+    // the cwd branch.
+    if (args.role === 'base' && args.repo !== undefined && args.branch === undefined) {
+      return envelope({
+        ok: false,
+        error:
+          `A 'repo' (${args.repo}) was given to branch_guard(role='base') but no 'branch'. Refusing to ` +
+          `infer this directory's current branch ('${currentBranch(cwd) || 'none'}') and resolve its base ` +
+          `in a different repository — the branch may not belong there. Pass the branch explicitly.`,
+      });
+    }
+
     // Live default branch — required for the envelope AND the B===default
     // comparison. Never a cached value.
     const defRes = await adapter.resolveDefaultBranch({ repo: args.repo, cwd });

--- a/index.ts
+++ b/index.ts
@@ -5,10 +5,17 @@ import { CallToolRequestSchema, ErrorCode, ListToolsRequestSchema, McpError } fr
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { handlers } from './handlers/_registry';
 import { log } from './logger';
-import { checkDeployFreshness } from './lib/deploy_freshness.js';
+import { checkDeployFreshness, getBuildInfo, DEV_SENTINEL } from './lib/deploy_freshness.js';
 import { ghFreshnessDeps } from './lib/deploy_freshness_gh.js';
 
-const SERVER_VERSION = '1.0.0';
+// #459: report the release tag this binary was built at (e.g. "2.1.0"), injected
+// at compile time by scripts/ci/build.sh as __BUILD_REF__ (`git describe --tags`).
+// A hardcoded literal silently drifts from the tag — the old '1.0.0' made every
+// release's startup log indistinguishable and undercut #447's freshness diagnostic.
+// Uncompiled dev runs (ref === the 'dev' sentinel) report a dev marker rather than
+// claiming to be a release.
+const _build = getBuildInfo();
+const SERVER_VERSION = _build.ref === DEV_SENTINEL ? '0.0.0-dev' : _build.ref.replace(/^v/, '');
 
 const server = new Server(
   { name: 'sdlc-server', version: SERVER_VERSION },

--- a/lib/deploy_freshness.ts
+++ b/lib/deploy_freshness.ts
@@ -39,7 +39,7 @@ export interface BuildInfo {
   builtAt: string;
 }
 
-const DEV_SENTINEL = 'dev';
+export const DEV_SENTINEL = 'dev';
 
 export function getBuildInfo(): BuildInfo {
   return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server-sdlc",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "description": "SDLC workflow MCP server for Claude Code agents",
   "type": "module",
   "scripts": {
@@ -24,5 +24,9 @@
   "devDependencies": {
     "@types/bun": "latest",
     "typescript": "^5.7.0"
+  },
+  "overrides": {
+    "fast-uri": "^3.1.2",
+    "hono": "^4.12.25"
   }
 }

--- a/tests/branch_guard.test.ts
+++ b/tests/branch_guard.test.ts
@@ -240,4 +240,21 @@ describe('branch_guard role=base — base detection via open PR', () => {
     expect(data.is_protected).toBe(false);
     expect(String(data.reason)).toContain('No open PR');
   });
+
+  test('repo set + no branch → refuse, never a cwd-branch lookup in the wrong repo (#480)', async () => {
+    onExec('git remote get-url origin', GITHUB_ORIGIN);
+    onExec('git branch --show-current', 'feature/470-name-based\n');
+    // Deliberately NO `gh repo view` / `gh pr list` mocks: the guard must refuse
+    // BEFORE any base-resolution work. If the guard is removed the handler falls
+    // through to resolveDefaultBranch/prList (unmocked) and this assertion goes red.
+
+    const data = parseResult(
+      await handler.execute({ role: 'base', repo: 'someorg/unrelated' }),
+    );
+    expect(data.ok).toBe(false);
+    expect(String(data.error)).toContain("no 'branch'");
+    expect(String(data.error)).toContain('someorg/unrelated');
+    // The whole point: we never looked up the cwd branch's base in the foreign repo.
+    expect(execCalls().some((c) => c.includes('pr list'))).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

v2.1.0 release-prep: closes a live correctness bug in `branch_guard`, patches three HIGH CVEs, and fixes the binary/version metadata drift — so the v2.1.0 cut ships clean, CVE-free, and self-consistent.

## Changes

- **branch_guard (#480):** refuse `role:'base'` with a foreign `repo` but no `branch`, instead of pairing the cwd branch with a repo it may not belong to (mirrors the #475 fix in `ibm`). Scoped to base role — `target`/explicit-branch/consistent-base paths are unchanged. Adds a mutation-proven regression test.
- **deps (#468, #450):** `overrides` bump `fast-uri` → `^3.1.2` (resolved 3.1.3) and `hono` → `^4.12.25` (resolved 4.12.30), patching CVE-2026-6321/6322 and CVE-2026-54290. Capped to major-compatible ranges so `ajv`/MCP-SDK consumers are unaffected. `trivy fs --severity HIGH,CRITICAL`: **0 findings**.
- **version (#459):** `SERVER_VERSION` derives from the injected build tag (`__BUILD_REF__` via `getBuildInfo`) instead of a hardcoded `'1.0.0'` that made every release's startup log indistinguishable and undercut #447's freshness diagnostic; `package.json` `1.0.0` → `2.1.0`; export `DEV_SENTINEL` so the dev-fallback coupling is type-enforced.
- **changelog (#459):** retire the drift-prone in-repo `CHANGELOG.md` to a pointer (GitHub Releases auto-notes are authoritative); README changelog-policy note.

## Linked Issues

Closes #459
Closes #468
Closes #450
Closes #480

## Test Plan

- `./scripts/ci/validate.sh` → 78/78 tool assertions, codegen + smoke pass
- `bunx tsc --noEmit` clean; `bun test` → **2398 pass / 3 skip / 0 fail**
- `#480` guard **mutation-tested**: neutered the guard → the new test went red → restored
- Built `dist/sdlc-server-linux-x64`, ran it → startup `version` now derives from `git describe` (`2.0.3-9-g…`), not `1.0.0`
- `trivy fs --scanners vuln --severity HIGH,CRITICAL` → 0
- code-reviewer (opus): no critical/important; 1 minor (DEV_SENTINEL coupling) fixed
