### PR TITLE
chore(release): bump package.json to 2.1.1 to match the released tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server-sdlc",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "SDLC workflow MCP server for Claude Code agents",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

`package.json` on `main` said `2.1.0` while the latest release tag is **`v2.1.1`**. House style bumps it as part of the release cut (#485 moved it `1.0.0 → 2.1.0` for v2.1.0); the v2.1.1 cut tagged without it.

## Why this is cosmetic — stated, so the low severity isn't mistaken for the field being unused

The binary does **not** read `package.json`. `index.ts:16-18` derives `SERVER_VERSION` from `__BUILD_REF__`, injected at compile time from `git describe --tags`:

```
git describe --tags 8a0efb1  ->  v2.1.1
SERVER_VERSION               ->  2.1.1
```

So the shipped v2.1.1 binary already self-reports correctly, and **post-install verification of the fleet hotfix is reliable**. That is only true because #459 moved the authoritative version off `package.json` and onto the build ref — before that fix, this same omission would have made the release unverifiable, since the binary would have claimed `1.0.0` regardless.

Two places state a version; exactly one is load-bearing. This aligns the other one.

## Changes

- `package.json`: `"version": "2.1.0"` → `"2.1.1"`. One line.

**Deliberately unchanged:**
- `CHANGELOG.md:10,21` / `README.md:89` — historical references (*"retired as of v2.1.0"*, *"pre-v2.1.0 hand-written history"*). Correct as written; rewriting them would falsify the record.
- `index.ts:11` — an illustrative `(e.g. "2.1.0")` in the comment explaining the injection mechanism. Not a version source.

## Test Plan

- `./scripts/ci/validate.sh` — green: **2416 unit + 48 flightdeck + 21 integration, 0 fail**, 78/78 runtime smoke.
- Test counts are **identical to pre-change**, which is the expected result for a metadata edit: nothing reads this field at runtime (verified by grep), so any movement would itself have been the finding.

## Process

**Precheck skipped on BJ's explicit authority**, given during the fleet hotfix window. Recorded here for the audit trail rather than left implicit.

Tagging is @babelfish's; this covers the in-repo version file only.

## Linked Issues

Closes #498
