### PR TITLE
chore: bump package.json version to 2.1.2 for v2.1.2 tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server-sdlc",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "SDLC workflow MCP server for Claude Code agents",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
Mechanical version bump so `main` at head can be tagged `v2.1.2`.

## Changes
- `package.json`: `"version": "2.1.1"` → `"version": "2.1.2"`. No other file
  changed — `index.ts`'s `SERVER_VERSION` is derived at build time from
  `_build.ref` (via `scripts/ci/build.sh`), confirmed by reading the source,
  not assumed.

## Linked Issues
Closes #500

## Test Plan
Ran `./scripts/ci/validate.sh` locally (codegen, tsc lint, gate-greps,
shellcheck, unit tests, isolated flightdeck suite, integration tests, runtime
smoke) — full pipeline, exit 0:
- unit: 2416 pass / 0 fail across 164 files
- flightdeck emit suite: 48 pass / 0 fail across 1 file
- integration: 21 pass / 0 fail across 2 files
- gate-greps: OK (78 handlers)
- shellcheck: 6 file(s) OK
- smoke: tools/list returned 78 tools, 78/78 per-tool assertions passed

`grep -rn "2\.1\.1"` across the repo (excluding `.git`, `node_modules`) shows
only `finalhandler@2.1.1` in `bun.lock` (unrelated npm dependency) — no other
literal referencing this package's own version.
