### PR TITLE
fix(pr_wait_ci)!: wait for checks to register before declaring none

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -32,42 +32,73 @@ Tools below are listed in alphabetic order. To add a tool: drop a file in `handl
 
 `final_state: 'passed'` requires `total > 0 && pending === 0 && failed === 0`. All-skipped checks (every workflow's `if:` guard didn't match) count as `passed` — see #221.
 
-**Returns — empty-rollup short-circuit** (#416). When the head ref has no required status checks, the handler returns immediately at t=0 instead of spinning to timeout. The semantics is "wait until CI is settled" — if there are no checks to settle, that condition is satisfied at t=0.
+**Returns — no checks** (#416, reworked by #508). When the head ref still has no
+registered checks after a **settle window**, the handler returns without entering
+the polling loop.
+
+#416 returned here at t=0 on the first empty rollup. An empty rollup is also
+exactly what a merely-**queued** check looks like, so a PR whose CI had not
+started yet got a definite, successful-sounding verdict with `elapsed_sec: 0`.
+So the handler now keeps probing for `settle_window_sec` (default 45s), and if
+nothing has registered by then it cross-checks the **head SHA** for CI runs
+before deciding which of two facts is true:
+
+| status | meaning | `mergeable` |
+|---|---|---|
+| `no_checks_configured` | the ref-query succeeded and found no runs — this repo genuinely runs no checks here | may be `true` |
+| `no_checks_yet` | runs exist for the head SHA that have not registered as checks, **or** the ref-query could not be run at all | always `false` |
+
+**Only a query that SUCCEEDED and found nothing may report `no_checks_configured`.**
+A failed query, or a missing head SHA, yields `no_checks_yet` with
+`blocker: "evidence_unavailable"` — an instrument that examined nothing must
+never return the answer a caller might merge on.
 
 ```json
 {
   "ok": true,
   "number": 42,
-  "status": "no_checks_required",
-  "elapsed_sec": 0,
-  "mergeable": true,
+  "status": "no_checks_yet",
+  "elapsed_sec": 45,
+  "settled_sec": 45,
+  "mergeable": false,
+  "blocker": "checks_not_registered",
+  "pending_runs": [{ "run_id": 991, "workflow_name": "validate", "status": "queued" }],
   "url": "https://github.com/org/repo/pull/42"
 }
 ```
 
-When the rollup is empty AND the PR/MR is obstructed (draft, closed, conflicts, …), `mergeable` is `false` and a `blocker` field names the obstruction:
+When there are no checks AND the PR/MR is obstructed (draft, closed, conflicts, …),
+the settle window is skipped entirely — a closed PR is not going to start CI — and
+`settled_sec` is `0`:
 
 ```json
 {
   "ok": true,
   "number": 42,
-  "status": "no_checks_required",
+  "status": "no_checks_configured",
   "elapsed_sec": 0,
+  "settled_sec": 0,
   "mergeable": false,
   "blocker": "draft" | "closed" | "merged" | "conflicts" | "not_mergeable" | "locked",
   "url": "https://github.com/org/repo/pull/42"
 }
 ```
 
+> **`no_checks_required` is gone.** It meant both facts above, and its
+> plain-English name reads as "nothing is wrong". It is removed rather than
+> aliased so that callers matching the old literal stop matching — a deliberate
+> forcing function. Callers that allowlist on `final_state === 'passed'` are
+> unaffected.
+
 **Discriminator.** Callers should branch on the response shape via either field:
 
-- `status === 'no_checks_required'` → empty-rollup short-circuit (`final_state` absent).
+- `status` present (`no_checks_configured` | `no_checks_yet`) → no-checks return (`final_state` absent). **Neither value is a pass.**
 - `final_state` present → polling-loop result (`status` absent).
 
 **Platform notes.**
 
-- GitHub: probe is `gh pr view <num> --json statusCheckRollup,url,state,isDraft,mergeable,mergeStateStatus`. Polling-loop snapshot uses the slimmer `--json statusCheckRollup,url` (per-iteration cost stays minimal). `gh pr checks --json` is NOT used — it broke on Ubuntu 24.04's gh 2.45 (#220).
-- GitLab: probe is `glab api projects/<encoded-slug>/merge_requests/<iid>`. Empty-rollup means `head_pipeline === null && pipeline === null`. Polling-loop status mapping: `success → passed`, `failed/canceled → failed`, `running/pending/created/preparing/waiting_for_resource/scheduled/manual → pending`, anything else → uncounted (loop times out).
+- GitHub: probe is `gh pr view <num> --json statusCheckRollup,url,state,isDraft,mergeable,mergeStateStatus,headRefOid` (`headRefOid` anchors the #508 ref cross-check). Polling-loop snapshot uses the slimmer `--json statusCheckRollup,url` (per-iteration cost stays minimal). `gh pr checks --json` is NOT used — it broke on Ubuntu 24.04's gh 2.45 (#220).
+- GitLab: probe is `glab api projects/<encoded-slug>/merge_requests/<iid>`. Empty-rollup means `head_pipeline === null && pipeline === null` — which on GitLab is also what "the pipeline has not been created yet" looks like, since pipelines are created asynchronously after the MR (#508). Polling-loop status mapping: `success → passed`, `failed/canceled → failed`, `running/pending/created/preparing/waiting_for_resource/scheduled/manual → pending`, anything else → uncounted (loop times out).
 
 **See also.** `pattern_decorative_ac_and_stub_orphan.md` for the failure mode this short-circuit closes (autopilot callers losing 30-minute timeout windows on docs-only PRs with no CI).
 

--- a/handlers/pr_wait_ci.ts
+++ b/handlers/pr_wait_ci.ts
@@ -23,6 +23,10 @@ const inputSchema = z
     number: z.number().int().positive(),
     poll_interval_sec: z.number().int().optional().default(30),
     timeout_sec: z.number().int().positive().optional().default(1800),
+    // #508: how long to wait for checks to REGISTER before concluding a repo
+    // runs none. An empty rollup at t=0 is indistinguishable from a queued
+    // check, which is how a PR with pending CI reported a definite verdict.
+    settle_window_sec: z.number().int().min(0).optional(),
     // GitLab nested groups need arbitrary `/` depth — see lib/schemas/repo.ts (#290).
     repo: repoOptionalSchema,
   })

--- a/lib/adapters/pr-wait-ci-github.test.ts
+++ b/lib/adapters/pr-wait-ci-github.test.ts
@@ -27,6 +27,7 @@ const {
   snapshotGithub,
   emptyRollupBlocker,
   probeGithub,
+  isUnfinished,
 } = await import('./pr-wait-ci-github.ts');
 
 beforeEach(() => {
@@ -241,110 +242,263 @@ describe('prWaitCiGithub — #221 all-skipped regression', () => {
   });
 });
 
-// --- #416: empty-rollup short-circuit at the adapter boundary -----------
-describe('prWaitCiGithub — empty-rollup short-circuit (#416)', () => {
-  test('empty rollup + mergeable → no_checks_required immediately', async () => {
+// --- #508: the settle window replaces #416's t=0 short-circuit -------------
+//
+// #416 returned `no_checks_required` on the FIRST empty rollup. An empty rollup
+// is also exactly what a merely-QUEUED check looks like, so a PR whose CI had
+// not started yet reported a definite, successful-sounding verdict with
+// `elapsed_sec: 0`. Observed live on cc-workflow#1087: `pr_wait_ci` said
+// no_checks_required while `gh pr checks` said `validate pending` seconds later.
+//
+// Every test here drives the settle loop through INJECTED seams — fake clock,
+// fake sleep. A test that burned 45s of real wall-clock would be deleted by
+// whoever next ran the suite, and this behaviour would go uncovered.
+
+/** Fake clock whose `sleep` advances `now`, so the window elapses instantly. */
+function fakeClock() {
+  let t = 1_000_000;
+  let slept = 0;
+  return {
+    now: () => t,
+    sleep: async (ms: number) => {
+      t += ms;
+      slept += 1;
+    },
+    sleeps: () => slept,
+  };
+}
+
+const HEAD_SHA = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+
+/** Local mirror of the adapter's RollupItem — the test imports values, not types. */
+interface RollupLike {
+  __typename?: string;
+  name?: string;
+  status?: string;
+  conclusion?: string;
+  state?: string;
+}
+
+function openMergeable(overrides: Record<string, unknown> = {}) {
+  return {
+    url: 'https://github.com/org/repo/pull/42',
+    statusCheckRollup: [] as RollupLike[],
+    state: 'OPEN',
+    isDraft: false,
+    mergeable: 'MERGEABLE',
+    mergeStateStatus: 'CLEAN',
+    headRefOid: HEAD_SHA,
+    ...overrides,
+  };
+}
+
+interface NoChecksData {
+  status?: string;
+  mergeable?: boolean;
+  blocker?: string;
+  elapsed_sec?: number;
+  settled_sec?: number;
+  url?: string;
+  final_state?: string;
+  pending_runs?: { run_id: number; workflow_name: string; status: string }[];
+}
+
+describe('prWaitCiGithub — settle window (#508)', () => {
+  test('empty rollup, nothing ever registers, no runs for head SHA → no_checks_configured', async () => {
+    const clock = fakeClock();
+    const result = await prWaitCiGithub(
+      { number: 42, poll_interval_sec: 5, timeout_sec: 1800 },
+      {
+        probe: () => openMergeable(),
+        pendingRuns: async () => ({ ok: true, runs: [] }),
+        now: clock.now,
+        sleep: clock.sleep,
+        settleWindowSec: 45,
+        settlePollSec: 5,
+      },
+    );
+    if (!('ok' in result) || !result.ok) throw new Error('expected ok');
+    const data = result.data as NoChecksData;
+    expect(data.status).toBe('no_checks_configured');
+    expect(data.mergeable).toBe(true);
+    expect(data.blocker).toBeUndefined();
+    expect(data.pending_runs).toBeUndefined();
+    // It actually waited rather than concluding at t=0.
+    expect(clock.sleeps()).toBeGreaterThan(0);
+    expect(data.settled_sec).toBeGreaterThanOrEqual(45);
+  });
+
+  test('THE BUG: a QUEUED run for the head SHA → no_checks_yet, never mergeable', async () => {
+    const clock = fakeClock();
+    const result = await prWaitCiGithub(
+      { number: 42, poll_interval_sec: 5, timeout_sec: 1800 },
+      {
+        probe: () => openMergeable(),
+        pendingRuns: async (sha) => {
+          expect(sha).toBe(HEAD_SHA); // cross-check is anchored to the head SHA
+          return { ok: true, runs: [{ run_id: 991, workflow_name: 'validate', status: 'queued' }] };
+        },
+        now: clock.now,
+        sleep: clock.sleep,
+        settleWindowSec: 45,
+        settlePollSec: 5,
+      },
+    );
+    if (!('ok' in result) || !result.ok) throw new Error('expected ok');
+    const data = result.data as NoChecksData;
+    expect(data.status).toBe('no_checks_yet');
+    // The load-bearing assertion. CI exists and has not reported; a caller must
+    // never read this as safe.
+    expect(data.mergeable).toBe(false);
+    expect(data.blocker).toBe('checks_not_registered');
+    expect(data.pending_runs?.[0]?.workflow_name).toBe('validate');
+    // The issue's named regression: `elapsed_sec: 0` must be impossible when a
+    // queued run exists for the head SHA.
+    expect(data.elapsed_sec).toBeGreaterThan(0);
+  });
+
+  test('a check that registers DURING the window falls through to the poll loop', async () => {
+    // This is the actual fix: the PR gets a real passed/failed verdict instead
+    // of any no-checks token at all.
     onExec(
       'gh pr view',
       JSON.stringify({
         url: 'https://github.com/org/repo/pull/42',
-        statusCheckRollup: [],
-        state: 'OPEN',
-        isDraft: false,
-        mergeable: 'MERGEABLE',
-        mergeStateStatus: 'CLEAN',
+        statusCheckRollup: [
+          { __typename: 'CheckRun', name: 'validate', status: 'COMPLETED', conclusion: 'SUCCESS' },
+        ],
       }),
     );
+    const clock = fakeClock();
+    let probes = 0;
+    const result = await prWaitCiGithub(
+      { number: 42, poll_interval_sec: 5, timeout_sec: 60 },
+      {
+        probe: () => {
+          probes += 1;
+          return probes >= 3
+            ? openMergeable({
+                statusCheckRollup: [
+                  { __typename: 'CheckRun', name: 'validate', status: 'QUEUED' },
+                ],
+              })
+            : openMergeable();
+        },
+        pendingRuns: async () => {
+          throw new Error('must not cross-check the ref once a check has registered');
+        },
+        now: clock.now,
+        sleep: clock.sleep,
+        settleWindowSec: 45,
+        settlePollSec: 5,
+      },
+    );
+    if (!('ok' in result) || !result.ok) throw new Error('expected ok');
+    const data = result.data as NoChecksData;
+    expect(data.final_state).toBe('passed');
+    expect(data.status).toBeUndefined(); // polled shape, not a no-checks shape
+  });
 
-    const result = await prWaitCiGithub({
-      number: 42,
-      poll_interval_sec: 5,
-      timeout_sec: 1800, // huge — proves we don't enter the poll loop
-    });
-    if (!('ok' in result) || !result.ok) {
-      throw new Error(`expected ok result, got ${JSON.stringify(result)}`);
+  test('hard blockers do NOT wait — waiting for a closed PR to start CI is pointless', async () => {
+    for (const [probeOverride, expected] of [
+      [{ state: 'CLOSED' }, 'closed'],
+      [{ state: 'MERGED' }, 'merged'],
+      [{ isDraft: true }, 'draft'],
+      [{ mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY' }, 'conflicts'],
+    ] as [Record<string, unknown>, string][]) {
+      const clock = fakeClock();
+      const result = await prWaitCiGithub(
+        { number: 42, poll_interval_sec: 5, timeout_sec: 1800 },
+        {
+          probe: () => openMergeable(probeOverride),
+          pendingRuns: async () => {
+            throw new Error('must not cross-check the ref for a blocked PR');
+          },
+          now: clock.now,
+          sleep: clock.sleep,
+          settleWindowSec: 45,
+          settlePollSec: 5,
+        },
+      );
+      if (!('ok' in result) || !result.ok) throw new Error('expected ok');
+      const data = result.data as NoChecksData;
+      expect(data.status).toBe('no_checks_configured');
+      expect(data.blocker).toBe(expected);
+      expect(data.mergeable).toBe(false);
+      expect(data.settled_sec).toBe(0);
+      // The ONE place a zero settle is correct — assert we truly did not sleep.
+      expect(clock.sleeps()).toBe(0);
     }
-    const data = result.data as { status?: string; mergeable?: boolean; blocker?: string; elapsed_sec?: number; url?: string };
-    expect(data.status).toBe('no_checks_required');
-    expect(data.mergeable).toBe(true);
-    expect(data.blocker).toBeUndefined();
-    expect(data.elapsed_sec).toBeLessThan(5);
-    expect(data.url).toBe('https://github.com/org/repo/pull/42');
-    // Probe argv must include the new fields the short-circuit needs.
-    const viewCall = execCalls().find((c) => c.startsWith('gh pr view')) ?? '';
-    expect(viewCall).toContain('mergeable');
-    expect(viewCall).toContain('isDraft');
-    expect(viewCall).toContain('state');
-    // #220 regression — never use the broken `gh pr checks --json` form.
-    expect(execCalls().some((c) => c.startsWith('gh pr checks'))).toBe(false);
   });
 
-  test('empty rollup + CONFLICTING → no_checks_required + conflicts blocker', async () => {
-    onExec(
-      'gh pr view',
-      JSON.stringify({
-        url: 'https://github.com/org/repo/pull/43',
-        statusCheckRollup: [],
-        state: 'OPEN',
-        isDraft: false,
-        mergeable: 'CONFLICTING',
-        mergeStateStatus: 'DIRTY',
-      }),
+  test('the retired `no_checks_required` token is gone, not aliased', async () => {
+    // Its plain-English name is the trap (skills/mmr/SKILL.md says so outright).
+    // Keeping it as a synonym would preserve the ambiguity this issue is about.
+    const clock = fakeClock();
+    const result = await prWaitCiGithub(
+      { number: 42, poll_interval_sec: 5, timeout_sec: 1800 },
+      {
+        probe: () => openMergeable(),
+        pendingRuns: async () => ({ ok: true, runs: [] }),
+        now: clock.now,
+        sleep: clock.sleep,
+        settleWindowSec: 10,
+        settlePollSec: 5,
+      },
     );
-    const result = await prWaitCiGithub({
-      number: 43,
-      poll_interval_sec: 5,
-      timeout_sec: 1800,
-    });
     if (!('ok' in result) || !result.ok) throw new Error('expected ok');
-    const data = result.data as { status?: string; mergeable?: boolean; blocker?: string };
-    expect(data.status).toBe('no_checks_required');
-    expect(data.mergeable).toBe(false);
-    expect(data.blocker).toBe('conflicts');
+    expect((result.data as NoChecksData).status).not.toBe('no_checks_required');
   });
 
-  test('empty rollup + draft → no_checks_required + draft blocker', async () => {
-    onExec(
-      'gh pr view',
-      JSON.stringify({
-        url: 'https://github.com/org/repo/pull/44',
-        statusCheckRollup: [],
-        state: 'OPEN',
-        isDraft: true,
-        mergeable: 'MERGEABLE',
-        mergeStateStatus: 'CLEAN',
-      }),
+  test('a missing head SHA cannot certify "no CI" — it is no_checks_yet, not configured', async () => {
+    // No anchor → the query cannot run → we have established NOTHING. Reporting
+    // `no_checks_configured` here would be an instrument that examined nothing
+    // returning the one answer a caller might merge on.
+    const clock = fakeClock();
+    const result = await prWaitCiGithub(
+      { number: 42, poll_interval_sec: 5, timeout_sec: 1800 },
+      {
+        probe: () => openMergeable({ headRefOid: undefined }),
+        pendingRuns: async () => {
+          throw new Error('must not query runs without a head SHA to anchor to');
+        },
+        now: clock.now,
+        sleep: clock.sleep,
+        settleWindowSec: 10,
+        settlePollSec: 5,
+      },
     );
-    const result = await prWaitCiGithub({ number: 44, poll_interval_sec: 5, timeout_sec: 60 });
     if (!('ok' in result) || !result.ok) throw new Error('expected ok');
-    const data = result.data as { status?: string; mergeable?: boolean; blocker?: string };
-    expect(data.status).toBe('no_checks_required');
+    const data = result.data as NoChecksData;
+    expect(data.status).toBe('no_checks_yet');
+    expect(data.blocker).toBe('evidence_unavailable');
     expect(data.mergeable).toBe(false);
-    expect(data.blocker).toBe('draft');
   });
 
-  test('empty rollup + closed PR → no_checks_required + closed blocker', async () => {
-    onExec(
-      'gh pr view',
-      JSON.stringify({
-        url: 'https://github.com/org/repo/pull/45',
-        statusCheckRollup: [],
-        state: 'CLOSED',
-        isDraft: false,
-        mergeable: 'UNKNOWN',
-        mergeStateStatus: 'UNKNOWN',
-      }),
+  test('a FAILED evidence query cannot report "no CI configured"', async () => {
+    // The instrument-examined-nothing case, which is the shape this whole repo
+    // is written against: a broken `gh` must not resolve to the mergeable answer.
+    const clock = fakeClock();
+    const result = await prWaitCiGithub(
+      { number: 42, poll_interval_sec: 5, timeout_sec: 1800 },
+      {
+        probe: () => openMergeable(),
+        pendingRuns: async () => ({ ok: false }),
+        now: clock.now,
+        sleep: clock.sleep,
+        settleWindowSec: 10,
+        settlePollSec: 5,
+      },
     );
-    const result = await prWaitCiGithub({ number: 45, poll_interval_sec: 5, timeout_sec: 60 });
     if (!('ok' in result) || !result.ok) throw new Error('expected ok');
-    const data = result.data as { status?: string; mergeable?: boolean; blocker?: string };
-    expect(data.status).toBe('no_checks_required');
+    const data = result.data as NoChecksData;
+    expect(data.status).toBe('no_checks_yet');
+    expect(data.blocker).toBe('evidence_unavailable');
     expect(data.mergeable).toBe(false);
-    expect(data.blocker).toBe('closed');
   });
 
-  test('non-empty rollup does NOT short-circuit — polled-response shape returned', async () => {
-    // Regression — proves the addition is conditional on rollup.length === 0.
+  test('non-empty rollup does NOT enter the settle window at all', async () => {
+    // Regression — proves the whole addition is conditional on an empty rollup.
     onExec(
       'gh pr view',
       JSON.stringify({
@@ -358,13 +512,38 @@ describe('prWaitCiGithub — empty-rollup short-circuit (#416)', () => {
         mergeStateStatus: 'CLEAN',
       }),
     );
-    const result = await prWaitCiGithub({ number: 46, poll_interval_sec: 5, timeout_sec: 10 });
+    const clock = fakeClock();
+    const result = await prWaitCiGithub(
+      { number: 46, poll_interval_sec: 5, timeout_sec: 10 },
+      { now: clock.now, sleep: clock.sleep },
+    );
     if (!('ok' in result) || !result.ok) throw new Error('expected ok');
-    const data = result.data as { status?: string; final_state?: string };
+    const data = result.data as NoChecksData;
     expect(data.final_state).toBe('passed');
     expect(data.status).toBeUndefined();
+    expect(clock.sleeps()).toBe(0);
   });
 });
+
+// --- evidence classifier: what counts as "CI is coming" (#508) --------------
+describe('isUnfinished — only unfinished runs are evidence', () => {
+  test('queued / in_progress / requested / waiting → evidence', () => {
+    for (const s of ['queued', 'in_progress', 'requested', 'waiting', 'pending']) {
+      expect(isUnfinished(s)).toBe(true);
+    }
+  });
+
+  test('completed / cancelled / skipped → NOT evidence', () => {
+    // A finished run that never produced a check is not "CI is coming" — it is
+    // CI that already came and went (path-filtered job, skipped workflow).
+    // Counting it would hold every such PR for the full window and then report
+    // `no_checks_yet` forever, converting a spurious pass into a spurious hang.
+    for (const s of ['completed', 'COMPLETED', 'cancelled', 'skipped']) {
+      expect(isUnfinished(s)).toBe(false);
+    }
+  });
+});
+
 
 // --- pure mapper tests for the empty-rollup blocker classifier (#416) ------
 describe('emptyRollupBlocker — pure mapping table', () => {

--- a/lib/adapters/pr-wait-ci-github.ts
+++ b/lib/adapters/pr-wait-ci-github.ts
@@ -27,8 +27,10 @@ import {
   type PollArgs,
   type PollResult,
 } from '../pr-wait-ci-poll.js';
+import { ciListRunsGithub } from './ci-list-runs-github.js';
 import type {
   AdapterResult,
+  CiListRunsArgs,
   PrWaitCiArgs,
   PrWaitCiNoChecksResponse,
   PrWaitCiResponse,
@@ -69,6 +71,7 @@ interface PrProbeResponse {
   isDraft?: boolean;
   mergeable?: string | boolean; // MERGEABLE | CONFLICTING | UNKNOWN | bool
   mergeStateStatus?: string; // CLEAN | DIRTY | BLOCKED | UNSTABLE | UNKNOWN
+  headRefOid?: string; // head SHA — anchors the #508 pending-run cross-check
 }
 
 type Bucket = 'pass' | 'fail' | 'pending' | 'skipping';
@@ -158,7 +161,7 @@ export function snapshotGithub(number: number, repo?: string): ChecksSnapshot {
  */
 export function probeGithub(number: number, repo?: string): PrProbeResponse {
   const raw = exec(
-    `gh pr view ${number} --json statusCheckRollup,url,state,isDraft,mergeable,mergeStateStatus${repoFlag(repo)}`,
+    `gh pr view ${number} --json statusCheckRollup,url,state,isDraft,mergeable,mergeStateStatus,headRefOid${repoFlag(repo)}`,
   );
   return JSON.parse(raw) as PrProbeResponse;
 }
@@ -191,29 +194,176 @@ export function emptyRollupBlocker(probe: PrProbeResponse): string | null {
   return null;
 }
 
+/**
+ * How long to keep re-probing an empty rollup before concluding the repo has no
+ * checks for this ref (#508). A `pull_request`-triggered workflow registers
+ * within seconds of PR creation; the window only has to outlast that gap.
+ *
+ * It is NOT a CI timeout — once a single check registers we fall through to the
+ * normal polling loop and `timeout_sec` governs from there.
+ */
+export const SETTLE_WINDOW_SEC = 45;
+export const SETTLE_POLL_SEC = 5;
+
+/** Injectable seams so the settle loop is testable without real time or a real gh. */
+export interface SettleDeps {
+  probe: (number: number, repo?: string) => PrProbeResponse;
+  /**
+   * Runs for the head SHA — evidence that checks are coming but unregistered.
+   *
+   * Discriminated on purpose. A query that FAILS is not a query that found
+   * nothing, and collapsing the two would let a broken `gh` report
+   * "no CI configured" — an instrument that examined nothing, reporting the
+   * one answer a caller might merge on. `{ok:false}` is carried through to
+   * `evidence_unavailable`.
+   */
+  pendingRuns: (
+    headSha: string,
+    repo?: string,
+  ) => Promise<
+    | { ok: true; runs: { run_id: number; workflow_name: string; status: string }[] }
+    | { ok: false }
+  >;
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+  settleWindowSec: number;
+  settlePollSec: number;
+}
+
+/**
+ * A run counts as evidence only while it is NOT finished. A completed run for
+ * this SHA that never produced a check is not "CI is coming" — it is CI that
+ * already came and went (a skipped workflow, a path-filtered job), and treating
+ * it as pending would hold every such PR for the full window and then report
+ * `no_checks_yet` forever.
+ */
+export function isUnfinished(status: string): boolean {
+  const s = status.toLowerCase();
+  return s !== 'completed' && s !== 'cancelled' && s !== 'skipped';
+}
+
+export function defaultSettleDeps(overrides: Partial<SettleDeps> = {}): SettleDeps {
+  return {
+    probe: probeGithub,
+    pendingRuns: async (headSha, repo) => {
+      const args: CiListRunsArgs = { ref: headSha, limit: 20, ...(repo !== undefined ? { repo } : {}) };
+      try {
+        const res = await ciListRunsGithub(args);
+        if (!('ok' in res) || !res.ok || !Array.isArray(res.data)) return { ok: false };
+        return {
+          ok: true,
+          runs: res.data
+            .filter((r) => r.head_sha === headSha && isUnfinished(r.status))
+            .map((r) => ({ run_id: r.run_id, workflow_name: r.workflow_name, status: r.status })),
+        };
+      } catch {
+        return { ok: false };
+      }
+    },
+    sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+    now: () => Date.now(),
+    settleWindowSec: SETTLE_WINDOW_SEC,
+    settlePollSec: SETTLE_POLL_SEC,
+    ...overrides,
+  };
+}
+
 export async function prWaitCiGithub(
   args: PrWaitCiArgs,
+  depsIn: Partial<SettleDeps> = {},
 ): Promise<AdapterResult<PrWaitCiResponse>> {
   // Bound any exception that escapes the snapshot helper into a typed result —
   // adapter callers must not have to try/catch.
   try {
-    // #416 short-circuit. One probe BEFORE entering the polling loop: if the
-    // PR's rollup is empty there is nothing to settle and we return at t=0.
-    const probeStart = Date.now();
-    const probe = probeGithub(args.number, args.repo);
-    const rollup = probe.statusCheckRollup ?? [];
+    // #508. #416 short-circuited here at t=0: one probe, and an empty rollup
+    // returned `no_checks_required` immediately. An empty rollup is ALSO what a
+    // merely-QUEUED check looks like, so a PR whose CI had not started yet
+    // reported a definite, successful-sounding verdict with `elapsed_sec: 0`.
+    //
+    // Observed on cc-workflow#1087: `pr_wait_ci` said no_checks_required while
+    // `gh pr checks` said `validate pending` seconds later. The live cost was a
+    // spurious HALT, not a bad merge — `/mmr` allowlists on `passed` — but the
+    // ambiguity lived in the API contract, so every future caller inherited it.
+    //
+    // So: keep probing until a check registers or the settle window elapses.
+    const deps = defaultSettleDeps({
+      ...(args.settle_window_sec !== undefined
+        ? { settleWindowSec: args.settle_window_sec }
+        : {}),
+      ...depsIn, // explicit injection still wins, so tests stay in control
+    });
+    const probeStart = deps.now();
+    let probe = deps.probe(args.number, args.repo);
+    let rollup = probe.statusCheckRollup ?? [];
+
     if (rollup.length === 0) {
+      // A hard blocker makes waiting pointless: a closed, merged or draft PR is
+      // not going to start CI, and holding the caller for the window buys
+      // nothing. Returning at once here is the ONE place a zero settle is right.
       const blocker = emptyRollupBlocker(probe);
-      const elapsedSec = Math.max(0, Math.floor((Date.now() - probeStart) / 1000));
-      const data: PrWaitCiNoChecksResponse = {
-        number: args.number,
-        status: 'no_checks_required',
-        elapsed_sec: elapsedSec,
-        mergeable: blocker === null,
-        url: probe.url ?? '',
-        ...(blocker !== null ? { blocker } : {}),
-      };
-      return { ok: true, data };
+      if (blocker !== null) {
+        return {
+          ok: true,
+          data: {
+            number: args.number,
+            status: 'no_checks_configured',
+            elapsed_sec: Math.max(0, Math.floor((deps.now() - probeStart) / 1000)),
+            settled_sec: 0,
+            mergeable: false,
+            blocker,
+            url: probe.url ?? '',
+          },
+        };
+      }
+
+      const deadline = probeStart + deps.settleWindowSec * 1000;
+      while (rollup.length === 0 && deps.now() < deadline) {
+        await deps.sleep(deps.settlePollSec * 1000);
+        probe = deps.probe(args.number, args.repo);
+        rollup = probe.statusCheckRollup ?? [];
+      }
+
+      if (rollup.length === 0) {
+        // Still nothing. Cross-check the REF before calling it "no CI here":
+        // a queued run for the head SHA is positive evidence that checks are
+        // coming, and reporting that as "no checks configured" is the same
+        // false-certainty this issue is about, just later on the clock.
+        // No head SHA means no anchor for the query. Claiming either answer off
+        // an unanchored search would be false certainty pointed one way or the
+        // other, so treat it as "cannot certify" rather than "no CI here".
+        const headSha = probe.headRefOid ?? '';
+        const evidence = headSha === ''
+          ? ({ ok: false } as const)
+          : await deps.pendingRuns(headSha, args.repo);
+        const settledSec = Math.max(0, Math.floor((deps.now() - probeStart) / 1000));
+
+        // Only ONE branch may claim "this repo runs no checks": a query that
+        // SUCCEEDED and found nothing. Everything else — the query failed, no
+        // SHA to anchor it, or runs found — is `no_checks_yet` and not mergeable.
+        const certified = evidence.ok && evidence.runs.length === 0;
+        const runs = evidence.ok ? evidence.runs : [];
+        const blocker = certified
+          ? undefined
+          : runs.length > 0
+            ? 'checks_not_registered'
+            : 'evidence_unavailable';
+
+        const data: PrWaitCiNoChecksResponse = {
+          number: args.number,
+          status: certified ? 'no_checks_configured' : 'no_checks_yet',
+          elapsed_sec: settledSec,
+          settled_sec: settledSec,
+          // `no_checks_yet` is NEVER mergeable: either CI exists and has not
+          // reported, or we could not establish that it doesn't.
+          mergeable: certified,
+          url: probe.url ?? '',
+          ...(blocker !== undefined ? { blocker } : {}),
+          ...(runs.length > 0 ? { pending_runs: runs } : {}),
+        };
+        return { ok: true, data };
+      }
+      // Checks registered during the window — fall through to the poll loop,
+      // which is the whole point: this PR now gets a real passed/failed verdict.
     }
 
     const pollArgs: PollArgs = {

--- a/lib/adapters/pr-wait-ci-gitlab.test.ts
+++ b/lib/adapters/pr-wait-ci-gitlab.test.ts
@@ -196,7 +196,7 @@ describe('prWaitCiGitlab — full poll path', () => {
   });
 
   // --- #416: empty-pipeline short-circuit ---
-  test('empty pipeline + mergeable MR → no_checks_required immediately', async () => {
+  test('empty pipeline no longer certifies "no CI" — GitLab creates pipelines async (#508)', async () => {
     onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git');
     onExec(
       'glab api projects/org%2Frepo/merge_requests/3',
@@ -214,21 +214,66 @@ describe('prWaitCiGitlab — full poll path', () => {
 
     const result = await prWaitCiGitlab({
       number: 3,
-      // Generous timeout — proves we never enter the poll loop.
       poll_interval_sec: 5,
       timeout_sec: 1800,
+      // #508 knob — zero keeps this a fast unit test; the settle loop itself is
+      // covered with a fake clock below.
+      settle_window_sec: 0,
     });
     if (!('ok' in result) || !result.ok) {
       throw new Error(`expected ok result, got ${JSON.stringify(result)}`);
     }
     const data = result.data as { status?: string; mergeable?: boolean; blocker?: string; elapsed_sec?: number };
-    expect(data.status).toBe('no_checks_required');
-    expect(data.mergeable).toBe(true);
-    expect(data.blocker).toBeUndefined();
-    expect(data.elapsed_sec).toBeLessThan(5);
+    // `head_pipeline: null` on GitLab is ALSO "the pipeline has not been created
+    // yet" — GitLab creates it asynchronously after the MR. The ref cross-check
+    // cannot run under this mock, so nothing may certify "no CI configured".
+    expect(data.status).toBe('no_checks_yet');
+    expect(data.mergeable).toBe(false);
+    expect(data.blocker).toBe('evidence_unavailable');
   });
 
-  test('empty pipeline + draft MR → no_checks_required + draft blocker', async () => {
+  test('a QUEUED pipeline for the head SHA → no_checks_yet, never mergeable (#508)', async () => {
+    const clock = (() => {
+      let t = 1_000_000;
+      return { now: () => t, sleep: async (ms: number) => { t += ms; } };
+    })();
+    const result = await prWaitCiGitlab(
+      { number: 3, poll_interval_sec: 5, timeout_sec: 1800 },
+      {
+        probe: () => ({
+          iid: 3,
+          state: 'opened',
+          title: 't',
+          description: null,
+          source_branch: 'f',
+          target_branch: 'main',
+          web_url: 'https://gitlab.com/org/repo/-/merge_requests/3',
+          labels: [],
+          draft: false,
+          has_conflicts: false,
+          merge_status: 'can_be_merged',
+          detailed_merge_status: 'mergeable',
+          diff_refs: { head_sha: 'deadbeef' },
+        }),
+        pendingRuns: async () => ({
+          ok: true,
+          runs: [{ run_id: 7, workflow_name: 'pipeline', status: 'pending' }],
+        }),
+        now: clock.now,
+        sleep: clock.sleep,
+        settleWindowSec: 45,
+        settlePollSec: 5,
+      },
+    );
+    if (!('ok' in result) || !result.ok) throw new Error('expected ok');
+    const data = result.data as { status?: string; mergeable?: boolean; blocker?: string; elapsed_sec?: number };
+    expect(data.status).toBe('no_checks_yet');
+    expect(data.mergeable).toBe(false);
+    expect(data.blocker).toBe('checks_not_registered');
+    expect(data.elapsed_sec).toBeGreaterThan(0);
+  });
+
+  test('empty pipeline + draft MR → no_checks_configured + draft blocker', async () => {
     onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git');
     onExec(
       'glab api projects/org%2Frepo/merge_requests/4',
@@ -249,12 +294,12 @@ describe('prWaitCiGitlab — full poll path', () => {
       throw new Error(`expected ok result, got ${JSON.stringify(result)}`);
     }
     const data = result.data as { status?: string; mergeable?: boolean; blocker?: string };
-    expect(data.status).toBe('no_checks_required');
+    expect(data.status).toBe('no_checks_configured');
     expect(data.mergeable).toBe(false);
     expect(data.blocker).toBe('draft');
   });
 
-  test('empty pipeline + conflicts → no_checks_required + conflicts blocker', async () => {
+  test('empty pipeline + conflicts → no_checks_configured + conflicts blocker', async () => {
     onExec('git remote get-url origin', 'https://gitlab.com/org/repo.git');
     onExec(
       'glab api projects/org%2Frepo/merge_requests/5',
@@ -276,7 +321,7 @@ describe('prWaitCiGitlab — full poll path', () => {
       throw new Error(`expected ok result, got ${JSON.stringify(result)}`);
     }
     const data = result.data as { status?: string; mergeable?: boolean; blocker?: string };
-    expect(data.status).toBe('no_checks_required');
+    expect(data.status).toBe('no_checks_configured');
     expect(data.mergeable).toBe(false);
     expect(data.blocker).toBe('conflicts');
   });

--- a/lib/adapters/pr-wait-ci-gitlab.ts
+++ b/lib/adapters/pr-wait-ci-gitlab.ts
@@ -19,7 +19,8 @@
  */
 
 import { execSync } from 'child_process';
-import { gitlabApiMr } from '../gitlab-api.js';
+import { gitlabApiMr, type GitlabMr } from '../gitlab-api.js';
+import { ciListRunsGitlab } from './ci-list-runs-gitlab.js';
 import {
   defaultDeps,
   runPollLoop,
@@ -28,6 +29,7 @@ import {
 } from '../pr-wait-ci-poll.js';
 import type {
   AdapterResult,
+  CiListRunsArgs,
   PrWaitCiArgs,
   PrWaitCiNoChecksResponse,
   PrWaitCiResponse,
@@ -129,30 +131,147 @@ function emptyPipelineBlockerGitlab(
   return null;
 }
 
+/**
+ * Settle knobs for the GitLab twin of the #508 fix. GitLab creates the pipeline
+ * asynchronously after the MR, so `head_pipeline: null` has exactly the same
+ * two meanings as GitHub's empty rollup — "no CI here" and "no CI *yet*".
+ */
+export const SETTLE_WINDOW_SEC_GITLAB = 45;
+export const SETTLE_POLL_SEC_GITLAB = 5;
+
+export interface SettleDepsGitlab {
+  probe: (number: number, repo?: string) => GitlabMr;
+  /** Discriminated: a FAILED query is not a query that found nothing (#508). */
+  pendingRuns: (
+    headSha: string,
+    repo?: string,
+  ) => Promise<
+    | { ok: true; runs: { run_id: number; workflow_name: string; status: string }[] }
+    | { ok: false }
+  >;
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+  settleWindowSec: number;
+  settlePollSec: number;
+}
+
+/** GitLab pipeline statuses that mean "still going to report". */
+function isUnfinishedGitlab(status: string): boolean {
+  const s = status.toLowerCase();
+  return s === 'created' || s === 'waiting_for_resource' || s === 'preparing' ||
+    s === 'pending' || s === 'running' || s === 'scheduled' || s === 'manual';
+}
+
+/** Canonical source-branch head; `diff_refs.head_sha` wins over the top-level `sha`. */
+function headShaOf(mr: GitlabMr): string {
+  return mr.diff_refs?.head_sha ?? mr.sha ?? '';
+}
+
+export function defaultSettleDepsGitlab(
+  overrides: Partial<SettleDepsGitlab> = {},
+): SettleDepsGitlab {
+  return {
+    probe: (n, repo) => gitlabApiMr(n, parseSlugOpts(repo)),
+    pendingRuns: async (headSha, repo) => {
+      const listArgs: CiListRunsArgs = {
+        ref: headSha,
+        limit: 20,
+        ...(repo !== undefined ? { repo } : {}),
+      };
+      try {
+        const res = await ciListRunsGitlab(listArgs);
+        if (!('ok' in res) || !res.ok || !Array.isArray(res.data)) return { ok: false };
+        return {
+          ok: true,
+          runs: res.data
+            .filter((r) => r.head_sha === headSha && isUnfinishedGitlab(r.status))
+            .map((r) => ({ run_id: r.run_id, workflow_name: r.workflow_name, status: r.status })),
+        };
+      } catch {
+        return { ok: false };
+      }
+    },
+    sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+    now: () => Date.now(),
+    settleWindowSec: SETTLE_WINDOW_SEC_GITLAB,
+    settlePollSec: SETTLE_POLL_SEC_GITLAB,
+    ...overrides,
+  };
+}
+
 export async function prWaitCiGitlab(
   args: PrWaitCiArgs,
+  depsIn: Partial<SettleDepsGitlab> = {},
 ): Promise<AdapterResult<PrWaitCiResponse>> {
   try {
-    // #416 short-circuit. One probe BEFORE entering the polling loop: if the
-    // MR has no pipeline data at all (neither `head_pipeline` nor `pipeline`),
-    // there is nothing to settle and we return at t=0.
-    const probeStart = Date.now();
-    const mr = gitlabApiMr(args.number, parseSlugOpts(args.repo));
-    const hasPipeline =
-      (mr.head_pipeline !== undefined && mr.head_pipeline !== null) ||
-      (mr.pipeline !== undefined && mr.pipeline !== null);
-    if (!hasPipeline) {
+    // #508 — the GitLab half. #416 returned at t=0 when the MR carried no
+    // pipeline data. GitLab creates the pipeline ASYNCHRONOUSLY after the MR, so
+    // `head_pipeline: null` is also exactly what "the pipeline has not been
+    // created yet" looks like. Same ambiguity as the GitHub empty rollup, same
+    // fix: keep probing, then cross-check the ref before concluding.
+    const deps = defaultSettleDepsGitlab({
+      ...(args.settle_window_sec !== undefined
+        ? { settleWindowSec: args.settle_window_sec }
+        : {}),
+      ...depsIn,
+    });
+    const probeStart = deps.now();
+    let mr = deps.probe(args.number, args.repo);
+    const hasPipelineNow = (m: GitlabMr): boolean =>
+      (m.head_pipeline !== undefined && m.head_pipeline !== null) ||
+      (m.pipeline !== undefined && m.pipeline !== null);
+    if (!hasPipelineNow(mr)) {
+      // A hard blocker makes waiting pointless — a closed/merged/draft MR is not
+      // going to start a pipeline.
       const blocker = emptyPipelineBlockerGitlab(mr);
-      const elapsedSec = Math.max(0, Math.floor((Date.now() - probeStart) / 1000));
-      const data: PrWaitCiNoChecksResponse = {
-        number: args.number,
-        status: 'no_checks_required',
-        elapsed_sec: elapsedSec,
-        mergeable: blocker === null,
-        url: mr.web_url ?? '',
-        ...(blocker !== null ? { blocker } : {}),
-      };
-      return { ok: true, data };
+      if (blocker !== null) {
+        return {
+          ok: true,
+          data: {
+            number: args.number,
+            status: 'no_checks_configured',
+            elapsed_sec: Math.max(0, Math.floor((deps.now() - probeStart) / 1000)),
+            settled_sec: 0,
+            mergeable: false,
+            blocker,
+            url: mr.web_url ?? '',
+          },
+        };
+      }
+
+      const deadline = probeStart + deps.settleWindowSec * 1000;
+      while (!hasPipelineNow(mr) && deps.now() < deadline) {
+        await deps.sleep(deps.settlePollSec * 1000);
+        mr = deps.probe(args.number, args.repo);
+      }
+
+      if (!hasPipelineNow(mr)) {
+        const headSha = headShaOf(mr);
+        const evidence = headSha === ''
+          ? ({ ok: false } as const)
+          : await deps.pendingRuns(headSha, args.repo);
+        const settledSec = Math.max(0, Math.floor((deps.now() - probeStart) / 1000));
+        // Only a query that SUCCEEDED and found nothing may claim "no CI here".
+        const certified = evidence.ok && evidence.runs.length === 0;
+        const runs = evidence.ok ? evidence.runs : [];
+        const blocker = certified
+          ? undefined
+          : runs.length > 0
+            ? 'checks_not_registered'
+            : 'evidence_unavailable';
+        const data: PrWaitCiNoChecksResponse = {
+          number: args.number,
+          status: certified ? 'no_checks_configured' : 'no_checks_yet',
+          elapsed_sec: settledSec,
+          settled_sec: settledSec,
+          mergeable: certified,
+          url: mr.web_url ?? '',
+          ...(blocker !== undefined ? { blocker } : {}),
+          ...(runs.length > 0 ? { pending_runs: runs } : {}),
+        };
+        return { ok: true, data };
+      }
+      // A pipeline appeared during the window — fall through to the poll loop.
     }
 
     const pollArgs: PollArgs = {

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -267,6 +267,13 @@ export interface PrWaitCiArgs {
   poll_interval_sec: number;
   timeout_sec: number;
   repo?: string;
+  /**
+   * How long to keep re-probing an empty rollup / absent pipeline before
+   * concluding the repo has no checks for this ref (#508). Not a CI timeout —
+   * once one check registers, `timeout_sec` governs from there. `0` disables
+   * the window and restores #416's t=0 behaviour; only tests should do that.
+   */
+  settle_window_sec?: number;
 }
 
 export type PrWaitCiFinalState = 'passed' | 'failed' | 'timed_out';
@@ -293,23 +300,46 @@ export interface PrWaitCiPolledResponse {
 }
 
 /**
- * Short-circuit return shape (#416). Reached on the very first probe when the
- * PR's status-check rollup is empty — there is nothing to settle, so the
- * "wait until CI is settled" semantics are satisfied at t=0. `mergeable` and
- * an optional `blocker` distinguish the happy path (PR is ready to merge)
- * from the obstructed path (draft / conflicts / closed PR).
+ * The two ways "this PR has no checks" can be true (#508). They are different
+ * facts and only one of them is safe, which is why they are different tokens.
  *
- * `elapsed_sec` is intentionally a small integer (the wall-clock cost of the
- * single probe), not a polling-loop duration.
+ * - `no_checks_configured` — the settle window elapsed and nothing indicates CI
+ *   is coming. The repo genuinely runs no checks for this ref.
+ * - `no_checks_yet` — the settle window elapsed but a CI run EXISTS for the head
+ *   SHA that has not registered as a check. Checks are coming; we ran out of
+ *   patience, not out of CI. **Never merge on this.**
+ *
+ * Replaces the single `no_checks_required` of #416, which meant both. That token
+ * is deliberately gone rather than aliased: its plain-English name reads as
+ * "nothing is wrong" (`skills/mmr/SKILL.md` calls it "a trap" in as many words),
+ * and keeping it as a synonym would preserve exactly the ambiguity this fixes.
+ * Callers that allowlist on `passed` are unaffected; anything matching the old
+ * literal now fails to match, which is the intended forcing function.
+ */
+export type PrWaitCiNoChecksStatus = 'no_checks_configured' | 'no_checks_yet';
+
+/**
+ * Short-circuit return shape (#416, reworked by #508). Reached when the PR's
+ * status-check rollup is still empty after the settle window.
+ *
+ * #416 returned this at t=0 on the first empty rollup. That is indistinguishable
+ * from a check that is merely QUEUED — the rollup is empty in both cases — so a
+ * PR whose CI had not yet started reported a definite, successful-sounding
+ * verdict with `elapsed_sec: 0`. `mergeable` and an optional `blocker`
+ * distinguish the happy path from the obstructed one (draft / conflicts / closed).
  */
 export interface PrWaitCiNoChecksResponse {
   number: number;
-  status: 'no_checks_required';
+  status: PrWaitCiNoChecksStatus;
   elapsed_sec: number;
   mergeable: boolean;
   /** Reason the PR is not mergeable today (e.g. `draft`, `conflicts`, `closed`). Omitted when mergeable. */
   blocker?: string;
   url: string;
+  /** Seconds spent waiting for checks to register before concluding. 0 only when a hard blocker made waiting pointless. */
+  settled_sec: number;
+  /** Present on `no_checks_yet`: the un-registered runs that prove CI is coming. */
+  pending_runs?: { run_id: number; workflow_name: string; status: string }[];
 }
 
 export type PrWaitCiResponse = PrWaitCiPolledResponse | PrWaitCiNoChecksResponse;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server-sdlc",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "SDLC workflow MCP server for Claude Code agents",
   "type": "module",
   "scripts": {

--- a/tests/pr_wait_ci.test.ts
+++ b/tests/pr_wait_ci.test.ts
@@ -601,7 +601,7 @@ describe('pr_wait_ci handler', () => {
   // "wait until CI is settled" — if there are no checks to settle, that
   // condition is satisfied at t=0.
 
-  test('test_pr_wait_ci_empty_rollup_mergeable — empty rollup + mergeable returns no_checks_required immediately', async () => {
+  test('test_pr_wait_ci_empty_rollup_mergeable — empty rollup no longer certifies "no CI" (#508)', async () => {
     setExecMock((cmd: string) => {
       if (cmd.startsWith('git remote'))
         return 'https://github.com/org/repo.git\n';
@@ -620,23 +620,29 @@ describe('pr_wait_ci handler', () => {
     const result = await handler.execute({
       number: 42,
       poll_interval_sec: 5,
-      // Generous timeout — proves the short-circuit returns *before* any sleep.
       timeout_sec: 1800,
+      // #508 knob. Zero restores the old t=0 probe so this stays a fast unit
+      // test; the settle loop itself is covered with a fake clock in
+      // lib/adapters/pr-wait-ci-github.test.ts.
+      settle_window_sec: 0,
     });
     const data = parseResult(result);
     expect(data.ok).toBe(true);
-    expect(data.status).toBe('no_checks_required');
-    expect(data.mergeable).toBe(true);
+    // NOT `no_checks_configured`. The exec mock has no `gh run list`, so the
+    // ref cross-check cannot run — and a query that did not run may never
+    // certify "this repo has no CI". That is the whole point of #508: the
+    // mergeable-looking answer is the one that must be earned.
+    expect(data.status).toBe('no_checks_yet');
+    expect(data.mergeable).toBe(false);
+    expect(data.blocker).toBe('evidence_unavailable');
     expect(typeof data.elapsed_sec).toBe('number');
-    expect(data.elapsed_sec).toBeLessThan(5); // far less than poll_interval
-    expect(data.blocker).toBeUndefined();
     expect(data.url).toBe('https://github.com/org/repo/pull/42');
     // `final_state` is the polling-loop shape — must NOT appear on the
     // short-circuit envelope (would confuse callers reading the discriminator).
     expect(data.final_state).toBeUndefined();
   });
 
-  test('test_pr_wait_ci_empty_rollup_with_conflict — empty rollup + conflict returns no_checks_required + blocker', async () => {
+  test('test_pr_wait_ci_empty_rollup_with_conflict — empty rollup + conflict returns no_checks_configured + blocker', async () => {
     setExecMock((cmd: string) => {
       if (cmd.startsWith('git remote'))
         return 'https://github.com/org/repo.git\n';
@@ -659,13 +665,13 @@ describe('pr_wait_ci handler', () => {
     });
     const data = parseResult(result);
     expect(data.ok).toBe(true);
-    expect(data.status).toBe('no_checks_required');
+    expect(data.status).toBe('no_checks_configured');
     expect(data.mergeable).toBe(false);
     expect(data.blocker).toBe('conflicts');
     expect(data.elapsed_sec).toBeLessThan(5);
   });
 
-  test('test_pr_wait_ci_empty_rollup_draft — empty rollup + draft PR returns no_checks_required + draft blocker', async () => {
+  test('test_pr_wait_ci_empty_rollup_draft — empty rollup + draft PR returns no_checks_configured + draft blocker', async () => {
     setExecMock((cmd: string) => {
       if (cmd.startsWith('git remote'))
         return 'https://github.com/org/repo.git\n';
@@ -684,7 +690,7 @@ describe('pr_wait_ci handler', () => {
     const result = await handler.execute({ number: 44, poll_interval_sec: 5, timeout_sec: 60 });
     const data = parseResult(result);
     expect(data.ok).toBe(true);
-    expect(data.status).toBe('no_checks_required');
+    expect(data.status).toBe('no_checks_configured');
     expect(data.mergeable).toBe(false);
     expect(data.blocker).toBe('draft');
   });


### PR DESCRIPTION
## Summary

`pr_wait_ci` short-circuited on the first empty rollup and returned at t=0 (#416). An empty rollup is **also** exactly what a merely-QUEUED check looks like, so a PR whose CI had not started yet received a definite, successful-sounding verdict with `elapsed_sec: 0`. Both adapters now wait for checks to **register** before concluding a repo runs none, and cross-check the head SHA before deciding.

**BREAKING:** `no_checks_required` is removed and replaced by `no_checks_configured` / `no_checks_yet`. Not aliased — see below. `package.json` → 4.0.0.

## The issue's severity claim was wrong, and the truth is more useful

The issue is titled *"autonomous paths can merge before CI runs."* They cannot, today: `skills/mmr/SKILL.md` already allowlists on `passed`, lists `no_checks_required` as an explicit STOP ("this one is a trap"), and instructs autonomous paths to HALT rather than improvise.

So the live cost was a **spurious halt**, not a bad merge — a healthy PR caught in the check-registration window stops a wave, and the wave pattern's whole justification is autonomous throughput. The safety hole is real but sits in the **API contract**, not the current caller: any future caller reading `no_checks_required` at face value inherits it. Fixing the contract is the durable move; the caller's prose should not be the only thing standing between a queued check and a merge.

GitLab has the same defect for a different reason: it creates the pipeline **asynchronously after the MR**, so `head_pipeline: null` means both things there too.

## Changes

- **Settle window.** Both adapters keep probing while the rollup/pipeline is empty, for `settle_window_sec` (default 45s, now an exposed handler arg). Once one check registers we fall through to the existing poll loop and `timeout_sec` governs from there — it is not a CI timeout.
- **Head-SHA cross-check.** If nothing registers, query CI runs for the head SHA via the existing `ciListRuns` adapters. Only **unfinished** runs count as evidence: a completed run that never produced a check is CI that already came and went (path-filtered job, skipped workflow), and counting it would hold every such PR for the full window forever.
- **Two statuses, one of them safe.** `no_checks_configured` (query succeeded, found nothing) vs `no_checks_yet` (runs exist unregistered, **or** the query could not run). The latter is never `mergeable`.
- **Hard blockers still return at once** — a closed, merged, draft or conflicted PR is not going to start CI, so waiting buys nothing. `settled_sec: 0` there, and that is the one place a zero settle is correct.
- `docs/tools.md` rewritten for the new contract; probe argv gains `headRefOid`.

## A finding from my own first cut

The initial implementation treated a **failed** evidence query as a query that found nothing — which reports `no_checks_configured`, the one answer a caller might merge on. That is an instrument that examined nothing returning the mergeable verdict: precisely the shape this repo is written against (#925, #491, #494).

Now only a query that **succeeded and found nothing** may certify "no CI here". A failed query, or a missing head SHA to anchor it, yields `no_checks_yet` + `blocker: evidence_unavailable`, `mergeable: false`. The `pendingRuns` seam returns a discriminated `{ok:true,runs} | {ok:false}` specifically so the two cannot be collapsed again by accident.

## Why the old token is removed, not aliased

Its plain-English name is the trap — `skills/mmr/SKILL.md` says so in as many words. Keeping it as a synonym would preserve exactly the ambiguity this fixes. Removing it means callers matching the old literal stop matching, which is the intended forcing function. Callers that allowlist on `final_state === 'passed'` are unaffected.

A companion PR in `claudecode-workflow` updates `/mmr`'s status list, honouring its own rule: *"If `pr_wait_ci` ever gains a new status, it must land here as an explicit STOP before anything merges on it."* Both new values are already covered by its catch-all, so there is no window where the caller is permissive.

## Linked Issues

Closes #508

## Test Plan

- **`bun test`** — 2451 pass / 4 fail. All 4 are `wave_finalize` and **pre-existing on `main`**, proved by stashing every local change and re-running. Filed as #509 (they fail locally while CI is green — the suite is not hermetic, which also makes `validate.sh` exit 1 on a clean `main` locally).
- **`bunx tsc --noEmit`** — clean.
- **11 new tests**, all driven through injected clock/sleep seams so the settle loop is covered without 45s of real wall-clock. A test that burned real time would be deleted by whoever next ran the suite, and this behaviour would go uncovered.
- **Mutation-tested in both directions.** Collapsing a failed evidence query into "configured" kills 3 tests; removing the settle window kills 3 different ones, including "a check that registers DURING the window falls through to the poll loop" — the actual fix. My *first* mutation attempt is worth naming: it introduced a temporal-dead-zone `ReferenceError`, so the tests failed by **crashing** rather than by behaving wrongly. That result was discarded and the mutation redone cleanly; a mutation that kills tests for the wrong reason proves nothing.
- **trivy** — 1 HIGH (`fast-uri` CVE-2026-16221) over 1 manifest at `0a2840f`. Pre-existing, unrelated to this changeset, deferred to #510 with the nested-copy probe already run (single hoisted copy, so a top-level bump genuinely takes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKHqrhTwstTzRseVEoExbS