### PR TITLE
fix(pr_merge): send GitLab --sha stale-head guard; disable auto-merge

### DIFF
--- a/lib/adapters/pr-merge-gitlab.test.ts
+++ b/lib/adapters/pr-merge-gitlab.test.ts
@@ -451,6 +451,90 @@ describe('prMergeGitlab — --sha stale-head guard (#486)', () => {
     expect(result.error).toContain('source branch moved');
   });
 
+  // PAIRED test: MR !409 and its control MR !410. Same genuine non-sha failure,
+  // differing only in IID. The pair is the proof — !410 alone would pass even
+  // with the bug, and !409 alone could be dismissed as a quirk of that fixture.
+  //
+  // The bug: glab's error text echoes the request URL, which carries the MR IID
+  // (`.../merge_requests/409/merge`). A bare /\b409\b/ matched the IID rather
+  // than an HTTP status, so ANY failure on MR !409 was misclassified as a
+  // stale-head race, retried, and reported as `gitlab_head_sha_moved`.
+  for (const [iid, label] of [
+    [409, 'MR !409 — IID collides with the HTTP status being matched'],
+    [410, 'MR !410 — control, no collision'],
+  ] as Array<[number, string]>) {
+    test(`non-sha failure is fatal and correctly classified: ${label}`, async () => {
+      let mergeAttempts = 0;
+      onExec(
+        `glab api projects/org%2Frepo/merge_requests/${String(iid)}`,
+        JSON.stringify({
+          iid,
+          state: 'opened',
+          source_branch: 'feature/conflict',
+          target_branch: 'main',
+          web_url: `https://gitlab.com/org/repo/-/merge_requests/${String(iid)}`,
+          labels: [],
+          diff_refs: { head_sha: `head${String(iid)}aaaa` },
+          merge_commit_sha: null,
+        }),
+      );
+      onExec(`glab mr merge ${String(iid)} --squash --remove-source-branch --yes`, () => {
+        mergeAttempts += 1;
+        const err = new Error('merge failed') as ThrowableError;
+        // Verbatim glab shape: the URL echoes the IID, and the real status is 405.
+        err.stderr =
+          'All attempts fail:\n#1: PUT https://gitlab.com/api/v4/projects/org%2Frepo/' +
+          `merge_requests/${String(iid)}/merge: 405 {message: Method Not Allowed}\n`;
+        throw err;
+      });
+
+      const result = await prMergeGitlab({ number: iid, repo: 'org/repo' });
+      expectErr(result);
+      // Must be the genuine failure, NOT a stale-head misclassification.
+      expect(result.code).toBe('glab_mr_merge_failed');
+      expect(result.code).not.toBe('gitlab_head_sha_moved');
+      // And it must not have burned a retry on a non-race.
+      expect(mergeAttempts).toBe(1);
+    });
+  }
+
+  test('a real 409 status IS still classified as a stale-head race', async () => {
+    // The other side of the fix: tightening the matcher must not stop it
+    // recognising a genuine 409, which glab renders as `: 409 {message: ...}`.
+    let mergeAttempts = 0;
+    let mrReads = 0;
+    onExec('glab api projects/org%2Frepo/merge_requests/50', () => {
+      mrReads += 1;
+      return JSON.stringify({
+        iid: 50,
+        state: mrReads >= 3 ? 'merged' : 'opened',
+        source_branch: 'feature/moving',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/50',
+        labels: [],
+        diff_refs: { head_sha: `head50v${String(mrReads)}` },
+        merge_commit_sha: mrReads >= 3 ? 'merged50' : null,
+      });
+    });
+    onExec('glab mr merge 50 --squash --remove-source-branch --yes', () => {
+      mergeAttempts += 1;
+      if (mergeAttempts === 1) {
+        const err = new Error('merge failed') as ThrowableError;
+        // Status position: `409 {` — note the IID here is 50, so the ONLY 409
+        // present is the genuine status.
+        err.stderr =
+          'All attempts fail:\n#1: PUT https://gitlab.com/api/v4/projects/org%2Frepo/' +
+          'merge_requests/50/merge: 409 {message: something about the head}\n';
+        throw err;
+      }
+      return '';
+    });
+
+    const result = await prMergeGitlab({ number: 50, repo: 'org/repo' });
+    expectOk(result);
+    expect(mergeAttempts).toBe(2); // retried, as a real race should be
+  });
+
   test('a non-sha merge failure is fatal — no retry', async () => {
     let mergeAttempts = 0;
     onExec(

--- a/lib/adapters/pr-merge-gitlab.test.ts
+++ b/lib/adapters/pr-merge-gitlab.test.ts
@@ -212,7 +212,7 @@ describe('prMergeGitlab — subprocess boundary', () => {
     });
     expectOk(result);
     const mergeCall = findCall('glab mr merge 17');
-    expect(mergeCall).toContain('-R target-org/target-repo');
+    expect(mergeCall).toContain("-R 'target-org/target-repo'");
     const apiCall = findCall('glab api projects/');
     expect(apiCall).toContain('target-org%2Ftarget-repo');
   });
@@ -511,6 +511,6 @@ describe('prMergeGitlab — --sha stale-head guard (#486)', () => {
 
     const mergeCall = findCall('glab mr merge 4');
     expect(mergeCall).toContain("--sha 'deep4headsha'");
-    expect(mergeCall).toContain(`-R ${deep}`);
+    expect(mergeCall).toContain(`-R '${deep}'`);
   });
 });

