### PR TITLE
chore(release): v3.0.0 — target_branch is required, no trunk default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server-sdlc",
-  "version": "2.1.2",
+  "version": "3.0.0",
   "description": "SDLC workflow MCP server for Claude Code agents",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Version bump for the v3.0.0 release. #503 (PR #505) made `wave_finalize.target_branch` required, removing a default that resolved to the repo's live default branch. A caller relying on the omission now fails its zod parse instead of silently targeting the protected branch — a breaking API change, so a major.

Repo precedent is v2.0.0, cut for the `wave_init` / `wave_finalize` signature breaks (#370, #371). The blast radius here is narrow — the only production caller is claudecode-workflow's `nextwave/gate.js`, which already passes `target_branch` explicitly — but the contract changed and the version should say so rather than hide it in a minor.

## Changes

- `package.json` version `2.1.2` → `3.0.0`.

The stamp is for the record only: the binary self-reports its build tag from `git describe --tags` via `bun build --define` (`index.ts:18`, `scripts/ci/build.sh:21`), so the tag — not this file — is what a running server reports. Nothing in `lib/` or `handlers/` reads it.

## Linked Issues

Closes #506

## Test Plan

Actually run on this branch:

- `./scripts/ci/validate.sh` — **78/78 per-tool assertions**, codegen + tsc + gate-greps + shellcheck + unit tests.
- Full suite under an isolated project dir — 2449 pass / 3 skip / 0 fail. The isolation is required, not cosmetic: 4 pre-existing `wave_finalize` tests read the session project's real gitignored `.claude/status/` through the #415 durable-state fallback and fail on any machine carrying live wave state.

After merge, tagging `v3.0.0` fires the release workflow (validate → build linux-x64 / darwin-x64 / darwin-arm64 → `gh release create`). Note the repo carries a **"Release tags immutable (v\*)"** ruleset, so the tag cannot be moved afterward — it goes on the verified merge commit or not at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)