### PR TITLE
fix(pr_status): read checks from statusCheckRollup; fail closed on unknown

### DIFF
--- a/docs/handlers/origin-operations-guide.md
+++ b/docs/handlers/origin-operations-guide.md
@@ -371,7 +371,22 @@ GitHub lets you request only the fields you need; GitLab always dumps the whole 
 | `mergeStateStatus` (CLEAN/DIRTY/BLOCKED/UNSTABLE) | `detailed_merge_status` (`mergeable`, `broken_status`, `blocked_status`, `ci_must_pass`, ...) | `merge_state` (`clean`/`dirty`/`blocked`/`unstable`/`unknown`) |
 | `mergeable` (boolean)                             | `merge_status` (`can_be_merged`/`cannot_be_merged`)   | `mergeable` (boolean)           |
 | `url`                                             | `web_url`                                             | `url`                           |
-| `checks[].name` + `checks[].conclusion` (from `gh pr checks --json name,state,conclusion`) | `pipeline.status` (`success`/`failed`/`running`/`pending`) | `checks.summary` (`all_passed`/`has_failures`/`pending`/`none`) |
+| `statusCheckRollup[]` (from `gh pr view --json ...,statusCheckRollup` — the SAME call as the fields above) | `pipeline.status` (`success`/`failed`/`running`/`pending`) | `checks.summary` (`all_passed`/`has_failures`/`pending`/`none`) |
+
+> ⚠️ **Do NOT use `gh pr checks --json` for checks.** That flag does not exist on
+> gh 2.45 (what Ubuntu 24.04 LTS ships). It exits non-zero, and treating that
+> failure as "no checks configured" makes `pr_status` report `checks: none` for
+> PRs with passing checks — silently, on every PR. `pr_wait_ci` was migrated off
+> it by **#220**; `pr_status` carried the same defect until **#491**. Request
+> `statusCheckRollup` on the existing `gh pr view` call instead — one subprocess,
+> and no second query that can fail unnoticed.
+>
+> **Fail closed on an absent rollup.** `gh` always returns a requested `--json`
+> key, so a missing/null `statusCheckRollup` means the check state is UNKNOWN,
+> not absent. Return `{ok: false, code: 'gh_status_check_rollup_missing'}` rather
+> than inventing a summary: `/mmr` halts on an error envelope but treats an
+> unrecognised `checks.summary` as permission to merge, so an error is the only
+> representation that actually stops it.
 
 **Normalization rules:**
 - GitHub `mergeStateStatus`:

--- a/docs/platform-adapter-retrofit-devspec.md
+++ b/docs/platform-adapter-retrofit-devspec.md
@@ -962,7 +962,7 @@ Migrate `pr_status` to the adapter pair. Note: `pr_status.ts` line 218 has the i
 **Implementation Steps:**
 
 1. Add `prStatus(args: PrStatusArgs): Promise<AdapterResult<PrStatusResponse>>` to `PlatformAdapter`
-2. Create `lib/adapters/pr-status-github.ts` — lift GitHub logic from `handlers/pr_status.ts`; preserve the `aggregateGithubChecks` normalization
+2. Create `lib/adapters/pr-status-github.ts` — lift GitHub logic from `handlers/pr_status.ts`; preserve the `aggregateRollup` normalization
 3. Create `lib/adapters/pr-status-gitlab.ts` — lift GitLab logic; make the pipeline-status fallthrough EXPLICIT (when both `pipeline?.status` and `head_pipeline?.status` are undefined, return a typed "no pipeline data" outcome rather than silently producing `summary: 'none'`)
 4. Wire into adapter assemblers
 5. Refactor `handlers/pr_status.ts` to ~50-line dispatch
@@ -977,7 +977,7 @@ Migrate `pr_status` to the adapter pair. Note: `pr_status.ts` line 218 has the i
 | Test Name | Purpose | File Location |
 |-----------|---------|---------------|
 | `pr-status-github — parses state + mergeStateStatus + checks` | Aggregate response | `lib/adapters/pr-status-github.test.ts` |
-| `pr-status-github — aggregateGithubChecks counts pass/fail/pending` | Check normalization | `lib/adapters/pr-status-github.test.ts` |
+| `pr-status-github — aggregateRollup counts pass/fail/pending` | Check normalization | `lib/adapters/pr-status-github.test.ts` |
 | `pr-status-gitlab — parses state + detailed_merge_status` | Aggregate response | `lib/adapters/pr-status-gitlab.test.ts` |
 | `pr-status-gitlab — pipeline-status fallthrough is explicit` | Regression for line 218 silent loss | `lib/adapters/pr-status-gitlab.test.ts` |
 