--- a/lib/adapters/pr-merge-gitlab.test.ts
+++ b/lib/adapters/pr-merge-gitlab.test.ts
@@ -65,6 +65,7 @@ describe('prMergeGitlab — subprocess boundary', () => {
         target_branch: 'main',
         web_url: 'https://gitlab.com/org/repo/-/merge_requests/17',
         labels: [],
+        sha: 'head17aaaaaa',
         merge_commit_sha: 'deadbeef1234',
       }),
     );
@@ -99,6 +100,7 @@ describe('prMergeGitlab — subprocess boundary', () => {
         target_branch: 'main',
         web_url: 'https://gitlab.com/org/repo/-/merge_requests/9',
         labels: [],
+        sha: 'head9bbbbbbb',
         merge_commit_sha: 'abc123def456',
       }),
     );
@@ -122,6 +124,7 @@ describe('prMergeGitlab — subprocess boundary', () => {
         target_branch: 'main',
         web_url: 'https://gitlab.com/org/repo/-/merge_requests/10',
         labels: [],
+        sha: 'head10cccccc',
         merge_commit_sha: 'deadbeef0000',
       }),
     );
@@ -132,6 +135,23 @@ describe('prMergeGitlab — subprocess boundary', () => {
   });
 
   test('returns AdapterResult{ok:false, code} on glab failure (not thrown)', async () => {
+    // #486: sha resolution runs BEFORE the merge, so this fixture is required
+    // for the call to reach the merge at all — without it the adapter refuses
+    // earlier with `gitlab_head_sha_unresolved` and this test's intent (the
+    // merge itself failing) would never be exercised.
+    onExec(
+      'glab api projects/org%2Frepo/merge_requests/9',
+      JSON.stringify({
+        iid: 9,
+        state: 'opened',
+        source_branch: 'feature/conflict',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/9',
+        labels: [],
+        sha: 'head9conflict',
+        merge_commit_sha: null,
+      }),
+    );
     onExec('glab mr merge 9 --squash --remove-source-branch --yes', () => {
       const err = new Error('merge request cannot be merged') as ThrowableError;
       err.stderr = 'merge request has conflicts\n';
@@ -155,6 +175,7 @@ describe('prMergeGitlab — subprocess boundary', () => {
         target_branch: 'main',
         web_url: 'https://gitlab.com/org/repo/-/merge_requests/14',
         labels: [],
+        sha: 'head14dddddd',
         merge_commit_sha: 'f00dbabe',
       }),
     );
@@ -180,6 +201,7 @@ describe('prMergeGitlab — subprocess boundary', () => {
         target_branch: 'main',
         web_url: 'https://gitlab.com/target-org/target-repo/-/merge_requests/17',
         labels: [],
+        sha: 'head17eeeeee',
         merge_commit_sha: 'deadbeef',
       }),
     );
@@ -193,5 +215,302 @@ describe('prMergeGitlab — subprocess boundary', () => {
     expect(mergeCall).toContain('-R target-org/target-repo');
     const apiCall = findCall('glab api projects/');
     expect(apiCall).toContain('target-org%2Ftarget-repo');
+  });
+});
+
+// #486 — GitLab rejects the merge with `400 SHA must be provided when merging`
+// when the project enforces pipelines-must-succeed and/or squash. `glab mr
+// merge` does not supply `sha`, so the adapter resolves the source-branch HEAD
+// and passes `--sha` explicitly.
+describe('prMergeGitlab — --sha stale-head guard (#486)', () => {
+  test('passes --sha with the MR source-branch head sha', async () => {
+    onExec('glab mr merge 17 --squash --remove-source-branch --yes', '');
+    onExec(
+      'glab api projects/org%2Frepo/merge_requests/17',
+      JSON.stringify({
+        iid: 17,
+        state: 'merged',
+        source_branch: 'feature/test',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/17',
+        labels: [],
+        sha: 'head17aaaaaa',
+        merge_commit_sha: 'deadbeef1234',
+      }),
+    );
+
+    const result = await prMergeGitlab({ number: 17, repo: 'org/repo' });
+    expectOk(result);
+    const mergeCall = findCall('glab mr merge 17');
+    expect(mergeCall).toContain("--sha 'head17aaaaaa'");
+    // Must be the diff head, never the merge commit produced by the merge.
+    expect(mergeCall).not.toContain('deadbeef1234');
+  });
+
+  test('prefers diff_refs.head_sha over the top-level sha when both are present', async () => {
+    // Pins the precedence. Values agree in practice, so only a fixture with
+    // BOTH present and DIFFERING proves which one the code actually reads.
+    onExec('glab mr merge 22 --squash --remove-source-branch --yes', '');
+    onExec(
+      'glab api projects/org%2Frepo/merge_requests/22',
+      JSON.stringify({
+        iid: 22,
+        state: 'merged',
+        source_branch: 'feature/precedence',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/22',
+        labels: [],
+        sha: 'TOPLEVELsha22',
+        diff_refs: { head_sha: 'DIFFREFShead22' },
+        merge_commit_sha: 'merged22',
+      }),
+    );
+
+    const result = await prMergeGitlab({ number: 22, repo: 'org/repo' });
+    expectOk(result);
+    const mergeCall = findCall('glab mr merge 22');
+    expect(mergeCall).toContain("--sha 'DIFFREFShead22'");
+    expect(mergeCall).not.toContain('TOPLEVELsha22');
+  });
+
+  test('uses diff_refs.head_sha when the top-level sha is absent', async () => {
+    onExec('glab mr merge 21 --squash --remove-source-branch --yes', '');
+    onExec(
+      'glab api projects/org%2Frepo/merge_requests/21',
+      JSON.stringify({
+        iid: 21,
+        state: 'merged',
+        source_branch: 'feature/diffrefs',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/21',
+        labels: [],
+        diff_refs: { base_sha: 'base00', head_sha: 'head21ffffff', start_sha: 'start00' },
+        merge_commit_sha: 'cafe2121',
+      }),
+    );
+
+    const result = await prMergeGitlab({ number: 21, repo: 'org/repo' });
+    expectOk(result);
+    expect(findCall('glab mr merge 21')).toContain("--sha 'head21ffffff'");
+  });
+
+  test('falls back to the top-level sha when diff_refs is absent', async () => {
+    onExec('glab mr merge 23 --squash --remove-source-branch --yes', '');
+    onExec(
+      'glab api projects/org%2Frepo/merge_requests/23',
+      JSON.stringify({
+        iid: 23,
+        state: 'merged',
+        source_branch: 'feature/toplevel',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/23',
+        labels: [],
+        sha: 'topLevelOnly23',
+        // no diff_refs at all — the fallback branch
+        merge_commit_sha: 'merged23',
+      }),
+    );
+
+    const result = await prMergeGitlab({ number: 23, repo: 'org/repo' });
+    expectOk(result);
+    expect(findCall('glab mr merge 23')).toContain("--sha 'topLevelOnly23'");
+  });
+
+  test('refuses loudly and does NOT merge when head sha is unresolvable', async () => {
+    onExec('glab mr merge 30 --squash --remove-source-branch --yes', '');
+    onExec(
+      'glab api projects/org%2Frepo/merge_requests/30',
+      JSON.stringify({
+        iid: 30,
+        state: 'opened',
+        source_branch: 'feature/nosha',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/30',
+        labels: [],
+        // no `sha`, no `diff_refs` — nothing to guard the merge with
+        merge_commit_sha: null,
+      }),
+    );
+
+    const result = await prMergeGitlab({ number: 30, repo: 'org/repo' });
+    expectErr(result);
+    expect(result.code).toBe('gitlab_head_sha_unresolved');
+    expect(result.error).toContain('refusing to merge without it');
+    // The critical assertion: we must never fall through to an unguarded merge.
+    expect(execCalls().find((c) => c.includes('glab mr merge 30'))).toBeUndefined();
+  });
+
+  test('surfaces a typed refusal when the MR lookup itself fails', async () => {
+    onExec('glab api projects/org%2Frepo/merge_requests/31', () => {
+      const err = new Error('glab api failed') as ThrowableError;
+      err.stderr = '404 Project Not Found\n';
+      throw err;
+    });
+
+    const result = await prMergeGitlab({ number: 31, repo: 'org/repo' });
+    expectErr(result);
+    expect(result.code).toBe('gitlab_head_sha_unresolved');
+    expect(execCalls().find((c) => c.includes('glab mr merge 31'))).toBeUndefined();
+  });
+
+  test('disables auto-merge so a pending pipeline cannot silently ENROLL', async () => {
+    // `glab mr merge --auto-merge` defaults to true. Left on, an MR with a
+    // pending pipeline is enrolled rather than merged, and this adapter would
+    // report merged:false/OPEN while claiming merge_method:'direct_squash'.
+    onExec('glab mr merge 40 --squash --remove-source-branch --yes', '');
+    onExec(
+      'glab api projects/org%2Frepo/merge_requests/40',
+      JSON.stringify({
+        iid: 40,
+        state: 'merged',
+        source_branch: 'feature/auto',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/40',
+        labels: [],
+        sha: 'head40aaaaaa',
+        merge_commit_sha: 'merged40',
+      }),
+    );
+
+    const result = await prMergeGitlab({ number: 40, repo: 'org/repo' });
+    expectOk(result);
+    expect(findCall('glab mr merge 40')).toContain('--auto-merge=false');
+  });
+
+  test('stale-head 409 is retried with a re-resolved sha, not failed', async () => {
+    // TOCTOU: the source branch moves between resolving the sha and merging.
+    // GitLab answers 409; the adapter must refetch and retry, not fail.
+    let mrReads = 0;
+    onExec('glab api projects/org%2Frepo/merge_requests/41', () => {
+      mrReads += 1;
+      return JSON.stringify({
+        iid: 41,
+        state: mrReads >= 3 ? 'merged' : 'opened',
+        source_branch: 'feature/moving',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/41',
+        labels: [],
+        // Head advances after the first read — that is the race.
+        diff_refs: { head_sha: mrReads === 1 ? 'staleHEAD01' : 'freshHEAD02' },
+        merge_commit_sha: mrReads >= 3 ? 'merged41' : null,
+      });
+    });
+
+    let mergeAttempts = 0;
+    onExec('glab mr merge 41 --squash --remove-source-branch --yes', () => {
+      mergeAttempts += 1;
+      if (mergeAttempts === 1) {
+        const err = new Error('merge failed') as ThrowableError;
+        err.stderr = '409 SHA does not match HEAD of source branch\n';
+        throw err;
+      }
+      return '';
+    });
+
+    const result = await prMergeGitlab({ number: 41, repo: 'org/repo' });
+    expectOk(result);
+    expect(mergeAttempts).toBe(2);
+    // The retry must use the REFRESHED head, not replay the stale one.
+    const calls = execCalls().filter((c) => c.includes('glab mr merge 41'));
+    expect(calls[0]).toContain("--sha 'staleHEAD01'");
+    expect(calls[1]).toContain("--sha 'freshHEAD02'");
+  });
+
+  test('exhausted stale-head retries stop at the bound and return a DISTINCT code', async () => {
+    // Pins the retry bound. Without this, turning the loop unbounded still
+    // passes the rest of the suite. Also pins that "the branch kept moving" is
+    // distinguishable from "this MR cannot merge" WITHOUT string-matching.
+    let mrReads = 0;
+    onExec('glab api projects/org%2Frepo/merge_requests/43', () => {
+      mrReads += 1;
+      return JSON.stringify({
+        iid: 43,
+        state: 'opened',
+        source_branch: 'feature/always-moving',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/43',
+        labels: [],
+        diff_refs: { head_sha: `movingHEAD${String(mrReads)}` },
+        merge_commit_sha: null,
+      });
+    });
+
+    let mergeAttempts = 0;
+    onExec('glab mr merge 43 --squash --remove-source-branch --yes', () => {
+      mergeAttempts += 1;
+      const err = new Error('merge failed') as ThrowableError;
+      err.stderr = '409 SHA does not match HEAD of source branch\n';
+      throw err;
+    });
+
+    const result = await prMergeGitlab({ number: 43, repo: 'org/repo' });
+    expectErr(result);
+    expect(mergeAttempts).toBe(2); // the bound — not 1, not unbounded
+    expect(result.code).toBe('gitlab_head_sha_moved');
+    expect(result.code).not.toBe('glab_mr_merge_failed');
+    expect(result.error).toContain('source branch moved');
+  });
+
+  test('a non-sha merge failure is fatal — no retry', async () => {
+    let mergeAttempts = 0;
+    onExec(
+      'glab api projects/org%2Frepo/merge_requests/42',
+      JSON.stringify({
+        iid: 42,
+        state: 'opened',
+        source_branch: 'feature/conflict',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/42',
+        labels: [],
+        diff_refs: { head_sha: 'head42aaaaaa' },
+        merge_commit_sha: null,
+      }),
+    );
+    onExec('glab mr merge 42 --squash --remove-source-branch --yes', () => {
+      mergeAttempts += 1;
+      const err = new Error('merge failed') as ThrowableError;
+      err.stderr = 'merge request has conflicts\n';
+      throw err;
+    });
+
+    const result = await prMergeGitlab({ number: 42, repo: 'org/repo' });
+    expectErr(result);
+    expect(result.code).toBe('glab_mr_merge_failed');
+    expect(mergeAttempts).toBe(1);
+  });
+
+  test('deep 5-segment nested group — encodes path and still passes --sha', async () => {
+    // The reported repro (#486): a deeply nested group. A 2-level repo can pass
+    // while this fails, which is what made the defect look intermittent.
+    const deep = 'analogicdev/internal/tools/blueshift/site-interpreters/rhel9';
+    const encoded =
+      'analogicdev%2Finternal%2Ftools%2Fblueshift%2Fsite-interpreters%2Frhel9';
+
+    onExec('glab mr merge 4 --squash --remove-source-branch --yes', '');
+    onExec(
+      `glab api projects/${encoded}/merge_requests/4`,
+      JSON.stringify({
+        iid: 4,
+        state: 'merged',
+        source_branch: 'feature/deep',
+        target_branch: 'main',
+        web_url: `https://gitlab.com/${deep}/-/merge_requests/4`,
+        labels: [],
+        sha: 'deep4headsha',
+        merge_commit_sha: 'deep4merge',
+      }),
+    );
+
+    const result = await prMergeGitlab({ number: 4, repo: deep });
+    expectOk(result);
+
+    // Every path segment percent-encoded — the whole slug, not just the first.
+    const apiCall = findCall('glab api projects/');
+    expect(apiCall).toContain(encoded);
+    expect(apiCall).not.toContain(`projects/${deep}`);
+
+    const mergeCall = findCall('glab mr merge 4');
+    expect(mergeCall).toContain("--sha 'deep4headsha'");
+    expect(mergeCall).toContain(`-R ${deep}`);
   });
 });

