### PR TITLE
chore(wave): parameterize the kahuna branch name, drop trunk-defaulting target_branch

### DIFF
--- a/handlers/wave_finalize.ts
+++ b/handlers/wave_finalize.ts
@@ -1,10 +1,19 @@
 // KAHUNA epic-final gate: opens (or returns) the kahuna → target_branch MR.
-// Idempotent on (kahuna_branch, target_branch). `target_branch` defaults to the
-// repo's LIVE default branch (resolved via the adapter) when the caller omits
-// it — never a hardcoded 'main' (#472). Platform-agnostic dispatcher —
-// `findExistingPr` + `prCreate` + `resolveDefaultBranch` go through
-// `getAdapter()`; body composition and SHA hashing live in `lib/wave-finalize.ts`.
-// Story 2.23 (#317).
+// Idempotent on (kahuna_branch, target_branch). Platform-agnostic dispatcher —
+// `findExistingPr` + `prCreate` go through `getAdapter()`; body composition and
+// SHA hashing live in `lib/wave-finalize.ts`. Story 2.23 (#317).
+//
+// `target_branch` is REQUIRED — no default of any kind (#503). It was a static
+// `.default('main')`, then (#472/#473) the repo's live default branch resolved
+// via the adapter. Both are wrong for the same reason: the default's *value* is
+// "the protected branch", and this handler's job is to open a MERGE TARGET.
+// Post-claudecode-workflow#1052 a campaign integrates each wave onto the campaign
+// branch and writes the protected branch exactly once, at the DoD gate — so a wave
+// that reaches this handler with `target_branch` omitted must fail loudly, not
+// silently promote to trunk. There is no safe guess for which branch a wave
+// integrates onto; only the caller knows whether it is mid-campaign or at the DoD.
+// (#472's own hazard — a repo whose default is e.g. release/1.0.0 — is unaffected:
+// a caller that wants the default branch resolves it and passes it.)
 
 import { z } from 'zod';
 import type { HandlerDef } from '../types.js';
@@ -20,9 +29,9 @@ const inputSchema = z.object({
   root: z.string().optional(),
   plan_id: z.number().int().positive(),
   kahuna_branch: z.string().min(1),
-  // Optional: an explicit target wins; when omitted the handler resolves the
-  // repo's LIVE default branch (never hardcode 'main' — #472).
-  target_branch: z.string().min(1).optional(),
+  // REQUIRED — no default (#503). A default here means "merge to the protected
+  // branch", which is exactly the early-trunk-write #1052 removed.
+  target_branch: z.string().min(1),
   body_artifacts_dir: z.string().optional(),
 });
 