--- a/handlers/pr_status.ts
+++ b/handlers/pr_status.ts
@@ -41,7 +41,12 @@ const prStatusHandler: HandlerDef = {
     if ('platform_unsupported' in result) {
       return envelope({ ok: true, platform_unsupported: true, hint: result.hint });
     }
-    if (!result.ok) return envelope({ ok: false, error: result.error });
+    // Surface the adapter's `code` alongside `error` (#491). `/mmr` documents
+    // handling a `{ok: false, code, error}` envelope, but this handler had been
+    // dropping `code`, leaving callers to string-match the message to tell one
+    // failure from another. Additive — existing readers of `error` are
+    // unaffected.
+    if (!result.ok) return envelope({ ok: false, code: result.code, error: result.error });
     // pr_status preserves the legacy `{ok: true, data: {...}}` envelope
     // (rather than spreading like other migrated handlers) so downstream
     // callers — e.g. /mmr — that read `result.data.checks.summary` keep

--- a/lib/adapters/pr-status-github.test.ts
+++ b/lib/adapters/pr-status-github.test.ts
@@ -6,12 +6,19 @@ import {
   installChildProcessMock,
 } from '../test-support/mock-child-process.ts';
 import type { AdapterResult, PrStatusResponse } from './types.ts';
+import type { RollupItem } from './pr-wait-ci-github.ts';
 
 // Subprocess-boundary tests for the GitHub pr_status adapter (R-15).
 // Integration-level coverage (handler dispatch, error envelope) stays in
 // tests/pr_status.test.ts; this file owns the argv-shape and response-parsing
 // assertions that prove the adapter speaks `gh` correctly, plus the
-// aggregateGithubChecks pass/fail/pending counting table.
+// aggregateRollup pass/fail/pending counting table.
+//
+// #491: checks come from `gh pr view --json ...,statusCheckRollup` — a SINGLE
+// call. The adapter previously issued a second `gh pr checks --json`, a flag
+// that does not exist on gh 2.45 (Ubuntu 24.04 LTS), and rendered that failure
+// as `summary: 'none'`. Tests here lock the single-call shape and the
+// fail-CLOSED behaviour that replaced the silent default.
 
 interface ThrowableError extends Error {
   stderr?: string;
@@ -25,7 +32,7 @@ function unquote(cmd: string): string {
 
 installChildProcessMock();
 
-const { prStatusGithub, aggregateGithubChecks } = await import('./pr-status-github.ts');
+const { prStatusGithub, aggregateRollup } = await import('./pr-status-github.ts');
 
 function expectOk(
   r: AdapterResult<PrStatusResponse>,
@@ -47,27 +54,38 @@ function findCall(needle: string): string {
   return execCalls().find((c) => c.includes(needle) || unquote(c).includes(needle)) ?? '';
 }
 
+/** A completed CheckRun in `statusCheckRollup` shape. */
+function checkRun(name: string, conclusion: string): RollupItem {
+  return { __typename: 'CheckRun', name, status: 'COMPLETED', conclusion };
+}
+
+/** Build a `gh pr view --json` payload including the rollup. */
+function viewPayload(
+  over: Partial<{
+    state: string;
+    mergeStateStatus: string;
+    mergeable: string | boolean;
+    url: string;
+    statusCheckRollup: RollupItem[];
+  }> = {},
+): string {
+  return JSON.stringify({
+    state: 'OPEN',
+    mergeStateStatus: 'CLEAN',
+    mergeable: 'MERGEABLE',
+    url: 'https://github.com/o/r/pull/1',
+    statusCheckRollup: [],
+    ...over,
+  });
+}
+
 beforeEach(() => {
   resetExecMock();
 });
 
 describe('prStatusGithub — subprocess boundary', () => {
   test('gh CLI invocation matches expected argv shape (happy path)', async () => {
-    onExec(
-      'gh pr view',
-      JSON.stringify({
-        state: 'OPEN',
-        mergeStateStatus: 'CLEAN',
-        mergeable: 'MERGEABLE',
-        url: 'https://github.com/o/r/pull/42',
-      }),
-    );
-    onExec(
-      'gh pr checks',
-      JSON.stringify([
-        { name: 'validate', state: 'completed', conclusion: 'success' },
-      ]),
-    );
+    onExec('gh pr view', viewPayload({ statusCheckRollup: [checkRun('validate', 'SUCCESS')] }));
 
     const result = await prStatusGithub({ number: 42 });
     expectOk(result);
@@ -76,33 +94,31 @@ describe('prStatusGithub — subprocess boundary', () => {
     const viewCall = findCall('gh pr view');
     expect(viewCall).toContain('42');
     expect(viewCall).toContain('--json');
-    // The handler-shape state/mergeStateStatus/mergeable/url JSON projection.
-    expect(viewCall).toContain('state,mergeStateStatus,mergeable,url');
+    // #491: the rollup is requested on the SAME call as the PR fields.
+    expect(viewCall).toContain('state,mergeStateStatus,mergeable,url,statusCheckRollup');
     expect(viewCall).not.toContain('--repo');
-
-    const checksCall = findCall('gh pr checks');
-    expect(checksCall).toContain('42');
-    expect(checksCall).toContain('--json');
-    expect(checksCall).toContain('name,state,conclusion');
-    expect(checksCall).not.toContain('--repo');
   });
 
-  test('parses pr view + pr checks responses into PrStatusResponse', async () => {
+  test('#491 regression: NEVER issues `gh pr checks` (flag absent on gh 2.45)', async () => {
+    onExec('gh pr view', viewPayload({ statusCheckRollup: [checkRun('validate', 'SUCCESS')] }));
+
+    const result = await prStatusGithub({ number: 42 });
+    expectOk(result);
+
+    // The defect: `gh pr checks --json` exits non-zero on the fleet's gh, and
+    // the old code rendered that as `summary: 'none'`. Guard the argv directly,
+    // mirroring the #220 guard that protects pr_wait_ci.
+    expect(execCalls().find((c) => unquote(c).includes('gh pr checks'))).toBeUndefined();
+    expect(execCalls().filter((c) => unquote(c).includes('gh pr view')).length).toBe(1);
+  });
+
+  test('parses view + rollup into PrStatusResponse', async () => {
     onExec(
       'gh pr view',
-      JSON.stringify({
-        state: 'OPEN',
-        mergeStateStatus: 'CLEAN',
-        mergeable: 'MERGEABLE',
+      viewPayload({
         url: 'https://github.com/o/r/pull/7',
+        statusCheckRollup: [checkRun('a', 'SUCCESS'), checkRun('b', 'SUCCESS')],
       }),
-    );
-    onExec(
-      'gh pr checks',
-      JSON.stringify([
-        { name: 'a', state: 'completed', conclusion: 'success' },
-        { name: 'b', state: 'completed', conclusion: 'success' },
-      ]),
     );
 
     const result = await prStatusGithub({ number: 7 });
@@ -117,17 +133,31 @@ describe('prStatusGithub — subprocess boundary', () => {
     });
   });
 
-  test('boolean mergeable=true is honored alongside MERGEABLE string', async () => {
+  test('the treebeard case: 4 passing checks report as all_passed, not none', async () => {
+    // The reported symptom (#491): pr_wait_ci said 4/4 passed while pr_status
+    // said `none`, seconds apart, same PR.
     onExec(
       'gh pr view',
-      JSON.stringify({
-        state: 'OPEN',
-        mergeStateStatus: 'CLEAN',
-        mergeable: true,
-        url: 'https://github.com/o/r/pull/3',
+      viewPayload({
+        statusCheckRollup: [
+          checkRun('lint', 'SUCCESS'),
+          checkRun('test', 'SUCCESS'),
+          checkRun('build', 'SUCCESS'),
+          checkRun('typecheck', 'SUCCESS'),
+        ],
       }),
     );
-    onExec('gh pr checks', JSON.stringify([]));
+
+    const result = await prStatusGithub({ number: 4 });
+    expectOk(result);
+    expect(result.data.checks.total).toBe(4);
+    expect(result.data.checks.passed).toBe(4);
+    expect(result.data.checks.summary).toBe('all_passed');
+    expect(result.data.checks.summary).not.toBe('none');
+  });
+
+  test('boolean mergeable=true is honored alongside MERGEABLE string', async () => {
+    onExec('gh pr view', viewPayload({ mergeable: true }));
 
     const result = await prStatusGithub({ number: 3 });
     expectOk(result);
@@ -144,16 +174,7 @@ describe('prStatusGithub — subprocess boundary', () => {
     ];
     for (const [status, expected] of cases) {
       resetExecMock();
-      onExec(
-        'gh pr view',
-        JSON.stringify({
-          state: 'OPEN',
-          mergeStateStatus: status,
-          mergeable: 'UNKNOWN',
-          url: 'https://github.com/o/r/pull/1',
-        }),
-      );
-      onExec('gh pr checks', JSON.stringify([]));
+      onExec('gh pr view', viewPayload({ mergeStateStatus: status, mergeable: 'UNKNOWN' }));
 
       const result = await prStatusGithub({ number: 1 });
       expectOk(result);
@@ -170,16 +191,7 @@ describe('prStatusGithub — subprocess boundary', () => {
     ];
     for (const [raw, expected] of cases) {
       resetExecMock();
-      onExec(
-        'gh pr view',
-        JSON.stringify({
-          state: raw,
-          mergeStateStatus: 'CLEAN',
-          mergeable: 'UNKNOWN',
-          url: 'https://github.com/o/r/pull/2',
-        }),
-      );
-      onExec('gh pr checks', JSON.stringify([]));
+      onExec('gh pr view', viewPayload({ state: raw, mergeable: 'UNKNOWN' }));
 
       const result = await prStatusGithub({ number: 2 });
       expectOk(result);
@@ -187,7 +199,14 @@ describe('prStatusGithub — subprocess boundary', () => {
     }
   });
 
-  test('gh pr checks failure is treated as no checks (summary none)', async () => {
+  test('#491: a MISSING rollup fails CLOSED — never rendered as summary none', async () => {
+    // This inverts the previous `gh pr checks failure is treated as no checks
+    // (summary none)` test, which encoded the defect as intended behaviour.
+    //
+    // A missing field means the check state is UNKNOWN, not absent. Reporting
+    // it as `none` is silent-permissive: /mmr halts on an {ok:false} envelope
+    // but treats an unrecognised checks.summary as permission to merge, so an
+    // error is the only representation that fails closed.
     onExec(
       'gh pr view',
       JSON.stringify({
@@ -195,21 +214,45 @@ describe('prStatusGithub — subprocess boundary', () => {
         mergeStateStatus: 'CLEAN',
         mergeable: 'MERGEABLE',
         url: 'https://github.com/o/r/pull/99',
+        // statusCheckRollup deliberately absent
       }),
     );
-    onExec('gh pr checks', () => {
-      const err = new Error('no checks reported') as ThrowableError;
-      err.stderr = 'no checks reported';
-      err.status = 1;
-      throw err;
-    });
 
     const result = await prStatusGithub({ number: 99 });
+    expectErr(result);
+    expect(result.code).toBe('gh_status_check_rollup_missing');
+    expect(result.error).toContain('UNKNOWN, not absent');
+  });
+
+  test('#491: a null rollup also fails closed', async () => {
+    onExec('gh pr view', JSON.stringify({
+      state: 'OPEN',
+      mergeStateStatus: 'CLEAN',
+      mergeable: 'MERGEABLE',
+      url: 'https://github.com/o/r/pull/98',
+      statusCheckRollup: null,
+    }));
+
+    const result = await prStatusGithub({ number: 98 });
+    expectErr(result);
+    expect(result.code).toBe('gh_status_check_rollup_missing');
+  });
+
+  test('an EMPTY rollup is a genuine zero — summary none, still ok', async () => {
+    // The distinction that matters: query succeeded and the PR really has no
+    // checks. This must stay representable, and stay distinct from the
+    // failure case above.
+    onExec('gh pr view', viewPayload({ statusCheckRollup: [] }));
+
+    const result = await prStatusGithub({ number: 11 });
     expectOk(result);
-    expect(result.data.checks.total).toBe(0);
-    expect(result.data.checks.summary).toBe('none');
-    // Mergeable etc. still flow from the pr view response.
-    expect(result.data.merge_state).toBe('clean');
+    expect(result.data.checks).toEqual({
+      total: 0,
+      passed: 0,
+      failed: 0,
+      pending: 0,
+      summary: 'none',
+    });
   });
 
   test('returns AdapterResult{ok:false, code} on gh pr view failure (not thrown)', async () => {
@@ -223,34 +266,48 @@ describe('prStatusGithub — subprocess boundary', () => {
     const result = await prStatusGithub({ number: 404 });
     expectErr(result);
     expect(result.code).toBe('gh_pr_view_failed');
-    expect(result.error).toContain('gh pr view failed');
+    // #493: the message reports what was queried and what came back, and names
+    // this a FAILED QUERY rather than an empty result.
+    expect(result.error).toContain('Could not determine');
+    expect(result.error).toContain('FAILED QUERY, not an empty result');
+    // ...and the verification hint is DERIVED from the argv that actually ran,
+    // so it cannot describe a different query than the one performed.
+    // renderArgv escapes per token so the command is copy-pasteable, hence
+    // the quoted form here rather than a bare substring.
+    expect(unquote(result.error)).toContain('gh pr view 404');
+    expect(result.error).toContain('statusCheckRollup');
   });
 
-  test('--repo flag forwarded into both pr view AND pr checks', async () => {
-    onExec(
-      'gh pr view',
-      JSON.stringify({
-        state: 'OPEN',
-        mergeStateStatus: 'CLEAN',
-        mergeable: 'MERGEABLE',
-        url: 'https://github.com/Org/Other/pull/5',
-      }),
-    );
-    onExec('gh pr checks', JSON.stringify([]));
+  test('#493: unparseable stdout is a FAILED QUERY, not an empty result', async () => {
+    // The other half of the defect class: the command SUCCEEDS but returns
+    // garbage. Without this, `classifyRun`'s parse branch had zero coverage
+    // while the adapter comment claimed it load-bearing.
+    onExec('gh pr view', 'this is not json');
+
+    const result = await prStatusGithub({ number: 77 });
+    expectErr(result);
+    expect(result.code).toBe('gh_pr_view_unparseable');
+    // Distinct from an exec failure — same fail-closed direction, different cause.
+    expect(result.code).not.toBe('gh_pr_view_failed');
+    expect(result.error).toContain('FAILED QUERY, not an empty result');
+    expect(result.error).toContain('unparseable output');
+  });
+
+  test('--repo flag forwarded into the single pr view call', async () => {
+    onExec('gh pr view', viewPayload({ url: 'https://github.com/Org/Other/pull/5' }));
 
     await prStatusGithub({ number: 5, repo: 'Org/Other' });
     const viewCall = findCall('gh pr view');
     expect(viewCall).toContain('--repo');
     expect(viewCall).toContain('Org/Other');
-    const checksCall = findCall('gh pr checks');
-    expect(checksCall).toContain('--repo');
-    expect(checksCall).toContain('Org/Other');
+    // There is no second call to forward it into any more.
+    expect(execCalls().find((c) => unquote(c).includes('gh pr checks'))).toBeUndefined();
   });
 });
 
-describe('aggregateGithubChecks helper', () => {
+describe('aggregateRollup helper', () => {
   test('empty list → summary none, all counts zero', () => {
-    expect(aggregateGithubChecks([])).toEqual({
+    expect(aggregateRollup([])).toEqual({
       total: 0,
       passed: 0,
       failed: 0,
@@ -259,12 +316,8 @@ describe('aggregateGithubChecks helper', () => {
     });
   });
 
-  test('all success → summary all_passed', () => {
-    const agg = aggregateGithubChecks([
-      { name: 'a', state: 'completed', conclusion: 'success' },
-      { name: 'b', state: 'completed', conclusion: 'success' },
-    ]);
-    expect(agg).toEqual({
+  test('all successful → all_passed', () => {
+    expect(aggregateRollup([checkRun('a', 'SUCCESS'), checkRun('b', 'SUCCESS')])).toEqual({
       total: 2,
       passed: 2,
       failed: 0,
@@ -273,46 +326,50 @@ describe('aggregateGithubChecks helper', () => {
     });
   });
 
-  test('any failure → summary has_failures (precedence over pending)', () => {
-    const agg = aggregateGithubChecks([
-      { name: 'a', state: 'completed', conclusion: 'success' },
-      { name: 'b', state: 'completed', conclusion: 'failure' },
-      { name: 'c', state: 'in_progress', conclusion: null },
+  test('any failure → has_failures, and failures outrank pending', () => {
+    const agg = aggregateRollup([
+      checkRun('a', 'SUCCESS'),
+      checkRun('b', 'FAILURE'),
+      { __typename: 'CheckRun', name: 'c', status: 'IN_PROGRESS' },
     ]);
-    expect(agg.summary).toBe('has_failures');
-    expect(agg.passed).toBe(1);
     expect(agg.failed).toBe(1);
     expect(agg.pending).toBe(1);
-  });
-
-  test('failure synonyms count as failed (cancelled/timed_out/action_required)', () => {
-    const agg = aggregateGithubChecks([
-      { name: 'a', conclusion: 'cancelled' },
-      { name: 'b', conclusion: 'timed_out' },
-      { name: 'c', conclusion: 'action_required' },
-      { name: 'd', state: 'failure' },
-    ]);
-    expect(agg.failed).toBe(4);
     expect(agg.summary).toBe('has_failures');
   });
 
-  test('pending → summary pending when no failures', () => {
-    const agg = aggregateGithubChecks([
-      { name: 'a', state: 'completed', conclusion: 'success' },
-      { name: 'b', state: 'in_progress', conclusion: null },
+  test('incomplete runs count pending → summary pending', () => {
+    const agg = aggregateRollup([
+      checkRun('a', 'SUCCESS'),
+      { __typename: 'CheckRun', name: 'b', status: 'QUEUED' },
     ]);
-    expect(agg.summary).toBe('pending');
-    expect(agg.passed).toBe(1);
-    expect(agg.pending).toBe(1);
-    expect(agg.failed).toBe(0);
+    expect(agg).toEqual({
+      total: 2,
+      passed: 1,
+      failed: 0,
+      pending: 1,
+      summary: 'pending',
+    });
   });
 
-  test('null/missing conclusion treated as pending', () => {
-    const agg = aggregateGithubChecks([
-      { name: 'a', state: 'queued' },
-      { name: 'b', conclusion: null },
+  test('SKIPPED / STALE count as passed, not blockers', () => {
+    const agg = aggregateRollup([checkRun('a', 'SKIPPED'), checkRun('b', 'STALE')]);
+    expect(agg.passed).toBe(2);
+    expect(agg.summary).toBe('all_passed');
+  });
+
+  test('legacy StatusContext items are classified too', () => {
+    const agg = aggregateRollup([
+      { __typename: 'StatusContext', name: 'legacy-ok', state: 'SUCCESS' },
+      { __typename: 'StatusContext', name: 'legacy-bad', state: 'FAILURE' },
     ]);
-    expect(agg.pending).toBe(2);
+    expect(agg.passed).toBe(1);
+    expect(agg.failed).toBe(1);
+    expect(agg.summary).toBe('has_failures');
+  });
+
+  test('unknown __typename defaults to pending — never decides on what it cannot classify', () => {
+    const agg = aggregateRollup([{ __typename: 'SomethingNew', name: 'x' }]);
+    expect(agg.pending).toBe(1);
     expect(agg.summary).toBe('pending');
   });
 });

--- a/lib/adapters/pr-status-github.ts
+++ b/lib/adapters/pr-status-github.ts
@@ -8,7 +8,7 @@
  * Errors that come back from `gh` are converted into `{ok: false, error, code}`
  * — never thrown — so the handler doesn't need a try/catch around the dispatch.
  *
- * The `aggregateGithubChecks` / `normalizeGithubState` / `normalizeGithubMergeState`
+ * The `normalizeGithubState` / `normalizeGithubMergeState`
  * helpers are preserved verbatim from the pre-migration handler — that logic
  * is correct as-is and the existing integration tests in `tests/pr_status.test.ts`
  * lock its behavior.
@@ -16,6 +16,8 @@
 
 import { execSync } from 'child_process';
 import { runArgv } from '../shared/error-norm.js';
+import { classifyRun, describeFailedQuery, renderArgv } from '../shared/query-outcome.js';
+import { classifyRollupItem, type RollupItem } from './pr-wait-ci-github.js';
 import type {
   AdapterResult,
   PrStatusArgs,
@@ -48,40 +50,44 @@ function normalizeGithubMergeState(mergeStateStatus: string): PrStatusMergeState
   return 'unknown';
 }
 
-interface GithubCheck {
-  name?: string;
-  state?: string;
-  conclusion?: string | null;
-}
 
-export function aggregateGithubChecks(checks: GithubCheck[]): PrStatusChecksAggregate {
+/**
+ * Aggregate a `statusCheckRollup` into the `pr_status` checks shape (#491).
+ *
+ * Reuses `classifyRollupItem` from `pr-wait-ci-github.ts` rather than adding a
+ * second classifier, so `pr_status` and `pr_wait_ci` cannot disagree about what
+ * a given check means — the disagreement that surfaced this bug (one reported
+ * `4/4 passed` while the other reported `none`, seconds apart, same PR).
+ *
+ * `skipping` counts as passed: a skipped or stale check is not a blocker, which
+ * is the same judgement `pr_wait_ci` already makes at the DECISION level
+ * (`decide()` returns passed when pending === 0 && failed === 0, #221).
+ *
+ * The COUNTS differ deliberately: `snapshotGithub` leaves skipped checks
+ * uncounted while still setting `total = checks.length`, so an all-skipped PR
+ * prints `0/4` there and `4/4` here. Same verdict, different arithmetic — kept
+ * so `passed + failed + pending === total` holds in this aggregate, which the
+ * `pr_status` response shape implies. Noted rather than silently divergent,
+ * because a cosmetic disagreement between these two tools is exactly what got
+ * #491 reported.
+ */
+export function aggregateRollup(items: RollupItem[]): PrStatusChecksAggregate {
   let passed = 0;
   let failed = 0;
   let pending = 0;
 
-  for (const c of checks) {
-    const conclusion = (c.conclusion ?? '').toLowerCase();
-    const state = (c.state ?? '').toLowerCase();
-
-    if (conclusion === 'success' || state === 'success') {
-      passed += 1;
-    } else if (
-      conclusion === 'failure' ||
-      conclusion === 'cancelled' ||
-      conclusion === 'timed_out' ||
-      conclusion === 'action_required' ||
-      state === 'failure'
-    ) {
-      failed += 1;
-    } else {
-      // null conclusion, in_progress, queued, pending, etc.
-      pending += 1;
-    }
+  for (const item of items) {
+    const bucket = classifyRollupItem(item);
+    if (bucket === 'pass' || bucket === 'skipping') passed += 1;
+    else if (bucket === 'fail') failed += 1;
+    else pending += 1;
   }
 
-  const total = checks.length;
+  const total = items.length;
   let summary: PrStatusChecksSummary;
   if (total === 0) {
+    // A genuine zero — the query SUCCEEDED and the PR has no checks. Distinct
+    // from the failure path above, which returns an error instead.
     summary = 'none';
   } else if (failed > 0) {
     summary = 'has_failures';
@@ -102,28 +108,58 @@ export async function prStatusGithub(
   try {
     const cwd = projectDir();
 
-    // 1. gh pr view
+    // 1. gh pr view — one call, checks included (#491).
+    //
+    // `statusCheckRollup` is requested HERE rather than via a second
+    // `gh pr checks --json` subprocess. Two reasons, both load-bearing:
+    //
+    //   * `gh pr checks --json` DOES NOT EXIST on gh 2.45 (what Ubuntu 24.04
+    //     LTS ships). It exits non-zero with `unknown flag: --json`, and the
+    //     old code treated that failure as "no checks configured" — so this
+    //     tool reported `checks: none` for PRs with passing checks, on every
+    //     GitHub PR, permanently. `pr_wait_ci` was migrated off that same flag
+    //     by #220; `pr_status` never received the fix.
+    //   * Folding it into the existing view call removes the second subprocess
+    //     entirely, and with it the whole category of "the second query failed
+    //     and nobody noticed".
     const viewCmd = [
       'gh', 'pr', 'view', String(args.number),
-      '--json', 'state,mergeStateStatus,mergeable,url',
+      '--json', 'state,mergeStateStatus,mergeable,url,statusCheckRollup',
     ];
     if (args.repo !== undefined) viewCmd.push('--repo', args.repo);
 
-    const viewResult = runArgv(viewCmd, cwd);
-    if (viewResult.exitCode !== 0) {
-      return {
-        ok: false,
-        code: 'gh_pr_view_failed',
-        error: `gh pr view failed: ${viewResult.stderr.trim() || viewResult.stdout.trim()}`,
-      };
-    }
-
-    const pr = JSON.parse(viewResult.stdout) as {
+    interface PrView {
       state: string;
       mergeStateStatus: string;
       mergeable: string | boolean;
       url: string;
-    };
+      statusCheckRollup?: RollupItem[] | null;
+    }
+
+    // #493: classify the run rather than hand-checking exitCode and leaving
+    // JSON.parse to throw into the generic catch. A failed query and an
+    // unparseable payload are BOTH "we did not learn the state" — they get one
+    // named code, and neither can be mistaken for a successful empty result.
+    const viewOutcome = classifyRun<PrView>(
+      runArgv(viewCmd, cwd),
+      (stdout) => JSON.parse(stdout) as PrView,
+      `PR #${String(args.number)} view`,
+    );
+    if (!viewOutcome.succeeded) {
+      return {
+        ok: false,
+        // Distinct codes: the command failing and the command returning garbage
+        // are different diagnoses, and collapsing them would reintroduce the
+        // distinguishability loss this fix is about (#493).
+        code: viewOutcome.kind === 'parse' ? 'gh_pr_view_unparseable' : 'gh_pr_view_failed',
+        error: describeFailedQuery({
+          what: `PR #${String(args.number)} status`,
+          failure: viewOutcome.failure,
+          argv: viewOutcome.argv,
+        }),
+      };
+    }
+    const pr = viewOutcome.value;
 
     const state = normalizeGithubState(pr.state);
     const merge_state = normalizeGithubMergeState(pr.mergeStateStatus);
@@ -133,29 +169,29 @@ export async function prStatusGithub(
     const mergeable =
       mergeableRaw === true || mergeableRaw === 'MERGEABLE' ? true : false;
 
-    // 2. gh pr checks — non-fatal: a failure here means "no checks configured"
-    //    rather than a hard error. Preserved from the pre-migration handler.
-    let checks: PrStatusChecksAggregate = {
-      total: 0,
-      passed: 0,
-      failed: 0,
-      pending: 0,
-      summary: 'none',
-    };
-    const checksCmd = [
-      'gh', 'pr', 'checks', String(args.number),
-      '--json', 'name,state,conclusion',
-    ];
-    if (args.repo !== undefined) checksCmd.push('--repo', args.repo);
-    const checksResult = runArgv(checksCmd, cwd);
-    if (checksResult.exitCode === 0) {
-      try {
-        const parsed = JSON.parse(checksResult.stdout) as GithubCheck[];
-        checks = aggregateGithubChecks(parsed);
-      } catch {
-        // JSON parse failure — leave checks at the 'none' default.
-      }
+    // 2. Aggregate checks from the rollup we already fetched.
+    //
+    // #491/#493: a MISSING field is NOT an empty result. `gh` always returns a
+    // requested `--json` key, so an absent `statusCheckRollup` means we did not
+    // successfully learn the check state — and reporting that as `summary:
+    // 'none'` is the silent-permissive failure this fix exists to remove.
+    //
+    // We fail the whole call rather than inventing a summary. That is the
+    // fail-CLOSED direction and it matters concretely: `/mmr` stops on an
+    // `{ok:false}` envelope, but treats an unrecognised `checks.summary` as
+    // permission to proceed (it only halts on `has_failures`). Returning a new
+    // summary variant would therefore still merge; returning an error stops.
+    if (pr.statusCheckRollup === undefined || pr.statusCheckRollup === null) {
+      return {
+        ok: false,
+        code: 'gh_status_check_rollup_missing',
+        error:
+          `gh pr view returned no statusCheckRollup field for PR #${String(args.number)}. ` +
+          'Check state is UNKNOWN, not absent — refusing to report it as "no checks". ' +
+          `Command run: ${renderArgv(viewCmd)}`,
+      };
     }
+    const checks: PrStatusChecksAggregate = aggregateRollup(pr.statusCheckRollup);
 
     return {
       ok: true,

--- a/lib/shared/error-norm.ts
+++ b/lib/shared/error-norm.ts
@@ -18,6 +18,20 @@ export interface RunResult {
   exitCode: number;
   stdout: string;
   stderr: string;
+  /**
+   * The argv actually executed (#493).
+   *
+   * Carried so a caller reporting "I found nothing" can derive its
+   * verification suggestion FROM THE QUERY THAT RAN, rather than hand-writing
+   * one that may describe a different query. A hand-written hint can drift from
+   * the real call — `ci_wait_run` shipped one that reproduced its own failing
+   * lookup (#492), so an operator who followed the advice got an empty result
+   * that appeared to confirm a false cause.
+   *
+   * Derived suggestions cannot disagree with the executed query, because they
+   * ARE the executed query.
+   */
+  argv: string[];
 }
 
 export interface ExecError extends Error {
@@ -43,15 +57,19 @@ export function bufToString(b: unknown): string {
  */
 export function runArgv(cmd: string[], cwd: string): RunResult {
   const shellCmd = cmd.map(shellEscape).join(' ');
+  // Copy so a caller mutating its own argv array afterwards cannot retroactively
+  // change what this result claims was executed.
+  const argv = [...cmd];
   try {
     const stdout = execSync(shellCmd, { cwd, encoding: 'utf8' });
-    return { exitCode: 0, stdout, stderr: '' };
+    return { exitCode: 0, stdout, stderr: '', argv };
   } catch (err) {
     const e = err as ExecError;
     return {
       exitCode: typeof e.status === 'number' ? e.status : -1,
       stdout: bufToString(e.stdout),
       stderr: bufToString(e.stderr) || (err instanceof Error ? err.message : String(err)),
+      argv,
     };
   }
 }

--- a/lib/shared/query-outcome.ts
+++ b/lib/shared/query-outcome.ts
@@ -1,0 +1,132 @@
+/**
+ * Query outcomes that cannot silently collapse "found nothing" into "did not
+ * look" (#493).
+ *
+ * ## Why this exists
+ *
+ * Three defects reported in one night shared one shape: a result that could not
+ * distinguish *checked and found nothing* from *did not look*. They form a
+ * ladder, each rung harder to catch than the last:
+ *
+ *   1. **Cannot distinguish** — `pr_status` rendered a failed `gh pr checks`
+ *      invocation as `checks: none` for a PR with four passing checks (#491).
+ *      Catching it requires suspicion.
+ *   2. **Asserts which it was** — `ci_wait_run` named "the pipeline may not have
+ *      been triggered" as the cause of what was only a failed lookup (#492).
+ *      Catching it requires disbelieving a plausible explanation.
+ *   3. **Supplies evidence for the wrong one** — that same message suggested
+ *      `gh run list --branch <ref>` using the ref that had just failed to match,
+ *      so an operator who followed the advice got an empty result that appeared
+ *      to *confirm* the false cause.
+ *
+ * Rung 3 is why this is a module and not a style guide: it is a defect that
+ * survives being checked, because the tool hands you a reproduction that agrees
+ * with its own wrong diagnosis. It does not evade "go verify it yourself" — it
+ * recruits it.
+ *
+ * ## The convention this enforces
+ *
+ * > A not-found result states WHAT WAS QUERIED and WHAT CAME BACK, and nothing
+ * > else. Any hypothesis is SEPARATED AND LABELLED as such. Any suggested
+ * > command MUST REPRODUCE THE QUERY ACTUALLY PERFORMED.
+ *
+ * The third clause is enforced structurally: renderers derive their verification
+ * line from `RunResult.argv` — the argv that actually ran — so a suggestion
+ * cannot describe a different query than the one performed. The empty-result
+ * renderer lands with #492, the issue that consumes it; shipping it here with
+ * no caller would be dead code.
+ *
+ * ## What this does NOT cover
+ *
+ * Twelve adapter files still call `execSync` directly rather than `runArgv`, so
+ * they carry no argv and get neither the derived verification line nor the
+ * type-level discrimination. Migrating them is tracked separately; until then
+ * this mechanism covers the `runArgv` callers only.
+ */
+
+import type { RunResult } from './error-norm.js';
+import { shellEscape } from './shell-escape.js';
+
+/**
+ * The outcome of a lookup, as two DIFFERENT types rather than one value that
+ * happens to be empty.
+ *
+ * `succeeded: false` cannot be read as "zero results" without explicitly
+ * unwrapping it, which is the point: #491 existed because a failed query and an
+ * empty one were the same value.
+ */
+export type QueryOutcome<T> =
+  | { succeeded: true; value: T }
+  | {
+      succeeded: false;
+      /**
+       * WHY it failed, kept distinct because "the command failed" and "the
+       * command succeeded and returned garbage" are different diagnoses.
+       * Collapsing them is the same distinguishability loss this module exists
+       * to prevent — it would just move the collapse one level down.
+       */
+      kind: 'exec' | 'parse';
+      failure: string;
+      argv: string[];
+    };
+
+/**
+ * Classify a `RunResult` into a `QueryOutcome`.
+ *
+ * A non-zero exit is a FAILED QUERY, never an empty one. Callers that want to
+ * report "none" must first prove the query ran, which makes #491's silent
+ * `summary: 'none'` unrepresentable rather than merely discouraged.
+ *
+ * `parse` runs only on success; if it throws (unparseable payload) that is also
+ * a failed query, not an empty one — the other half of how #491 stayed silent.
+ */
+export function classifyRun<T>(
+  result: RunResult,
+  parse: (stdout: string) => T,
+  what: string,
+): QueryOutcome<T> {
+  if (result.exitCode !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim() || '(no output)';
+    return {
+      succeeded: false,
+      kind: 'exec',
+      failure: `${what} query failed (exit ${String(result.exitCode)}): ${detail}`,
+      argv: result.argv,
+    };
+  }
+  try {
+    return { succeeded: true, value: parse(result.stdout) };
+  } catch (err) {
+    return {
+      succeeded: false,
+      kind: 'parse',
+      failure:
+        `${what} query returned unparseable output: ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+      argv: result.argv,
+    };
+  }
+}
+
+/** Render an argv array as a copy-pasteable shell command. */
+export function renderArgv(argv: string[]): string {
+  return argv.map(shellEscape).join(' ');
+}
+
+/**
+ * Describe a lookup that could not be performed.
+ *
+ * Deliberately distinct wording from `describeEmptyResult` so the two are
+ * distinguishable in logs and transcripts, not just in types.
+ */
+export function describeFailedQuery(opts: {
+  what: string;
+  failure: string;
+  argv: string[];
+}): string {
+  return (
+    `Could not determine ${opts.what}: ${opts.failure}. ` +
+    `This is a FAILED QUERY, not an empty result — the state is unknown, not absent. ` +
+    `Command run: ${renderArgv(opts.argv)}`
+  );
+}

--- a/tests/pr_status.test.ts
+++ b/tests/pr_status.test.ts
@@ -70,14 +70,11 @@ describe('pr_status handler', () => {
         mergeStateStatus: 'CLEAN',
         mergeable: 'MERGEABLE',
         url: 'https://github.com/Wave-Engineering/example/pull/42',
+        statusCheckRollup: [
+          { __typename: 'CheckRun', name: 'validate', status: 'COMPLETED', conclusion: 'SUCCESS' },
+          { __typename: 'CheckRun', name: 'lint', status: 'COMPLETED', conclusion: 'SUCCESS' },
+        ],
       }),
-    );
-    register(
-      'gh pr checks 42',
-      JSON.stringify([
-        { name: 'validate', state: 'completed', conclusion: 'success' },
-        { name: 'lint', state: 'completed', conclusion: 'success' },
-      ]),
     );
 
     const result = await prStatusHandler.execute({ number: 42 });
@@ -106,14 +103,11 @@ describe('pr_status handler', () => {
         mergeStateStatus: 'UNSTABLE',
         mergeable: 'MERGEABLE',
         url: 'https://github.com/Wave-Engineering/example/pull/100',
+        statusCheckRollup: [
+          { __typename: 'CheckRun', name: 'validate', status: 'COMPLETED', conclusion: 'SUCCESS' },
+          { __typename: 'CheckRun', name: 'flaky-test', status: 'COMPLETED', conclusion: 'FAILURE' },
+        ],
       }),
-    );
-    register(
-      'gh pr checks 100',
-      JSON.stringify([
-        { name: 'validate', state: 'completed', conclusion: 'success' },
-        { name: 'flaky-test', state: 'completed', conclusion: 'failure' },
-      ]),
     );
 
     const result = await prStatusHandler.execute({ number: 100 });
@@ -137,14 +131,11 @@ describe('pr_status handler', () => {
         mergeStateStatus: 'BLOCKED',
         mergeable: 'UNKNOWN',
         url: 'https://github.com/Wave-Engineering/example/pull/7',
+        statusCheckRollup: [
+          { __typename: 'CheckRun', name: 'validate', status: 'IN_PROGRESS' },
+          { __typename: 'CheckRun', name: 'lint', status: 'COMPLETED', conclusion: 'SUCCESS' },
+        ],
       }),
-    );
-    register(
-      'gh pr checks 7',
-      JSON.stringify([
-        { name: 'validate', state: 'in_progress', conclusion: null },
-        { name: 'lint', state: 'completed', conclusion: 'success' },
-      ]),
     );
 
     const result = await prStatusHandler.execute({ number: 7 });
@@ -167,9 +158,9 @@ describe('pr_status handler', () => {
         mergeStateStatus: '',
         mergeable: 'UNKNOWN',
         url: 'https://github.com/Wave-Engineering/example/pull/11',
+        statusCheckRollup: [],
       }),
     );
-    register('gh pr checks 11', JSON.stringify([]));
 
     const result = await prStatusHandler.execute({ number: 11 });
     const out = parseResult(result.content);
@@ -189,9 +180,9 @@ describe('pr_status handler', () => {
         mergeStateStatus: 'DIRTY',
         mergeable: 'CONFLICTING',
         url: 'https://github.com/Wave-Engineering/example/pull/22',
+        statusCheckRollup: [],
       }),
     );
-    register('gh pr checks 22', JSON.stringify([]));
 
     const result = await prStatusHandler.execute({ number: 22 });
     const out = parseResult(result.content);
@@ -201,7 +192,14 @@ describe('pr_status handler', () => {
     expect(data.mergeable).toBe(false);
   });
 
-  test('github_no_checks_command_failure_treated_as_none', async () => {
+  test('github_missing_rollup_fails_closed (#491)', async () => {
+    // INVERTED from `github_no_checks_command_failure_treated_as_none`, which
+    // asserted the defect as intended behaviour: a checks lookup that did not
+    // happen was reported as `summary: 'none'`, i.e. "this PR has no checks".
+    //
+    // That is the silent-permissive direction. `/mmr` halts on an {ok:false}
+    // envelope but treats an unrecognised checks.summary as permission to
+    // merge, so an error is the only representation that fails CLOSED.
     registerGithubRemote();
     register(
       'gh pr view 99 --json',
@@ -210,18 +208,15 @@ describe('pr_status handler', () => {
         mergeStateStatus: 'CLEAN',
         mergeable: 'MERGEABLE',
         url: 'https://github.com/Wave-Engineering/example/pull/99',
+        // statusCheckRollup deliberately absent — check state is UNKNOWN.
       }),
     );
-    // Intentionally do NOT register gh pr checks — the handler should catch and treat as 'none'
 
     const result = await prStatusHandler.execute({ number: 99 });
     const out = parseResult(result.content);
-    expect(out.ok).toBe(true);
-    const data = out.data as Record<string, unknown>;
-    expect(data.merge_state).toBe('clean');
-    const checks = data.checks as Record<string, unknown>;
-    expect(checks.total).toBe(0);
-    expect(checks.summary).toBe('none');
+    expect(out.ok).toBe(false);
+    expect(out.code).toBe('gh_status_check_rollup_missing');
+    expect(String(out.error)).toContain('UNKNOWN, not absent');
   });
 
   // --- GitLab paths ---
@@ -384,7 +379,7 @@ describe('pr_status handler', () => {
 
   // --- cross-repo routing ---
 
-  test('route_with_repo — github threads --repo into gh pr view and gh pr checks', async () => {
+  test('route_with_repo — github threads --repo into the single gh pr view call', async () => {
     // cwd origin points at a DIFFERENT repo than the target.
     register('git remote get-url origin', 'https://github.com/cwd-org/cwd-repo.git');
     register(
@@ -394,9 +389,9 @@ describe('pr_status handler', () => {
         mergeStateStatus: 'CLEAN',
         mergeable: 'MERGEABLE',
         url: 'https://github.com/Wave-Engineering/mcp-server-sdlc/pull/42',
+        statusCheckRollup: [],
       }),
     );
-    register('gh pr checks 42', JSON.stringify([]));
 
     const result = await prStatusHandler.execute({
       number: 42,
@@ -408,9 +403,6 @@ describe('pr_status handler', () => {
     const viewCall =
       execCalls().find((c) => unquote(c).startsWith('gh pr view 42')) ?? '';
     expect(unquote(viewCall)).toContain('--repo Wave-Engineering/mcp-server-sdlc');
-    const checksCall =
-      execCalls().find((c) => unquote(c).startsWith('gh pr checks 42')) ?? '';
-    expect(unquote(checksCall)).toContain('--repo Wave-Engineering/mcp-server-sdlc');
   });
 
   test('route_with_repo — gitlab forwards owner/repo slug into glab api path', async () => {
@@ -448,18 +440,15 @@ describe('pr_status handler', () => {
         mergeStateStatus: 'CLEAN',
         mergeable: 'MERGEABLE',
         url: 'https://github.com/Wave-Engineering/example/pull/42',
+        statusCheckRollup: [],
       }),
     );
-    register('gh pr checks 42', JSON.stringify([]));
 
     await prStatusHandler.execute({ number: 42 });
 
     const viewCall =
       execCalls().find((c) => unquote(c).startsWith('gh pr view 42')) ?? '';
     expect(unquote(viewCall)).not.toContain('--repo');
-    const checksCall =
-      execCalls().find((c) => unquote(c).startsWith('gh pr checks 42')) ?? '';
-    expect(unquote(checksCall)).not.toContain('--repo');
   });
 
   test('invalid_slug_early_error — returns ok:false with zero exec calls', async () => {


### PR DESCRIPTION
## Summary

`pr_status` reported **`checks: none` for PRs with passing checks** — on every GitHub PR, permanently, on this fleet. Found by @treebeard, who saw `pr_wait_ci` report `4/4 passed` and `pr_status` report `none` for the same PR seconds apart, and refused to trust either without independently verifying.

This is not a cosmetic inconsistency. A tool that reports `none` for four passing checks will report `none` for zero, and a caller cannot tell the difference — the silent-permissive direction.

## Root cause (two halves)

1. The adapter ran `gh pr checks --json`, a flag that **does not exist on gh 2.45** — the version Ubuntu 24.04 LTS ships. Measured:
   ```
   $ gh pr checks 4 --json name,state,conclusion --repo Wave-Engineering/mcp-logger
   unknown flag: --json          exit 1 · stdout 0 bytes
   ```
2. The result was only read on `exitCode === 0`, so that failure left `checks` at its `summary: 'none'` initialiser — and returned `ok: true`.

The comment above it stated the faulty premise in plain text: *"a failure here means 'no checks configured' rather than a hard error."* A non-zero exit means the **query failed**; it does not mean there are no checks.

**Why it mattered more than a wrong field:** `/mmr` halts on `has_failures` and waits on `pending`. `none` matches neither and falls through to merge — and `pr_wait_ci` is only invoked *when the summary is `pending`*, a condition unreachable when the query always collapses to `none`.

## Changes

Two commits, kept separate so #492's dependency on the shared mechanism stays legible.

**`33cd404` — `feat(shared)`: carry argv on `RunResult`; classify query outcomes (#493)**
Verified green standalone before the fix was committed on top.
- `RunResult` now carries the argv that produced it, so a verification suggestion is **derived from the executed query** and cannot describe a different one.
- `classifyRun` splits succeeded/failed with a `kind` discriminator separating "the command failed" from "the command returned garbage".
- Documented limit: covers `runArgv` callers only — 12 adapter files still call `execSync` directly and are a named, not discovered, gap.

**`dbda8b9` — `fix(pr_status)`: read checks from `statusCheckRollup`; fail closed on unknown**
- Request `statusCheckRollup` on the **existing** `gh pr view` call — one subprocess instead of two, removing the whole category of "the second query failed and nobody noticed".
- Reuse `classifyRollupItem` from `pr-wait-ci-github` rather than adding a second classifier, so the two tools cannot disagree about a check's meaning again.
- **Fail closed:** a missing/null rollup returns `{ok:false, code:'gh_status_check_rollup_missing'}` rather than inventing a summary. Deliberate — `/mmr` stops on an error envelope but treats an unrecognised `checks.summary` as permission to proceed, so a new summary variant would still merge while an error stops.
- Surface the adapter's `code` through the handler (`/mmr` documents a `{ok:false, code, error}` envelope; the handler was dropping `code`).
- Remove the now-dead `aggregateGithubChecks`.

**Docs — the most consequential part of this PR.** `docs/handlers/origin-operations-guide.md`, the canonical guide `handlers/pr_status.ts` points implementers at, **still documented `gh pr checks --json` as the design**. `pr_wait_ci` earned a do-not-use warning in `docs/tools.md` after #220; `pr_status` never did. That is precisely how this defect propagated: **the class survived in documentation while the instance was fixed in code.** Guide corrected, warning added, fail-closed code documented.

**Two tests asserted the defect as intended behaviour** — `github_no_checks_command_failure_treated_as_none` and `gh pr checks failure is treated as no checks (summary none)` — which is why any correct fix "broke tests". Both inverted.

## Test Plan

Run, not aspirational:

- `./scripts/ci/validate.sh` — green: codegen, lint, gate-greps, shellcheck, **2402 unit + 48 flightdeck + 20 integration, 0 fail**, 78/78 runtime smoke.
- `trivy fs --scanners vuln --severity HIGH,CRITICAL` — 0 findings.
- Code review (opus): 5 findings fixed, 1 deferred to #494.

**Live validation — paired experiment**, against @treebeard's actual repro (`Wave-Engineering/mcp-logger#4`). A successful read alone proves nothing, so the bug was first shown reproducing on the same fixture:

```
negative control : gh pr checks --json  ->  exit 1     (what main renders as summary 'none')
this branch      : total 4, passed 4, failed 0, pending 0, summary 'all_passed'
```

Matching the 4/4 @treebeard independently confirmed via `gh pr checks` / `gh run list`.

**Not covered by that run:** the fail-closed paths (`gh_status_check_rollup_missing`, `gh_pr_view_unparseable`) are unit-tested only — the green above does not cover them.

## Linked Issues

Closes #491
Refs #493

## Related

- **#494** — the GitLab half returns `no_pipeline_data` with `ok:true`, the same silent-permissive shape. Pre-existing; deliberately filed rather than absorbed here.
- **#220** — migrated `pr_wait_ci` off the same flag. Its guard was scoped to that one caller, which is why `pr_status` kept the defect.
- The `/mmr` default-allow branch structure (unrecognised summary → proceed) is the reason the failure *direction* matters. That is cc-workflow's and tracked separately; this fix makes `pr_status` truthful but does not change how `/mmr` treats an unfamiliar value.

Credit: @treebeard, for refusing a green she had not verified and then refusing the contradicting `none` either.