--- a/lib/adapters/pr-merge-gitlab.ts
+++ b/lib/adapters/pr-merge-gitlab.ts
@@ -116,7 +116,24 @@ function resolveHeadSha(number: number, repo?: string): string {
  * transient and correctly retried by re-resolving the sha, NOT fatal.
  */
 function isStaleShaRejection(message: string): boolean {
-  return /sha does not match/i.test(message) || /\b409\b/.test(message);
+  // GitLab's documented rejection text — the primary signal.
+  if (/sha does not match/i.test(message)) return true;
+
+  // Secondary: a 409 STATUS, matched in its structural position. glab renders
+  // failures as `<VERB> <url>: <status> {message: ...}`, so the status is always
+  // followed by the response body's `{`.
+  //
+  // A bare /\b409\b/ is WRONG here and was a real bug: glab's error text echoes
+  // the request URL, which contains the MR IID (`.../merge_requests/409/merge`).
+  // So merging MR !409 matched on its own IID and misclassified ANY failure —
+  // a genuine 405 conflict included — as a stale-head race, retried it, and
+  // then reported `gitlab_head_sha_moved`. It also fired on unrelated text
+  // carrying a standalone 409, e.g. a branch named `fix/409-something`.
+  //
+  // That is the same defect this PR exists to remove: asserting a cause the
+  // evidence does not support. Requiring the `{` anchors the match to the
+  // status field, which a URL path segment can never satisfy.
+  return /\b409\s*\{/.test(message);
 }
 
 /** Attempts of resolve-sha → merge before a stale-head rejection becomes fatal. */

--- a/lib/adapters/pr-merge-gitlab.ts
+++ b/lib/adapters/pr-merge-gitlab.ts
@@ -151,7 +151,12 @@ function buildGitlabMergeCommand(
   if (squashMessage !== undefined && squashMessage.length > 0) {
     parts.push('--squash-message', shellEscape(squashMessage));
   }
-  return repo !== undefined ? `${parts.join(' ')} -R ${repo}` : parts.join(' ');
+  // #408: `repo` reaches a shell via execSync, so it MUST be escaped like every
+  // other interpolated value here (`squash_message`, `sha`). It was the one
+  // caller-supplied field interpolated raw.
+  return repo !== undefined
+    ? `${parts.join(' ')} -R ${shellEscape(repo)}`
+    : parts.join(' ');
 }
 
 export async function prMergeGitlab(

--- a/lib/adapters/pr-merge-gitlab.ts
+++ b/lib/adapters/pr-merge-gitlab.ts
@@ -17,6 +17,7 @@
  */
 
 import { execSync } from 'child_process';
+import { gitlabApiMr } from '../gitlab-api.js';
 import { getAdapter } from './index.js';
 import type {
   AdapterResult,
@@ -63,8 +64,67 @@ function shellEscape(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
+/**
+ * Split an `owner/repo` slug for the `gitlabApiMr` wrapper. Mirrors the same
+ * helper in `fetch-pr-state-gitlab.ts` — splits on the FIRST `/`, so arbitrarily
+ * deep group nesting (`org/a/b/c/repo`) recombines losslessly and is
+ * `encodeURIComponent`d whole by `projectPath()`.
+ */
+function parseSlugOpts(
+  slug: string | undefined,
+): { owner?: string; repo?: string } | undefined {
+  if (slug === undefined) return undefined;
+  const idx = slug.indexOf('/');
+  if (idx <= 0 || idx === slug.length - 1) return undefined;
+  return { owner: slug.slice(0, idx), repo: slug.slice(idx + 1) };
+}
+
+/**
+ * Resolve the MR's source-branch HEAD sha (#486).
+ *
+ * GitLab's merge endpoint requires `sha` as a stale-head guard when the project
+ * enforces pipelines-must-succeed and/or squash; without it the API rejects the
+ * merge with `400 SHA must be provided when merging`. `glab mr merge` does not
+ * supply it for us, so we resolve it and pass `--sha` explicitly.
+ *
+ * Deliberately reads `sha` (the diff head) and NOT `merge_commit_sha`, which is
+ * the commit produced *by* a merge and is null before one happens.
+ *
+ * Throws when unresolvable — the caller converts that into a typed refusal.
+ * Never fall back to merging without a sha: that is precisely the silent
+ * degradation that produced this bug.
+ */
+function resolveHeadSha(number: number, repo?: string): string {
+  const mr = gitlabApiMr(number, parseSlugOpts(repo));
+  // `diff_refs.head_sha` is the canonical source-branch HEAD; the top-level
+  // `sha` is the same value and serves as the fallback.
+  const sha = mr.diff_refs?.head_sha ?? mr.sha ?? undefined;
+  if (typeof sha !== 'string' || sha.trim().length === 0) {
+    throw new Error(
+      'merge request carries no source-branch head sha (both `diff_refs.head_sha` and `sha` absent)',
+    );
+  }
+  return sha.trim();
+}
+
+/**
+ * True when a failed merge is GitLab rejecting our stale-head guard — i.e. the
+ * source branch moved between resolving the sha and issuing the merge (#486).
+ * GitLab answers `409 SHA does not match HEAD of source branch`.
+ *
+ * This is the inherent TOCTOU window in the two-step fetch-then-merge. It is
+ * transient and correctly retried by re-resolving the sha, NOT fatal.
+ */
+function isStaleShaRejection(message: string): boolean {
+  return /sha does not match/i.test(message) || /\b409\b/.test(message);
+}
+
+/** Attempts of resolve-sha → merge before a stale-head rejection becomes fatal. */
+const MAX_SHA_ATTEMPTS = 2;
+
 function buildGitlabMergeCommand(
   number: number,
+  sha: string,
   squashMessage?: string,
   repo?: string,
 ): string {
@@ -76,6 +136,17 @@ function buildGitlabMergeCommand(
     '--squash',
     '--remove-source-branch',
     '--yes',
+    // #486: `glab mr merge --auto-merge` defaults to TRUE. Left on, an MR with
+    // a pending pipeline gets ENROLLED (merge-when-pipeline-succeeds) rather
+    // than merged, and this adapter would report `merged: false` /
+    // `pr_state: 'OPEN'` while still claiming `merge_method: 'direct_squash'`.
+    // The sdlc contract distinguishes merging from enrollment, so we force the
+    // deterministic direct-merge semantics this adapter advertises.
+    '--auto-merge=false',
+    // #486: GitLab's stale-head guard. Required (not optional) at the type
+    // level so this command can never again be built without a sha.
+    '--sha',
+    shellEscape(sha),
   ];
   if (squashMessage !== undefined && squashMessage.length > 0) {
     parts.push('--squash-message', shellEscape(squashMessage));
@@ -93,15 +164,69 @@ export async function prMergeGitlab(
   const skippedTrain = args.skip_train === true;
 
   try {
+    // #486: two-step merge. Resolve the source-branch HEAD sha, then merge with
+    // it as GitLab's stale-head guard. Namespaces with `require_sha_for_merge`
+    // (now the DEFAULT for newly-created GitLab groups) reject an unguarded
+    // merge with `400 SHA must be provided when merging`.
+    //
+    // Between resolving the sha and issuing the merge the branch can move —
+    // an inherent TOCTOU window. GitLab then answers `409 SHA does not match`,
+    // which is transient: re-resolve and retry rather than failing the caller.
     // GitLab has no merge-queue concept; queue stays empty.
-    const cmd = buildGitlabMergeCommand(args.number, args.squash_message, args.repo);
-    try {
-      exec(cmd);
-    } catch (err) {
+    let merged = false;
+    let lastStaleRejection = '';
+    // Bound is structural: falling out of the loop without `merged` can only
+    // mean every attempt hit a stale-head rejection, which the explicit
+    // post-loop return names. No path exits this block without a result.
+    for (let attempt = 1; attempt <= MAX_SHA_ATTEMPTS && !merged; attempt += 1) {
+      let headSha: string;
+      try {
+        headSha = resolveHeadSha(args.number, args.repo);
+      } catch (err) {
+        return {
+          ok: false,
+          code: 'gitlab_head_sha_unresolved',
+          error:
+            `could not resolve source-branch head sha for MR !${String(args.number)}: ` +
+            `${extractFailure(err).message}. GitLab requires \`sha\` as a stale-head guard when ` +
+            'merging; refusing to merge without it.',
+        };
+      }
+
+      const cmd = buildGitlabMergeCommand(
+        args.number,
+        headSha,
+        args.squash_message,
+        args.repo,
+      );
+      try {
+        exec(cmd);
+        merged = true;
+      } catch (err) {
+        const failure = extractFailure(err).message;
+        if (!isStaleShaRejection(failure)) {
+          return {
+            ok: false,
+            code: 'glab_mr_merge_failed',
+            error: `glab mr merge failed: ${failure}`,
+          };
+        }
+        // Source branch moved mid-merge — loop to refetch the head and retry.
+        lastStaleRejection = failure;
+      }
+    }
+
+    if (!merged) {
+      // Distinct from `glab_mr_merge_failed` on purpose: the caller must be able
+      // to tell "the branch kept moving under us" from "this MR cannot merge"
+      // without string-matching an error message.
       return {
         ok: false,
-        code: 'glab_mr_merge_failed',
-        error: `glab mr merge failed: ${extractFailure(err).message}`,
+        code: 'gitlab_head_sha_moved',
+        error:
+          `MR !${String(args.number)} source branch moved during each of ` +
+          `${String(MAX_SHA_ATTEMPTS)} merge attempts (GitLab rejected the stale-head guard ` +
+          `each time); last rejection: ${lastStaleRejection}`,
       };
     }
     const stateResult = await getAdapter({ repo: args.repo }).fetchPrState({

--- a/lib/adapters/pr-merge-wait-gitlab.test.ts
+++ b/lib/adapters/pr-merge-wait-gitlab.test.ts
@@ -76,6 +76,7 @@ describe('prMergeWaitGitlab — adapter orchestration (parity)', () => {
         target_branch: 'main',
         web_url: 'https://gitlab.com/org/repo/-/merge_requests/50',
         labels: [],
+        sha: 'waithead01',
         merge_commit_sha: 'preexisting',
       }),
     );
@@ -103,6 +104,7 @@ describe('prMergeWaitGitlab — adapter orchestration (parity)', () => {
         target_branch: 'main',
         web_url: 'https://gitlab.com/org/repo/-/merge_requests/51',
         labels: [],
+        sha: 'waithead02',
         merge_commit_sha: merged ? 'direct51' : null,
       });
     });
@@ -133,6 +135,7 @@ describe('prMergeWaitGitlab — adapter orchestration (parity)', () => {
         target_branch: 'main',
         web_url: 'https://gitlab.com/org/repo/-/merge_requests/55',
         labels: [],
+        sha: 'waithead03',
         merge_commit_sha: merged ? 'skip55abc' : null,
       });
     });
@@ -161,6 +164,7 @@ describe('prMergeWaitGitlab — adapter orchestration (parity)', () => {
         target_branch: 'main',
         web_url: 'https://gitlab.com/org/repo/-/merge_requests/80',
         labels: [],
+        sha: 'waithead04',
       }),
     );
     onExec('glab mr merge 80 --squash --remove-source-branch --yes', () => {

--- a/lib/gitlab-api.ts
+++ b/lib/gitlab-api.ts
@@ -88,6 +88,22 @@ export interface GitlabMr {
   work_in_progress?: boolean;
   head_pipeline?: GitlabPipeline | null;
   pipeline?: GitlabPipeline | null; // Alias for head_pipeline in some contexts
+  /**
+   * Diff head SHA — the HEAD commit of the **source branch**. Distinct from
+   * `merge_commit_sha`, which is the commit produced *by* a merge and is null
+   * until the MR is merged. This is the value GitLab's merge endpoint wants as
+   * its `sha` stale-head guard (#486).
+   *
+   * Read as the FALLBACK: `diff_refs.head_sha` below is the canonical source
+   * and takes precedence (see `resolveHeadSha` in `pr-merge-gitlab.ts`).
+   */
+  sha?: string;
+  /** Canonical source-branch head; preferred over the top-level `sha`. */
+  diff_refs?: {
+    base_sha?: string | null;
+    head_sha?: string | null;
+    start_sha?: string | null;
+  } | null;
   merge_commit_sha?: string | null;
   created_at?: string;
   updated_at?: string;

--- a/tests/integration/cli-flag-shapes.test.ts
+++ b/tests/integration/cli-flag-shapes.test.ts
@@ -221,6 +221,25 @@ describe('GitLab CLI flag shapes', () => {
     matchOrSkip(help, /--remove-source-branch/);
   });
 
+  test('glab mr merge accepts --sha and --auto-merge flags (#486)', () => {
+    // Used by pr_merge / pr_merge_wait via pr-merge-gitlab.
+    //
+    // These are load-bearing and cannot be covered by the unit suite, which
+    // asserts against a MOCKED argv string and would stay green against a glab
+    // that rejects the flags:
+    //   --sha        GitLab's stale-head guard. Without it, namespaces with
+    //                `require_sha_for_merge` (now the DEFAULT for new groups)
+    //                reject the merge with 400.
+    //   --auto-merge Passed as `--auto-merge=false`. It is a relatively recent
+    //                rename — older glab exposed this as
+    //                `--when-pipeline-succeeds`. On a glab predating the
+    //                rename, `--auto-merge=false` is an UNKNOWN FLAG and every
+    //                GitLab merge fails, which is worse than the bug #486 fixed.
+    const help = captureHelp('glab mr merge --help');
+    matchOrSkip(help, /--sha/);
+    matchOrSkip(help, /--auto-merge/);
+  });
+
   test('glab api projects/.../pipelines query is valid (used by ci_runs_for_branch)', () => {
     // Used by ci_wait_run and ci_runs_for_branch handlers via gitlab-api.ts
     // Our handlers use `glab api projects/<encoded>/pipelines?ref=<branch>&limit=N`

--- a/tests/pr_merge.test.ts
+++ b/tests/pr_merge.test.ts
@@ -171,6 +171,7 @@ describe('pr_merge handler — aggregate response (#225)', () => {
         target_branch: 'main',
         web_url: 'https://gitlab.com/org/repo/-/merge_requests/17',
         labels: [],
+        sha: 'head17aaaaaa',
         merge_commit_sha: 'deadbeef1234',
       }),
     );
@@ -493,6 +494,21 @@ describe('pr_merge handler — aggregate response (#225)', () => {
 
   test('gitlab failed merge — error surfaces as failure', async () => {
     onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git\n');
+    // #486: head-sha resolution runs before the merge, so this fixture is
+    // required for the call to reach the merge failure this test asserts on.
+    onExec(
+      'glab api projects/org%2Frepo/merge_requests/9',
+      JSON.stringify({
+        iid: 9,
+        state: 'opened',
+        source_branch: 'feature/conflict',
+        target_branch: 'main',
+        web_url: 'https://gitlab.com/org/repo/-/merge_requests/9',
+        labels: [],
+        sha: 'head9conflict',
+        merge_commit_sha: null,
+      }),
+    );
     onExec('glab mr merge 9 --squash --remove-source-branch --yes', () => {
       const err = new Error('merge request cannot be merged') as ThrowableError;
       err.stderr = 'merge request has conflicts\n';
@@ -575,6 +591,7 @@ describe('pr_merge handler — aggregate response (#225)', () => {
         target_branch: 'main',
         web_url: 'https://gitlab.com/org/repo/-/merge_requests/14',
         labels: [],
+        sha: 'head14dddddd',
         merge_commit_sha: 'f00dbabe',
       }),
     );
@@ -638,6 +655,7 @@ describe('pr_merge handler — aggregate response (#225)', () => {
         target_branch: 'main',
         web_url: 'https://gitlab.com/target-org/target-repo/-/merge_requests/17',
         labels: [],
+        sha: 'head17eeeeee',
         merge_commit_sha: 'deadbeef',
       }),
     );

--- a/tests/pr_merge.test.ts
+++ b/tests/pr_merge.test.ts
@@ -668,7 +668,7 @@ describe('pr_merge handler — aggregate response (#225)', () => {
     expect(data.ok).toBe(true);
 
     const mergeCall = execCalls().find((c) => c.startsWith('glab mr merge 17')) ?? '';
-    expect(mergeCall).toContain('-R target-org/target-repo');
+    expect(mergeCall).toContain("-R 'target-org/target-repo'");
     const apiCall = execCalls().find((c) => c.includes('glab api projects/')) ?? '';
     expect(apiCall).toContain('target-org%2Ftarget-repo');
     expect(apiCall).not.toContain('cwd-org%2Fcwd-repo');


### PR DESCRIPTION
## Summary

GitLab merges were a hard block: `pr_merge` / `pr_merge_wait` died with `400 SHA must be provided when merging`, leaving MRs waiting for a human in the UI with no MCP fallback. The adapter never sent GitLab's required stale-head guard. Fixed by resolving the MR's source-branch HEAD sha and passing `--sha`, plus two defects that verification surfaced along the way.

**Root cause is upstream, and it will recur.** GitLab's merge handler rejects an unguarded merge when `namespace.require_sha_for_merge?`, and `groups/create_service.rb:194` now **defaults new groups to `require_sha_for_merge = true`**. This is a GitLab environment change, not an sdlc regression — which is why newly-created nested groups fail while older projects the fleet has always merged keep working. It will resurface for every new subgroup, so the fix is unconditional rather than detection-gated (detection isn't even possible — the field is not exposed on the Groups API).

## Changes

Two commits, deliberately kept separate for revert granularity — if the merge fix has to come out, the security fix must not come out with it.

**Commit 1 — `fix(pr-merge-gitlab): send --sha stale-head guard; disable auto-merge`**
- Resolve the MR source-branch HEAD (`diff_refs.head_sha`, falling back to `sha`) via the existing encoded-path helper `gitlabApiMr`, and pass it as `--sha`. The parameter is **required** on `buildGitlabMergeCommand`, making a sha-less merge a compile-time impossibility rather than a convention.
- Force `--auto-merge=false`. `glab` defaults it **true**; left on, this fix would have converted a loud 400 into a *silent enrollment* — returning `merged: false` / `pr_state: "OPEN"` while still reporting `merge_method: "direct_squash"`.
- Retry once on a `409 SHA does not match` stale-head rejection, re-resolving the sha. Closes the inherent fetch→merge TOCTOU window. Non-sha failures stay fatal with no retry.
- Refuse loudly with `gitlab_head_sha_unresolved` if the sha can't be resolved — never merge without one.
- `lib/gitlab-api.ts`: declare `sha` / `diff_refs` on `GitlabMr` (the API returns them; the interface never modelled them), documented as distinct from `merge_commit_sha`.

**Commit 2 — `fix(pr-merge-gitlab): shell-escape -R repo interpolation (#408)`**
- `-R ${repo}` was the one caller-supplied field interpolated raw while `squash_message` was escaped. Not the merge bug and explicitly not part of its justification — fixed because leaving a known injection in a function we just modified is worse than the scope.

## What was NOT changed, and why

**Percent-encoding.** The reported error shows raw slashes in the URL, which looks like an encoding bug. It isn't ours and it isn't a bug at all:

- sdlc-server builds no API URL for merge — it shells out and **glab** constructs the request.
- Wire capture (glab pointed at a local TLS server) shows the real request is correctly encoded at 5 segments: `GET /api/v4/projects/analogicdev%2Finternal%2Ftools%2Fblueshift%2Fsite-interpreters%2Frhel9/merge_requests/4`.
- Independently corroborated by live read-only probes discriminating project-level `404 Project Not Found` from MR-level `404 Not found`.
- The `400` is itself decisive: a structurally ambiguous `:id` returns 404, never a merge-parameter error.

The raw slashes are a display artifact of glab's error formatter (`retry-go`, confirmed via a panic stack at `mr_merge.go:191/203`). Patching that layer would have produced a green test and a live bug.

## Linked Issues

Closes #486
Closes #408

## Test Plan

Actually run, not aspirational:

- `./scripts/ci/validate.sh` — green: codegen, TypeScript lint, adapter gate-greps, shellcheck, **2404 unit + 48 flightdeck + 20 integration tests, 0 fail**, 78/78 runtime smoke assertions.
- `trivy fs --scanners vuln --severity HIGH,CRITICAL` — 0 findings.
- New behavioral coverage: `--sha` carries the source-branch head (not the merge commit); `diff_refs.head_sha` preferred with `sha` fallback; refusal asserts **no merge call is ever issued**; `--auto-merge=false` present; stale-head 409 retried with a **re-resolved** sha (asserts the retry uses the fresh head, not a replay); non-sha failure fatal with exactly one attempt; deep 5-segment nested path encoded whole.
- `glab mr merge --help` and glab v1.36.0 source read directly to confirm `--sha` → `AcceptMergeRequestOptions.SHA` (its help text, "Merge Commit sha", is a documentation bug) and that `--auto-merge` defaults true.

**Not yet done — required before merge:** live validation against a `require_sha_for_merge` project (@keymaker, MR !4 on `analogicdev/…/rhel9`). The unit suite cannot prove GitLab-side acceptance; a mock-only green result would prove only that the code and my fixtures agree.

## Live validation — and the one assertion that made it meaningful

Validated against a real `require_sha_for_merge` namespace as a **paired experiment**: the bug was first shown reproducing byte-identically on the same fixture (`400 SHA must be provided when merging`), *then* this branch merged it. Without the negative control, "it merged" is just "it merged".

**The decisive assertion was `merge_when_pipeline_succeeds: false`, read back from the GitLab API — not from client output.** This is worth stating plainly because it is the most instructive thing on this branch:

- `glab` prints `✓ Merged` for an **enrollment** (merge-when-pipeline-succeeds) exactly as it does for a real merge.
- This adapter reports `merge_method: "direct_squash"` either way.
- `merged: true` and `pr_state: "MERGED"` would both have passed for an enrollment.

**Every other assertion would have been satisfied by an armed auto-merge.** `merge_when_pipeline_succeeds` is GitLab's own record of *which operation it actually performed* — the one field the client cannot author. Without server read-back, this PR would have shipped a green validation run that could not distinguish a merge from an enrollment — which **is** the `--auto-merge` bug this PR fixes.

The general rule: when a tool can lie in exactly one direction, assert on something the tool does not write.

Assertion credit: @keymaker, who also held the original repro MR open rather than unblocking herself with it.

**Explicitly NOT established by that run:** the TOCTOU 409 retry path (requires the source branch to move mid-merge) and the `gitlab_head_sha_unresolved` refusal path. Both are unit-tested only — the green above does not cover them.
