### PR TITLE
fix: supply MR head SHA during GitLab merge operations to fix optimis…

### DIFF
--- a/lib/adapters/pr-merge-gitlab.test.ts
+++ b/lib/adapters/pr-merge-gitlab.test.ts
@@ -55,12 +55,13 @@ beforeEach(() => {
 
 describe('prMergeGitlab — subprocess boundary', () => {
   test('direct merge returns aggregate envelope', async () => {
-    onExec('glab mr merge 17 --squash --remove-source-branch --yes', '');
+    onExec("glab mr merge 17 --squash --remove-source-branch --yes --sha 'head-sha-123'", '');
     onExec(
       'glab api projects/org%2Frepo/merge_requests/17',
       JSON.stringify({
         iid: 17,
         state: 'merged',
+        sha: 'head-sha-123',
         source_branch: 'feature/test',
         target_branch: 'main',
         web_url: 'https://gitlab.com/org/repo/-/merge_requests/17',
@@ -89,12 +90,13 @@ describe('prMergeGitlab — subprocess boundary', () => {
   });
 
   test('skip_train is silently dropped — merge proceeds with warning (#423)', async () => {
-    onExec('glab mr merge 9 --squash --remove-source-branch --yes', '');
+    onExec("glab mr merge 9 --squash --remove-source-branch --yes --sha 'head-sha-123'", '');
     onExec(
       'glab api projects/org%2Frepo/merge_requests/9',
       JSON.stringify({
         iid: 9,
         state: 'merged',
+        sha: 'head-sha-123',
         source_branch: 'feature/train',
         target_branch: 'main',
         web_url: 'https://gitlab.com/org/repo/-/merge_requests/9',
@@ -112,12 +114,13 @@ describe('prMergeGitlab — subprocess boundary', () => {
   });
 
   test('skip_train omitted — no warning in response', async () => {
-    onExec('glab mr merge 10 --squash --remove-source-branch --yes', '');
+    onExec("glab mr merge 10 --squash --remove-source-branch --yes --sha 'head-sha-123'", '');
     onExec(
       'glab api projects/org%2Frepo/merge_requests/10',
       JSON.stringify({
         iid: 10,
         state: 'merged',
+        sha: 'head-sha-123',
         source_branch: 'feature/no-train',
         target_branch: 'main',
         web_url: 'https://gitlab.com/org/repo/-/merge_requests/10',
@@ -132,11 +135,24 @@ describe('prMergeGitlab — subprocess boundary', () => {
   });
 
   test('returns AdapterResult{ok:false, code} on glab failure (not thrown)', async () => {
-    onExec('glab mr merge 9 --squash --remove-source-branch --yes', () => {
+    onExec("glab mr merge 9 --squash --remove-source-branch --yes --sha 'head-sha-123'", () => {
       const err = new Error('merge request cannot be merged') as ThrowableError;
       err.stderr = 'merge request has conflicts\n';
       throw err;
     });
+    // Add the MR fetch mock that will be called before the failed merge
+    onExec(
+      'glab api projects/org%2Frepo/merge_requests/9',
+      JSON.stringify({
+        iid: 9,
+        state: 'open',
+        sha: 'head-sha-123',
+        source_branch: 'feature/train',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/9',
+        labels: [],
+      }),
+    );
 
     const result = await prMergeGitlab({ number: 9, repo: 'org/repo' });
     expectErr(result);
@@ -145,12 +161,13 @@ describe('prMergeGitlab — subprocess boundary', () => {
   });
 
   test('squash message → --squash-message inline', async () => {
-    onExec('glab mr merge 14 --squash --remove-source-branch --yes', '');
+    onExec("glab mr merge 14 --squash --remove-source-branch --yes --sha 'head-sha-123'", '');
     onExec(
       'glab api projects/org%2Frepo/merge_requests/14',
       JSON.stringify({
         iid: 14,
         state: 'merged',
+        sha: 'head-sha-123',
         source_branch: 'feature/fix',
         target_branch: 'main',
         web_url: 'https://gitlab.com/org/repo/-/merge_requests/14',
@@ -170,12 +187,13 @@ describe('prMergeGitlab — subprocess boundary', () => {
   });
 
   test('-R flag forwarded when args.repo provided (GitLab uses -R, not --repo)', async () => {
-    onExec('glab mr merge 17 --squash --remove-source-branch --yes', '');
+    onExec("glab mr merge 17 --squash --remove-source-branch --yes --sha 'head-sha-123'", '');
     onExec(
       'glab api projects/target-org%2Ftarget-repo/merge_requests/17',
       JSON.stringify({
         iid: 17,
         state: 'merged',
+        sha: 'head-sha-123',
         source_branch: 'feature/test',
         target_branch: 'main',
         web_url: 'https://gitlab.com/target-org/target-repo/-/merge_requests/17',

--- a/lib/adapters/pr-merge-gitlab.ts
+++ b/lib/adapters/pr-merge-gitlab.ts
@@ -17,6 +17,7 @@
  */
 
 import { execSync } from 'child_process';
+import { gitlabApiMr } from '../gitlab-api.js';
 import { getAdapter } from './index.js';
 import type {
   AdapterResult,
@@ -24,6 +25,15 @@ import type {
   PrMergeResponse,
   PrStateInfo,
 } from './types.js';
+
+function parseSlugOpts(
+  slug: string | undefined,
+): { owner?: string; repo?: string } | undefined {
+  if (slug === undefined) return undefined;
+  const idx = slug.indexOf('/');
+  if (idx <= 0 || idx === slug.length - 1) return undefined;
+  return { owner: slug.slice(0, idx), repo: slug.slice(idx + 1) };
+}
 
 interface ExecError extends Error {
   stdout?: Buffer | string;
@@ -67,6 +77,7 @@ function buildGitlabMergeCommand(
   number: number,
   squashMessage?: string,
   repo?: string,
+  sha?: string,
 ): string {
   const parts = [
     'glab',
@@ -77,6 +88,9 @@ function buildGitlabMergeCommand(
     '--remove-source-branch',
     '--yes',
   ];
+  if (sha !== undefined && sha.length > 0) {
+    parts.push('--sha', shellEscape(sha));
+  }
   if (squashMessage !== undefined && squashMessage.length > 0) {
     parts.push('--squash-message', shellEscape(squashMessage));
   }
@@ -93,8 +107,20 @@ export async function prMergeGitlab(
   const skippedTrain = args.skip_train === true;
 
   try {
+    let sha: string | undefined;
+    try {
+      const mr = gitlabApiMr(args.number, parseSlugOpts(args.repo));
+      if (mr.sha) {
+        sha = mr.sha;
+      }
+    } catch (err) {
+      // Ignore errors (e.g. network issue, MR not found). The subsequent
+      // glab mr merge command will fail natively and preserve existing 
+      // error handling output.
+    }
+
     // GitLab has no merge-queue concept; queue stays empty.
-    const cmd = buildGitlabMergeCommand(args.number, args.squash_message, args.repo);
+    const cmd = buildGitlabMergeCommand(args.number, args.squash_message, args.repo, sha);
     try {
       exec(cmd);
     } catch (err) {

--- a/lib/gitlab-api.ts
+++ b/lib/gitlab-api.ts
@@ -88,6 +88,7 @@ export interface GitlabMr {
   work_in_progress?: boolean;
   head_pipeline?: GitlabPipeline | null;
   pipeline?: GitlabPipeline | null; // Alias for head_pipeline in some contexts
+  sha?: string;
   merge_commit_sha?: string | null;
   created_at?: string;
   updated_at?: string;


### PR DESCRIPTION
**Description**
This PR fixes an issue where GitLab merge operations fail on repositories that require optimistic concurrency checks, caused by the GitLab merge adapter not passing the --sha flag during the merge process.

**Changes included:**

**lib/gitlab-api.ts:** Updated the GitlabMr interface to include the sha?: string property.
lib/adapters/pr-merge-gitlab.ts: Added logic to pre-fetch the merge request metadata (via gitlabApiMr) before constructing the glab mr merge command. If the API returns a head SHA (mr.sha), it is explicitly passed to the merge command via the --sha flag.
**Error Handling:** Missing SHAs, closed/merged MRs, and API fetch failures are handled gracefully without short-circuiting. The adapter simply falls back to executing the merge command without the flag, fully preserving existing organic error outputs.
lib/adapters/pr-merge-gitlab.test.ts: Updated the tests and subprocess mocks to expect the API pre-fetch and assert that the --sha parameter is successfully injected into the merge command.
**Verification**
 Verified bun test passes successfully for all adapter test files.
 Verified bun run lint (TypeScript compilation checks) passes with zero errors.
 Ensured behaviour for GitHub and other source control providers is completely unaffected.