@@ -35,7 +44,9 @@ const waveFinalizeHandler: HandlerDef = {
   name: 'wave_finalize',
   description:
     'Open (or return the existing) kahuna→target_branch MR for a KAHUNA epic. ' +
-    'Idempotent on (kahuna_branch, target_branch). `target_branch` defaults to the repo\'s live default branch when omitted. ' +
+    'Idempotent on (kahuna_branch, target_branch). `target_branch` is REQUIRED and has no default (#503) — ' +
+    'inside a campaign a wave integrates onto the campaign branch, and the protected branch is written once at the DoD gate; ' +
+    'a caller that wants the repo default must resolve it and pass it explicitly. ' +
     'The MR body is assembled from wavebus artifacts under `body_artifacts_dir` (default: /tmp/wavemachine/<slug>/); ' +
     'when those are absent (e.g. wave_complete cleanup wiped them on the last wave), the handler falls back to durable wave-status state ' +
     '(`<project>/.claude/status/{phases-waves.json,state.json}`) to re-derive the body from plan + recorded mr_urls. ' +
@@ -51,19 +62,9 @@ const waveFinalizeHandler: HandlerDef = {
       const resolved = resolveArtifactsDir(args.body_artifacts_dir, defaultArtifactsDir(args.kahuna_branch), cwd);
       if (!resolved.ok) return envelope({ ok: false, error: resolved.error });
       const adapter = getAdapter();
-      // target_branch: an explicit caller value wins; otherwise resolve the LIVE
-      // default branch from the host (never hardcode 'main' — a repo whose
-      // default is e.g. release/1.0.0 must finalize to release/1.0.0, not main).
-      const explicitTarget = args.target_branch;
-      let targetBranch: string;
-      if (explicitTarget !== undefined) {
-        targetBranch = explicitTarget;
-      } else {
-        const defRes = await adapter.resolveDefaultBranch({ cwd });
-        if ('platform_unsupported' in defRes) return envelope({ ok: false, error: `default-branch resolution unsupported: ${defRes.hint}` });
-        if (!defRes.ok) return envelope({ ok: false, error: defRes.error });
-        targetBranch = defRes.data.default_branch;
-      }
+      // target_branch is schema-required (#503) — nothing to resolve, nothing to
+      // guess. The zod parse above rejected an omitted or empty value.
+      const targetBranch = args.target_branch;
       // Try the bus first; fall back to durable wave-status state when the
       // bus has been cleaned up (#415). assembleBodyFromState consults
       // `<project>/.claude/status/{phases-waves.json,state.json}`.

--- a/handlers/wave_init.ts
+++ b/handlers/wave_init.ts
@@ -48,6 +48,12 @@ const inputSchema = z.object({
   kahuna: z.object({
     plan_id: z.number().int().positive(),
     slug: z.string().min(1).regex(/^[a-z0-9][a-z0-9-]*$/, 'slug must be kebab-case (lowercase, digits, hyphens)'),
+    // #503: the integration branch name, supplied by the caller. Omit it and the
+    // historical `kahuna/<plan_id>-<slug>` is derived — correct for a standalone
+    // single-wave run, wrong for a campaign, where the branch must be per-WAVE and
+    // cut from the campaign branch rather than per-plan and cut from trunk. Only the
+    // caller knows which of those it is running, so only the caller can name it.
+    branch: z.string().min(1).optional(),
   }).strict().optional(),
 });
 
@@ -70,8 +76,11 @@ const waveInitHandler: HandlerDef = {
   name: 'wave_init',
   description:
     'Initialize a wave plan from structured JSON; supports --extend mode. ' +
-    'Optional `kahuna` argument bootstraps a `kahuna/<plan_id>-<slug>` branch ' +
-    'off the plan\'s base_branch (default: the repo\'s live default branch) and records it in wave state. ' +
+    'Optional `kahuna` argument bootstraps an integration branch off the plan\'s base_branch ' +
+    '(default: the repo\'s live default branch) and records it in wave state. ' +
+    'The branch is `kahuna.branch` verbatim when supplied, else the derived `kahuna/<plan_id>-<slug>`; ' +
+    'pass it explicitly for a campaign, where the branch must be per-wave and cut from the ' +
+    'campaign branch rather than per-plan and cut from trunk (#503). ' +
     'Atomic across kahuna bootstrap + plan persist (#378): kahuna failure does ' +
     'not persist the plan; plan-persist failure leaves the branch claimable on retry.',
   inputSchema,
@@ -97,20 +106,43 @@ const waveInitHandler: HandlerDef = {
       if (args.kahuna !== undefined) {
         const slug = args.repo ?? parseRepoSlug() ?? undefined;
         const adapter = getAdapter({ repo: slug });
-        // Base branch: the plan's explicit base_branch wins; otherwise resolve
-        // the LIVE default branch from the host (never hardcode 'main' — a repo
-        // whose default is e.g. release/1.0.0 would otherwise cut the kahuna
-        // branch from the wrong place). Mirrors how pr_create defaults its base.
-        let baseBranch: string;
-        if (typeof plan.base_branch === 'string' && plan.base_branch.length > 0) {
-          baseBranch = plan.base_branch;
-        } else {
+        const resolveDefault = async (): Promise<{ ok: true; branch: string } | { ok: false; error: string }> => {
           const defRes = await adapter.resolveDefaultBranch({ repo: slug, cwd });
           if ('platform_unsupported' in defRes) {
-            return envelope({ ok: false, error: `default-branch resolution unsupported: ${defRes.hint}` });
+            return { ok: false, error: `default-branch resolution unsupported: ${defRes.hint}` };
           }
+          if (!defRes.ok) return { ok: false, error: defRes.error };
+          return { ok: true, branch: defRes.data.default_branch };
+        };
+        // Base branch: the plan's explicit base_branch wins; otherwise resolve the
+        // LIVE default branch from the host (never hardcode 'main' — a repo whose
+        // default is e.g. release/1.0.0 would otherwise cut the kahuna branch from
+        // the wrong place). Mirrors how pr_create defaults its base.
+        //
+        // `defaultBranch` is tracked SEPARATELY from `baseBranch` because the two
+        // diverge exactly when it matters: an explicit base means the protected
+        // branch is some other ref, and that other ref is the one an integration
+        // branch must never be (#503).
+        let baseBranch: string;
+        let defaultBranch: string | undefined;
+        if (typeof plan.base_branch === 'string' && plan.base_branch.length > 0) {
+          baseBranch = plan.base_branch;
+          // The base is explicit, so the default branch is a DIFFERENT ref and the
+          // bootstrap's "never equal to the protected branch" guard needs it. Only
+          // worth the extra host call when the caller named the branch: a derived
+          // `kahuna/<id>-<slug>` cannot collide with a plausible default (#503).
+          if (args.kahuna.branch !== undefined) {
+            const defRes = await resolveDefault();
+            // Fail loud rather than proceed with the guard disabled — a bootstrap that
+            // silently skips its trunk check is the failure mode this guard exists for.
+            if (!defRes.ok) return envelope({ ok: false, error: defRes.error });
+            defaultBranch = defRes.branch;
+          }
+        } else {
+          const defRes = await resolveDefault();
           if (!defRes.ok) return envelope({ ok: false, error: defRes.error });
-          baseBranch = defRes.data.default_branch;
+          baseBranch = defRes.branch;
+          defaultBranch = defRes.branch; // same ref — the guard's base check covers it
         }
         const statePath = join(await statusDir(cwd), 'state.json');
         const remote = await bootstrapKahunaBranchRemote(cwd, args.kahuna, baseBranch,
@@ -118,7 +150,8 @@ const waveInitHandler: HandlerDef = {
           {
             adapter, slug,
             branchPresentOnRemote: (b) => branchExistsOnRemote(cwd, b),
-          });
+          },
+          defaultBranch);
         if (!remote.ok) return envelope({ ok: false, error: remote.error });
         kahunaBranch = remote.kahuna_branch;
         kahunaCreated = remote.created;

--- a/lib/wave-finalize.ts
+++ b/lib/wave-finalize.ts
@@ -76,9 +76,20 @@ export function resolveArtifactsDir(
   };
 }
 
-/** Extract the free-text slug suffix from `kahuna/<plan_id>-<slug>`. */
+/**
+ * Extract the free-text slug suffix from `<prefix>/<id>-<slug>`.
+ *
+ * The prefix used to be pinned to `kahuna` (#503). Post-claudecode-workflow#1052
+ * an integration branch can also be a `campaign/<planId>-<slug>`, and a caller may
+ * supply any name via `wave_init`'s `kahuna.branch` — against which the pinned
+ * pattern returned `''` and silently degraded the MR title to
+ * `plan(#56):  — kahuna to …`. Any single-segment prefix is accepted now; the
+ * only structural requirement is the `<digits>-` that separates the id from the
+ * slug. Still `''` for a branch with no slug segment — the caller renders that as
+ * an empty slug rather than inventing one.
+ */
 export function epicSlugFromBranch(kahunaBranch: string): string {
-  const m = /^kahuna\/\d+-(.+)$/.exec(kahunaBranch);
+  const m = /^[^/]+\/\d+-(.+)$/.exec(kahunaBranch);
   return m !== null ? m[1] : '';
 }
 

--- a/lib/wave_init_plan.test.ts
+++ b/lib/wave_init_plan.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { normalizePlanJson } from './wave_init_plan.ts';
+import { bootstrapKahunaBranchRemote, kahunaBranchName, normalizePlanJson } from './wave_init_plan.ts';
 
 describe('normalizePlanJson', () => {
   test('transforms devspec-upshift shape to wave-status shape', () => {
@@ -108,5 +108,135 @@ describe('normalizePlanJson', () => {
     const result = JSON.parse(normalizePlanJson(upshift));
     expect(result.phases[0].waves[0].issues[1].repo).toBe('org/other-repo');
     expect(result.phases[0].waves[0].issues[1].ref).toBe('org/other-repo#19');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #503 — the integration branch name comes from the CALLER
+// ---------------------------------------------------------------------------
+// The bootstrap takes all of its platform contact through injected deps, so these
+// exercise the real function with no exec mocking. The load-bearing assertion in
+// every "rejected" case is `created: []` — that the branch was never CUT, not
+// merely that an error came back.
+
+const SHA = 'a'.repeat(40);
+
+/** A deps double that records every branch it was asked to create. */
+function fakeDeps(opts: { onRemote?: string[] } = {}) {
+  const created: string[] = [];
+  const onRemote = new Set(opts.onRemote ?? []);
+  return {
+    created,
+    deps: {
+      slug: 'o/r',
+      branchPresentOnRemote: (b: string) => onRemote.has(b),
+      adapter: {
+        resolveBranchSha: async () => ({ ok: true as const, data: { sha: SHA } }),
+        createBranch: async ({ branch }: { branch: string }) => {
+          created.push(branch);
+          onRemote.add(branch);
+          return { ok: true as const, data: {} };
+        },
+      },
+    } as unknown as Parameters<typeof bootstrapKahunaBranchRemote>[4],
+  };
+}
+
+const noState = async () => ({ kahuna_branch: null });
+
+describe('kahunaBranchName (#503)', () => {
+  test('derives the historical name when no branch is supplied', () => {
+    const r = kahunaBranchName({ plan_id: 56, slug: 'blueshift' });
+    expect(r).toEqual({ ok: true, branch: 'kahuna/56-blueshift' });
+  });
+
+  test('returns an explicit branch verbatim — no re-derivation, no normalization', () => {
+    const r = kahunaBranchName({ plan_id: 56, slug: 'blueshift', branch: 'kahuna/56-W-2' });
+    expect(r).toEqual({ ok: true, branch: 'kahuna/56-W-2' });
+  });
+
+  test.each([
+    ['ends with .lock', 'kahuna/56-w.lock'],
+    ['has a leading dash', '-kahuna/56-w'],
+    ['is fully qualified', 'refs/heads/kahuna/56-w'],
+    ['contains ..', 'kahuna/56../w'],
+    ['contains a space', 'kahuna/56 w'],
+    ['has an empty path component', 'kahuna//56-w'],
+    ['contains a glob char', 'kahuna/56-w*'],
+    ['contains @{', 'kahuna/56-w@{1}'],
+  ])('rejects a branch that %s', (_why, branch) => {
+    const r = kahunaBranchName({ plan_id: 56, slug: 'blueshift', branch });
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toContain('not a valid git ref');
+  });
+});
+
+describe('bootstrapKahunaBranchRemote branch naming (#503)', () => {
+  test('an explicit branch is the ref created — the derived name is not', async () => {
+    const { created, deps } = fakeDeps();
+    const r = await bootstrapKahunaBranchRemote(
+      '/tmp', { plan_id: 56, slug: 'blueshift', branch: 'kahuna/56-W-2' },
+      'campaign/56-blueshift', noState, deps, 'main',
+    );
+    expect(r).toMatchObject({ ok: true, kahuna_branch: 'kahuna/56-W-2', created: true });
+    expect(created).toEqual(['kahuna/56-W-2']);
+    expect(created).not.toContain('kahuna/56-blueshift');
+  });
+
+  test('omitting branch keeps the derived kahuna/<plan_id>-<slug>', async () => {
+    const { created, deps } = fakeDeps();
+    const r = await bootstrapKahunaBranchRemote(
+      '/tmp', { plan_id: 56, slug: 'blueshift' }, 'main', noState, deps, 'main',
+    );
+    expect(r).toMatchObject({ ok: true, kahuna_branch: 'kahuna/56-blueshift', created: true });
+    expect(created).toEqual(['kahuna/56-blueshift']);
+  });
+
+  test('a branch equal to the BASE is rejected and never created', async () => {
+    const { created, deps } = fakeDeps();
+    const r = await bootstrapKahunaBranchRemote(
+      '/tmp', { plan_id: 56, slug: 'blueshift', branch: 'campaign/56-blueshift' },
+      'campaign/56-blueshift', noState, deps, 'main',
+    );
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toContain('same ref as the base branch');
+    expect(created).toEqual([]);
+  });
+
+  // The dangerous one: trunk already EXISTS on the remote, so without this guard
+  // the reuse path claims the protected branch itself as the integration branch and
+  // every flight merges straight to it (claudecode-workflow#1052).
+  test('a branch equal to the REPO DEFAULT is rejected even though the base differs', async () => {
+    const { created, deps } = fakeDeps({ onRemote: ['main'] });
+    const r = await bootstrapKahunaBranchRemote(
+      '/tmp', { plan_id: 56, slug: 'blueshift', branch: 'main' },
+      'campaign/56-blueshift', noState, deps, 'main',
+    );
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toContain('same ref as the repo default branch');
+    expect(created).toEqual([]);
+  });
+
+  test('an invalid ref is rejected before any platform call', async () => {
+    const { created, deps } = fakeDeps();
+    const r = await bootstrapKahunaBranchRemote(
+      '/tmp', { plan_id: 56, slug: 'blueshift', branch: 'kahuna/56 W2' },
+      'campaign/56-blueshift', noState, deps, 'main',
+    );
+    expect(r.ok).toBe(false);
+    expect((r as { error: string }).error).toContain('not a valid git ref');
+    expect(created).toEqual([]);
+  });
+
+  // Per-wave branches accumulate across a campaign: the wave-2 bootstrap must reuse
+  // its own branch when a retry finds it, not error as a cross-plan orphan.
+  test('an existing explicit branch is claimed as reuse, not re-cut', async () => {
+    const { created, deps } = fakeDeps({ onRemote: ['kahuna/56-W-2'] });
+    const r = await bootstrapKahunaBranchRemote(
+      '/tmp', { plan_id: 56, slug: 'blueshift', branch: 'kahuna/56-W-2' },
+      'campaign/56-blueshift', noState, deps, 'main',
+    );
+    expect(r).toMatchObject({ ok: true, kahuna_branch: 'kahuna/56-W-2', created: false, previously_recorded: false });
+    expect(created).toEqual([]);
   });
 });

--- a/lib/wave_init_plan.ts
+++ b/lib/wave_init_plan.ts
@@ -271,6 +271,66 @@ export interface KahunaBootstrapDeps extends KahunaBootstrapRemoteDeps {
 }
 
 /**
+ * Resolve the integration branch name to create (#503).
+ *
+ * The name used to be derived here unconditionally as `kahuna/<plan_id>-<slug>`,
+ * which encodes two assumptions that hold for a standalone wave and fail for a
+ * campaign: the branch is per-PLAN (so it is shared by every wave of that plan,
+ * and the per-wave promote that deletes it destroys the next wave's base), and
+ * it is cut from the plan's base (so a later wave forks a baseline missing the
+ * earlier waves' integrated work). A campaign needs one branch PER WAVE, cut
+ * from the campaign branch — a name only the caller can know.
+ *
+ * So: an explicit `branch` wins verbatim; absent one, the historical derived name
+ * is kept, because it is still correct for the standalone single-wave case and
+ * existing callers depend on it.
+ *
+ * Two limits worth knowing before you rely on this:
+ *
+ * 1. The guard below forbids the integration branch from BEING the base or the repo
+ *    default; it cannot check what the branch is cut FROM. A caller that names a
+ *    per-wave branch but omits `plan.base_branch` gets a wave branch forked from
+ *    trunk — legal here, wrong for a campaign. Naming the branch and setting the
+ *    base are one decision; make them together.
+ * 2. As of #503 the live wave engine still cuts the per-wave branch client-side
+ *    (claudecode-workflow `skills/nextwave/per-wave-workflow.js`) and carries its own
+ *    copy of these inequality assertions, so this path is exercised by tests rather
+ *    than by the campaign hot path. Two implementations of one invariant drift —
+ *    when the engine moves to the server-side bootstrap, delete its copy.
+ */
+export function kahunaBranchName(
+  kahuna: { plan_id: number; slug: string; branch?: string },
+): { ok: true; branch: string } | KahunaBootstrapError {
+  if (kahuna.branch === undefined) {
+    return { ok: true, branch: `kahuna/${kahuna.plan_id}-${kahuna.slug}` };
+  }
+  const branch = kahuna.branch;
+  // Validate before handing it to `git`/the platform API. An invalid ref fails at
+  // create time with a platform-specific message that reads like an auth or
+  // network fault; naming the actual problem here is the difference between a
+  // one-line fix and a triage session. Rules per git-check-ref-format(1), plus a
+  // leading-`-` guard (argv injection) and a `refs/` guard (double-qualification).
+  const invalid =
+    branch.trim() !== branch ? 'has leading or trailing whitespace'
+    : /\s/.test(branch) ? 'contains whitespace'
+    : branch.startsWith('/') || branch.endsWith('/') ? 'starts or ends with "/"'
+    : branch.includes('//') ? 'contains an empty path component ("//")'
+    : branch.startsWith('-') ? 'starts with "-" (would be read as a command-line flag)'
+    : branch.startsWith('refs/') ? 'is fully qualified — pass a branch name, not a refs/ path'
+    : branch.endsWith('.') || branch.endsWith('.lock') ? 'ends with "." or ".lock"'
+    : branch.includes('..') ? 'contains ".."'
+    : branch.includes('@{') ? 'contains "@{"'
+    : /[~^:?*[\\]/.test(branch) ? 'contains one of ~ ^ : ? * [ \\'
+    // eslint-disable-next-line no-control-regex
+    : /[\x00-\x1f\x7f]/.test(branch) ? 'contains a control character'
+    : null;
+  if (invalid !== null) {
+    return { ok: false, error: `kahuna branch '${branch}' is not a valid git ref: it ${invalid}` };
+  }
+  return { ok: true, branch };
+}
+
+/**
  * Phase 1 of #378's atomic kahuna bootstrap: pre-check state + create the
  * branch on remote, but do NOT write to state.json. Safe to call BEFORE
  * `wave-status init` (state.json may not yet exist).
@@ -281,13 +341,35 @@ export interface KahunaBootstrapDeps extends KahunaBootstrapRemoteDeps {
  */
 export async function bootstrapKahunaBranchRemote(
   cwd: string,
-  kahuna: { plan_id: number; slug: string },
+  kahuna: { plan_id: number; slug: string; branch?: string },
   baseBranch: string,
   readState: () => Promise<{ kahuna_branch?: string | null }>,
   deps: KahunaBootstrapRemoteDeps,
+  /** The repo's live default branch, when the caller knows it. A DISTINCT ref from
+   *  `baseBranch` whenever the plan sets an explicit base (a campaign branch), and
+   *  the one ref an integration branch must never be — see the guard below (#503). */
+  defaultBranch?: string,
 ): Promise<KahunaBootstrapResult | KahunaBootstrapError> {
   void cwd;
-  const desired = `kahuna/${kahuna.plan_id}-${kahuna.slug}`;
+  const named = kahunaBranchName(kahuna);
+  if (!named.ok) return named;
+  const desired = named.branch;
+  // A branch that IS the base is not an integration branch — flights would merge
+  // straight into the ref the gate diffs them against, and the gate's own diff would
+  // be empty by the time it looked. And a branch that is the PROTECTED default is
+  // worse: it exists already, so the reuse path below would claim trunk itself as
+  // the integration branch and every flight would merge straight to it — the exact
+  // early-trunk-write claudecode-workflow#1052 removed. Reject both (#503).
+  for (const [role, ref] of [['base branch', baseBranch], ['repo default branch', defaultBranch]] as const) {
+    if (ref !== undefined && desired === ref) {
+      return {
+        ok: false,
+        error:
+          `kahuna branch '${desired}' is the same ref as the ${role} — a wave integrates onto its ` +
+          `own branch and is diffed AGAINST the base; the two cannot be equal`,
+      };
+    }
+  }
   const state = await readState();
   const recorded = state.kahuna_branch ?? null;
 
@@ -310,13 +392,20 @@ export async function bootstrapKahunaBranchRemote(
   // recorded === null: state unset. Check the remote for an existing branch
   // matching `desired`.
   //
-  // #378: if the remote has the EXACT desired branch (`kahuna/<plan_id>-<slug>`),
-  // claim it as idempotent reuse rather than refusing as an orphan. The branch
-  // name is fully determined by request inputs; a true "orphan from a different
-  // plan" is impossible because plan_id is the unique tracking-issue number for
-  // the master plan, and (plan_id, slug) is a deterministic mapping. This makes
-  // wave_init retry-safe after a phase-2 (`wave-status init`) failure that left
-  // the branch on remote but no state.json.
+  // #378: if the remote has the EXACT desired branch, claim it as idempotent reuse
+  // rather than refusing as an orphan. The branch name is fully determined by
+  // request inputs; for the derived name a true "orphan from a different plan" is
+  // impossible because plan_id is the unique tracking-issue number for the master
+  // plan, and (plan_id, slug) is a deterministic mapping. This makes wave_init
+  // retry-safe after a phase-2 (`wave-status init`) failure that left the branch on
+  // remote but no state.json.
+  //
+  // #503: with a caller-supplied `branch` that uniqueness argument is the CALLER's
+  // to make — this reuses whatever it finds under that name. That is the right
+  // behavior (an existing integration branch carries work already merged into it,
+  // so re-cutting would discard it), but it means a caller who reuses one name
+  // across two campaigns gets their commits interleaved on one branch. Callers must
+  // namespace the name; the engine does so as `kahuna/<planId>-<waveId>`.
   if (deps.branchPresentOnRemote(desired)) {
     return { ok: true, kahuna_branch: desired, created: false, previously_recorded: false };
   }
@@ -372,12 +461,13 @@ export function recordKahunaBranchInState(
  */
 export async function bootstrapKahunaBranch(
   cwd: string,
-  kahuna: { plan_id: number; slug: string },
+  kahuna: { plan_id: number; slug: string; branch?: string },
   baseBranch: string,
   readState: () => Promise<{ kahuna_branch?: string | null }>,
   deps: KahunaBootstrapDeps,
+  defaultBranch?: string,
 ): Promise<KahunaBootstrapResult | KahunaBootstrapError> {
-  const remote = await bootstrapKahunaBranchRemote(cwd, kahuna, baseBranch, readState, deps);
+  const remote = await bootstrapKahunaBranchRemote(cwd, kahuna, baseBranch, readState, deps, defaultBranch);
   if (!remote.ok) return remote;
   if (!remote.previously_recorded) {
     const recorded = recordKahunaBranchInState(remote.kahuna_branch, deps.recordKahunaBranch);

--- a/tests/flightdeck-emit.suite.ts
+++ b/tests/flightdeck-emit.suite.ts
@@ -825,6 +825,7 @@ describe('handler_emit (wired handlers → emit)', () => {
       const res = await waveFinalize.execute({
         plan_id: 42,
         kahuna_branch: headRef,
+        target_branch: 'main',
         body_artifacts_dir: artRoot,
         root: dir,
       });

--- a/tests/wave_finalize.plan_id.test.ts
+++ b/tests/wave_finalize.plan_id.test.ts
@@ -47,9 +47,8 @@ beforeEach(() => {
   resetExecMock();
   tmpRoot = makeTmpRoot();
   onExec('git remote get-url origin', () => 'git@github.com:o/r.git');
-  // #472: target_branch resolves to the live default when omitted. Stub the
-  // GitHub default-branch lookup to 'main' so title/base assertions still hold.
-  onExec('defaultBranchRef', 'main');
+  // No default-branch stub — `target_branch` is required as of #503, so the
+  // handler never resolves a default. See tests/wave_finalize.test.ts.
 });
 
 afterEach(() => {
@@ -67,6 +66,7 @@ describe('wave_finalize plan_id title pattern', () => {
     const result = await handler.execute({
       plan_id: 77,
       kahuna_branch: 'kahuna/77-docmancer-portal',
+      target_branch: 'main',
       body_artifacts_dir: tmpRoot,
     });
     const data = parseResult(result);
@@ -106,6 +106,7 @@ describe('wave_finalize plan_id title pattern', () => {
     await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
       body_artifacts_dir: tmpRoot,
     });
 
@@ -119,6 +120,7 @@ describe('wave_finalize plan_id title pattern', () => {
     const result = await handler.execute({
       epic_id: 42,
       kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
       body_artifacts_dir: tmpRoot,
     });
     const data = parseResult(result);

--- a/tests/wave_finalize.test.ts
+++ b/tests/wave_finalize.test.ts
@@ -16,6 +16,10 @@ installChildProcessMock();
 let currentPlatform: 'github' | 'gitlab' = 'github';
 
 const { default: handler, assembleBody } = await import('../handlers/wave_finalize.ts');
+// Deferred like the handler above — this module is pure, but importing it before
+// installChildProcessMock() has settled would break the mock-leakage discipline
+// the header describes.
+const { epicSlugFromBranch } = await import('../lib/wave-finalize.ts');
 
 function parseResult(result: { content: Array<{ type: string; text: string }> }) {
   return JSON.parse(result.content[0].text) as Record<string, unknown>;
@@ -60,16 +64,10 @@ beforeEach(() => {
       ? 'git@gitlab.com:o/r.git'
       : 'git@github.com:o/r.git',
   );
-  // #472: target_branch now resolves to the LIVE default branch when omitted
-  // (previously a static zod .default('main')). Stub both platforms' default
-  // lookup to 'main' so the existing "default → main" assertions still hold.
-  // GitHub: `gh repo view --json defaultBranchRef ...` (runArgv-escaped, matched
-  // on the unique field token). GitLab: `glab api projects/:id`.
-  onExec('defaultBranchRef', 'main');
-  // Quote-bounded token so this matches ONLY `glab api projects/:id` (the
-  // default-branch resolve) and NOT `projects/:id/merge_requests?...` (the
-  // prCreate post-create lookup, which uses the same `:id` placeholder).
-  onExec("'projects/:id'", JSON.stringify({ default_branch: 'main' }));
+  // No default-branch stub. #472 made an omitted `target_branch` resolve to the
+  // live default; #503 made the field REQUIRED, so the handler never asks the host
+  // for a default at all. A stub here would be dead — worse, it would let a
+  // regression that reintroduced defaulting pass silently.
 });
 
 afterEach(() => {
@@ -88,6 +86,7 @@ describe('wave_finalize handler', () => {
   test('schema rejects missing plan_id', async () => {
     const result = await handler.execute({
       kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
     });
     const data = parseResult(result);
     expect(data.ok).toBe(false);
@@ -98,6 +97,7 @@ describe('wave_finalize handler', () => {
     const result = await handler.execute({
       plan_id: 0,
       kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
     });
     const data = parseResult(result);
     expect(data.ok).toBe(false);
@@ -109,7 +109,12 @@ describe('wave_finalize handler', () => {
     expect(data.ok).toBe(false);
   });
 
-  test('target_branch defaults to main', async () => {
+  // #503 — inverts the former "target_branch defaults to main". A default whose
+  // value is the protected branch is one omitted argument away from the early
+  // trunk merge claudecode-workflow#1052 removed, so omitting it must be a SCHEMA
+  // error, never a PR against main. The two negative assertions are the point:
+  // no PR lookup and no PR create ran at all.
+  test('schema rejects missing target_branch — no implicit trunk target', async () => {
     onExec('gh pr list', JSON.stringify([{
       number: 99, url: 'https://github.com/o/r/pull/99',
       state: 'OPEN', headRefName: 'kahuna/42-foo', baseRefName: 'main', title: 't',
@@ -122,12 +127,62 @@ describe('wave_finalize handler', () => {
       body_artifacts_dir: tmpRoot,
     });
     const data = parseResult(result);
+    expect(data.ok).toBe(false);
+    expect(data.error as string).toContain('target_branch');
+    expect(execCalls().some(c => c.includes('gh pr list'))).toBe(false);
+    expect(execCalls().some(c => c.includes("'pr' 'create'"))).toBe(false);
+  });
+
+  test('schema rejects an empty target_branch', async () => {
+    const result = await handler.execute({
+      plan_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      target_branch: '',
+      body_artifacts_dir: tmpRoot,
+    });
+    const data = parseResult(result);
+    expect(data.ok).toBe(false);
+    expect(data.error as string).toContain('target_branch');
+  });
+
+  test('an explicit target_branch is honored verbatim', async () => {
+    onExec('gh pr list', JSON.stringify([{
+      number: 99, url: 'https://github.com/o/r/pull/99',
+      state: 'OPEN', headRefName: 'kahuna/42-foo', baseRefName: 'main', title: 't',
+    }]));
+    onExec('ls-remote', 'abc123\trefs/heads/kahuna/42-foo');
+
+    const result = await handler.execute({
+      plan_id: 42,
+      kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
+      body_artifacts_dir: tmpRoot,
+    });
+    const data = parseResult(result);
     expect(data.ok).toBe(true);
-    // gh pr list was called with --base main (default). The adapter
-    // validates head/base against a strict charset and emits unquoted argv.
+    // The adapter validates head/base against a strict charset and emits
+    // unquoted argv.
     const listCall = execCalls().find(c => c.includes('gh pr list'));
     expect(listCall).toBeDefined();
     expect(listCall).toContain('--base main');
+  });
+
+  // The campaign shape (#1052): a wave integrates onto the campaign branch and
+  // the protected branch is written exactly once, at the DoD gate.
+  test('a campaign integration base is targeted, not trunk', async () => {
+    await writeArtifact(tmpRoot, 'wave-1/flight-1/issue-5/results.md', 'done');
+    mockGithubCreate(601, 'kahuna/56-W-2', 'campaign/56-blueshift');
+
+    const result = await handler.execute({
+      plan_id: 56,
+      kahuna_branch: 'kahuna/56-W-2',
+      target_branch: 'campaign/56-blueshift',
+      body_artifacts_dir: tmpRoot,
+    });
+    expect(parseResult(result).ok).toBe(true);
+    const createCall = execCalls().find(c => c.includes("'pr' 'create'"));
+    expect(createCall as string).toContain("'--base' 'campaign/56-blueshift'");
+    expect(createCall as string).not.toContain("'--base' 'main'");
   });
 
   // --- error: kahuna_branch_not_found ---
@@ -138,6 +193,7 @@ describe('wave_finalize handler', () => {
     const result = await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-nonexistent',
+      target_branch: 'main',
       body_artifacts_dir: tmpRoot,
     });
     const data = parseResult(result);
@@ -159,6 +215,7 @@ describe('wave_finalize handler', () => {
     const result = await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
       body_artifacts_dir: tmpRoot,
     });
     const data = parseResult(result);
@@ -175,6 +232,7 @@ describe('wave_finalize handler', () => {
     const result = await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
       body_artifacts_dir: tmpRoot, // empty directory
     });
     const data = parseResult(result);
@@ -191,6 +249,7 @@ describe('wave_finalize handler', () => {
     const result = await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
       body_artifacts_dir: tmpRoot,
     });
     const data = parseResult(result);
@@ -211,6 +270,7 @@ describe('wave_finalize handler', () => {
     const result = await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
       body_artifacts_dir: tmpRoot,
     });
     const data = parseResult(result);
@@ -233,6 +293,7 @@ describe('wave_finalize handler', () => {
     await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
       body_artifacts_dir: tmpRoot,
     });
 
@@ -251,6 +312,7 @@ describe('wave_finalize handler', () => {
     const result = await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-wave-status-cli',
+      target_branch: 'main',
       body_artifacts_dir: tmpRoot,
     });
     const data = parseResult(result);
@@ -274,6 +336,7 @@ describe('wave_finalize handler', () => {
     const result = await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
       body_artifacts_dir: tmpRoot,
       root: tmpRoot, // the wave's target repo root
     });
@@ -298,6 +361,7 @@ describe('wave_finalize handler', () => {
     await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-wave-status-cli',
+      target_branch: 'main',
       body_artifacts_dir: tmpRoot,
     });
 
@@ -389,11 +453,13 @@ describe('wave_finalize handler', () => {
     const r1 = parseResult(await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
       body_artifacts_dir: tmpRoot,
     }));
     const r2 = parseResult(await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
       body_artifacts_dir: tmpRoot,
     }));
 
@@ -409,6 +475,7 @@ describe('wave_finalize handler', () => {
     const result = await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-wave-status-cli',
+      target_branch: 'main',
       // body_artifacts_dir omitted — defaults to /tmp/wavemachine/42-wave-status-cli
     });
     const data = parseResult(result);
@@ -444,6 +511,7 @@ describe('wave_finalize handler', () => {
     const result = await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
       body_artifacts_dir: tmpRoot,
     });
     const data = parseResult(result);
@@ -472,6 +540,7 @@ describe('wave_finalize handler', () => {
     const result = await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
       body_artifacts_dir: tmpRoot,
     });
     const data = parseResult(result);
@@ -487,6 +556,7 @@ describe('wave_finalize handler', () => {
     const result = await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
       body_artifacts_dir: '/etc',
     });
     const data = parseResult(result);
@@ -501,6 +571,7 @@ describe('wave_finalize handler', () => {
     const result = await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
       body_artifacts_dir: tmpRoot, // /tmp/wave-finalize-test-...
     });
     const data = parseResult(result);
@@ -512,6 +583,7 @@ describe('wave_finalize handler', () => {
     const result = await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
       body_artifacts_dir: '/tmp/foo/../../etc',
     });
     const data = parseResult(result);
@@ -529,6 +601,7 @@ describe('wave_finalize handler', () => {
     const result = await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
       body_artifacts_dir: tmpRoot,
     });
     const data = parseResult(result);
@@ -573,6 +646,7 @@ describe('wave_finalize handler', () => {
     const result = await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
       // bus tmpRoot is intentionally empty (cleanup happened).
       body_artifacts_dir: tmpRoot,
       // route the durable-state read at projectRoot.
@@ -610,6 +684,7 @@ describe('wave_finalize handler', () => {
     const result = await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
       body_artifacts_dir: tmpRoot,
       root: emptyRoot,
     });
@@ -637,6 +712,7 @@ describe('wave_finalize handler', () => {
     await handler.execute({
       plan_id: 42,
       kahuna_branch: 'kahuna/42-foo',
+      target_branch: 'main',
       body_artifacts_dir: tmpRoot,
       root: projectRoot,
     });
@@ -647,5 +723,33 @@ describe('wave_finalize handler', () => {
     expect(createCall as string).toContain('https://github.com/o/r/pull/999');
     // Durable-state issue must NOT leak into the body.
     expect(createCall as string).not.toContain('Issue #10');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #503 — slug extraction is prefix-agnostic
+// ---------------------------------------------------------------------------
+// `epicSlugFromBranch` pinned the prefix to `kahuna` and returned '' for anything
+// else, which silently degraded the MR title to `plan(#56):  — kahuna to …`. Post
+// claudecode-workflow#1052 an integration branch can be a `campaign/<planId>-<slug>`,
+// and `wave_init`'s `kahuna.branch` accepts any caller-supplied name — so the
+// pinned pattern was a title-corruption bug waiting on a non-kahuna prefix.
+describe('epicSlugFromBranch (#503)', () => {
+  test.each([
+    ['campaign/56-blueshift', 'blueshift'],
+    ['kahuna/56-blueshift', 'blueshift'],
+    ['kahuna/56-W-2', 'W-2'],
+    ['integration/7-multi-part-slug', 'multi-part-slug'],
+  ])('%s → %s', (branch, expected) => {
+    expect(epicSlugFromBranch(branch)).toBe(expected);
+  });
+
+  test.each([
+    ['no id segment', 'campaign/blueshift'],
+    ['no slug after the id', 'kahuna/56'],
+    ['no prefix at all', 'main'],
+    ['a nested prefix (the id is not in the second segment)', 'wave/kahuna/56-blueshift'],
+  ])('returns empty for %s', (_why, branch) => {
+    expect(epicSlugFromBranch(branch)).toBe('');
   });
 });

--- a/tests/wave_init.test.ts
+++ b/tests/wave_init.test.ts
@@ -449,6 +449,96 @@ describe('wave_init handler', () => {
     expect(parsed.ok).toBe(false);
   });
 
+  // ---- #503: the branch name comes from the caller ------------------------
+  // The naming/validation logic is unit-tested in `lib/wave_init_plan.test.ts`
+  // against the injected deps. These prove the HANDLER actually threads `branch`
+  // (and the resolved default) through to the bootstrap — the seam that a
+  // lib-only test cannot see.
+
+  test('#503 — an explicit kahuna.branch is the ref created on the platform', async () => {
+    await setupStatusFixture({ kahuna_branch: null });
+    setExecRoutes([
+      { match: 'git remote get-url', respond: 'git@github.com:Wave-Engineering/mcp-server-sdlc.git' },
+      { match: 'git ls-remote --heads origin', respond: '' },
+      { match: 'gh api repos/Wave-Engineering/mcp-server-sdlc/git/refs/heads/campaign/56-blueshift', respond: '0000000000000000000000000000000000000abc' },
+      { match: 'gh api repos/Wave-Engineering/mcp-server-sdlc/git/refs -X POST', respond: '' },
+      { match: 'wave-status set-kahuna-branch', respond: '' },
+    ]);
+
+    const result = await handler.execute({
+      // A campaign: the plan's base is the campaign branch, not trunk.
+      plan_json: JSON.stringify({ phases: [], base_branch: 'campaign/56-blueshift' }),
+      kahuna: { plan_id: 56, slug: 'blueshift', branch: 'kahuna/56-W-2' },
+    });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.kahuna_branch).toBe('kahuna/56-W-2');
+    expect(parsed.kahuna_created).toBe(true);
+
+    const calls = mockExecSync.mock.calls.map(c => unquote(c[0] as string));
+    // The caller's name was created; the derived `kahuna/56-blueshift` was not.
+    expect(calls.some(c => c.includes('ref=refs/heads/kahuna/56-W-2'))).toBe(true);
+    expect(calls.some(c => c.includes('ref=refs/heads/kahuna/56-blueshift'))).toBe(false);
+    // ...and it was cut from the CAMPAIGN branch's SHA, not trunk's.
+    expect(calls.some(c => c.includes('git/refs/heads/campaign/56-blueshift'))).toBe(true);
+  });
+
+  test('#503 — a branch equal to the repo default is refused, and nothing is created', async () => {
+    await setupStatusFixture({ kahuna_branch: null });
+    setExecRoutes([
+      { match: 'git remote get-url', respond: 'git@github.com:Wave-Engineering/mcp-server-sdlc.git' },
+      // Trunk exists on the remote — which is exactly why the guard has to run
+      // BEFORE the reuse path, or the protected branch gets claimed as the
+      // integration branch and every flight merges straight to it.
+      { match: 'git ls-remote --heads origin', respond: 'abc123\trefs/heads/main' },
+    ]);
+
+    const result = await handler.execute({
+      plan_json: JSON.stringify({ phases: [], base_branch: 'campaign/56-blueshift' }),
+      kahuna: { plan_id: 56, slug: 'blueshift', branch: 'main' },
+    });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error as string).toContain('same ref as the repo default branch');
+    const calls = mockExecSync.mock.calls.map(c => unquote(c[0] as string));
+    expect(calls.some(c => c.includes('git/refs -X POST'))).toBe(false);
+    expect(calls.some(c => c.includes('set-kahuna-branch'))).toBe(false);
+  });
+
+  // "before the branch is cut", not "before any platform call": the handler resolves
+  // the live default branch first (it needs it for the guard), so one read round-trip
+  // precedes validation. The assertion that matters is that no ref was CREATED.
+  test('#503 — an invalid ref is rejected before the branch is cut', async () => {
+    await setupStatusFixture({ kahuna_branch: null });
+    setExecRoutes([
+      { match: 'git remote get-url', respond: 'git@github.com:Wave-Engineering/mcp-server-sdlc.git' },
+    ]);
+
+    const result = await handler.execute({
+      plan_json: JSON.stringify({ phases: [], base_branch: 'campaign/56-blueshift' }),
+      kahuna: { plan_id: 56, slug: 'blueshift', branch: 'kahuna/56-W 2' },
+    });
+    const parsed = parseResult(result);
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error as string).toContain('not a valid git ref');
+    const calls = mockExecSync.mock.calls.map(c => unquote(c[0] as string));
+    expect(calls.some(c => c.includes('git/refs -X POST'))).toBe(false);
+  });
+
+  test('#503 — the schema rejects an unknown key inside kahuna (strict object)', async () => {
+    const result = await handler.execute({
+      plan_json: JSON.stringify({ phases: [] }),
+      kahuna: { plan_id: 56, slug: 'blueshift', branch_name: 'kahuna/56-W-2' },
+    });
+    const parsed = parseResult(result);
+    // `.strict()` — a near-miss key must fail loudly rather than being dropped
+    // and silently falling back to the derived name.
+    expect(parsed.ok).toBe(false);
+  });
+
   test('kahuna bootstrap — backward compat: omitting kahuna leaves response field absent', async () => {
     await setupStatusFixture(null);
     const result = await handler.execute({


### PR DESCRIPTION
## Summary

A wave campaign runs **one branch all the way through**, with no interim merge-backs to the protected branch (claudecode-workflow#1052). Two defaults stood in the way, and both resolved to the protected branch itself. This removes the notion that trunk is a defensible default for either an integration branch's parentage or a merge target.

The distinction from #472/#473: those fixed *which* trunk name got resolved. The remaining defect is that a merge target defaulting to the protected branch is wrong **at all**.

## Changes

- **`wave_init` gains `kahuna.branch`** — the caller names the integration branch. Omitting it keeps the historical derived `kahuna/<plan_id>-<slug>`, still correct for a standalone single-wave run. The derived name encodes two assumptions that fail for a campaign: the branch is per-PLAN (so every wave shares one, and the per-wave promote that deletes it destroys the next wave's base), and it is cut from the plan's base (so a later wave forks a baseline missing the earlier waves' work). A campaign needs one branch per WAVE cut from the campaign branch — a name only the caller can know.

- **Ref-name validation** (`kahunaBranchName`) per git-check-ref-format(1) before the name reaches `git` or the platform API, plus a leading-`-` guard (argv injection — `create-branch-gitlab.ts` reaches argv) and a `refs/` guard (double-qualification — `create-branch-github.ts` prepends `refs/heads/`). An invalid ref otherwise fails at create time with a platform message that reads like an auth or network fault.

- **The branch is refused if it equals the base branch or the repo's live default.** `defaultBranch` is tracked separately from `baseBranch` because the two diverge exactly when it matters: an explicit `plan.base_branch` means the protected branch is some *other* ref, and that other ref is the one an integration branch must never be. The default check is the load-bearing one — trunk already exists on the remote, so without it the idempotent-reuse path would claim the protected branch as the integration branch and every flight would merge straight to it, reintroducing the early-trunk-write #1052 removed. The guard runs **before** the reuse shortcut: a check ordered after an idempotency shortcut never fires on the dangerous input.

- **`wave_finalize.target_branch` is required, no default.** Verified every in-repo caller and the sole production caller (`nextwave/gate.js:103-104`, which already passes `target_branch="${integrationBase}"`) supply it explicitly — the break is intentional and fully migrated.

- **`epicSlugFromBranch` no longer pins the `kahuna/` prefix.** Against a `campaign/*` or caller-supplied name it returned `''` and silently degraded the MR title to `plan(#56):  — kahuna to ...`.

- Removed two `defaultBranchRef` / `'projects/:id'` test stubs left from #472. The suite stayed at 2449/0 without them, proving they were dead — and a dead stub would have let a regression that reintroduced defaulting pass silently.

## Linked Issues

Closes #503

## Test Plan

Actually run:

- `bunx tsc --noEmit` — clean.
- `CLAUDE_PROJECT_DIR=<empty> bun test` — **2449 pass / 3 skip / 0 fail** across 166 files. The isolated project dir is required: 4 pre-existing `wave_finalize` tests read the session project's real gitignored `.claude/status/` via the #415 durable-state fallback and fail on any machine carrying live wave state. Verified identical on a stashed clean tree — not introduced here.
- `./scripts/ci/validate.sh` — 78/78 per-tool assertions.
- `./scripts/ci/build.sh` — green on `linux-x64`, `darwin-arm64`, `darwin-x64`.
- `trivy fs --scanners vuln --severity HIGH,CRITICAL` — `scanned: 1 manifest [bun.lock | bun]`, 1 HIGH (`fast-uri` CVE-2026-16221). Pre-existing: `bun.lock` is byte-identical to `main` and all 9 changed files are `.ts`. Filed as #504.

New coverage: 6 bootstrap/naming cases (explicit wins, derived default, base refused, **repo default refused**, invalid ref refused pre-create, existing branch claimed as reuse), an 8-case invalid-ref table, 4 handler-level tests, and an `epicSlugFromBranch` table. Every rejection case asserts `created: []` — that the branch was never *cut*, not merely that an error came back.

## Notes

- **`kahuna.branch` has no live consumer yet.** The engine still cuts the per-wave branch client-side (`nextwave/per-wave-workflow.js:648-732`) with its own copy of these inequality assertions, and `campaign-workflow.js:304` logs that it ignores a plan-supplied `kahunaBranch`. Two implementations of one invariant drift; the limit is recorded in `kahunaBranchName`'s docstring, and pointing the engine at the server-side bootstrap is follow-up work.
- Step 4 of the issue (the `campaign/*` residue scan) targets unmerged code on `feature/457-wave-campaign-precheck` and is recorded as a comment there instead.
- `claudecode-workflow:docs/kahuna-devspec.md` §5.1.1 still documents `target_branch?: // defaults to "main"` and a `wave_init` signature without `branch`. Contract drift in the other repo; needs its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)