### PR TITLE
fix(deps): raise fast-uri and ip-address above their CVE floors

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,8 +16,10 @@
     },
   },
   "overrides": {
-    "fast-uri": "^3.1.2",
+    "express-rate-limit": "^8.6.2",
+    "fast-uri": "^3.1.5",
     "hono": "^4.12.25",
+    "ip-address": "^10.3.1",
   },
   "packages": {
     "@hono/node-server": ["@hono/node-server@1.19.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw=="],
@@ -82,11 +84,11 @@
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
-    "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
+    "express-rate-limit": ["express-rate-limit@8.6.2", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
+    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
@@ -114,7 +116,7 @@
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
-    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+    "ip-address": ["ip-address@10.4.0", "", {}, "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 

--- a/lib/dependency-floors.test.ts
+++ b/lib/dependency-floors.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Vulnerable dependencies stay fixed (#504).
+ *
+ * Three HIGH advisories were live here:
+ *   fast-uri    CVE-2026-16221  (fixed 3.1.4)
+ *   fast-uri    CVE-2026-18446  (fixed 3.1.5)
+ *   ip-address  CVE-2026-69192  (fixed 10.3.1)
+ *
+ * #504 asked for fast-uri 3.1.4, which still leaves CVE-2026-18446 live —
+ * the two advisories have different fixed versions and only the later one covers
+ * both.
+ *
+ * **This reads the INSTALLED TREE, not the lockfile.** `trivy` parses `bun.lock`
+ * and is therefore structurally blind to a vulnerable copy nested under a parent
+ * whose declared range excludes the fix: the top-level entry reads fixed, the
+ * scan agrees, and the CVE is live. That is precisely how a bump becomes
+ * cosmetic, and `ip-address` was one range away from it here —
+ * express-rate-limit <8.6.0 pinned it at EXACTLY 10.1.0, so forcing a fix
+ * without also bumping the parent would have produced a private nested copy.
+ *
+ * The probe is validated against a planted nested copy before its zeroes are
+ * trusted: a probe that has only ever run on a clean tree has not been tested.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+
+const REPO = resolve(import.meta.dir, "..");
+
+/**
+ * Every installed copy of `pkg`, at any depth, read in a SUBPROCESS.
+ *
+ * Not `node:fs` in-process, and not `node:child_process` either: this repo has
+ * known cross-file `mock.module` leakage (sdlc#456), and BOTH are mocked by
+ * other files. An in-process fs walk read a mocked filesystem; importing
+ * `spawnSync` then failed outright with "Export named 'spawnSync' not found in
+ * module 'node:child_process'" — a partial mock replacing the real module.
+ *
+ * `Bun.spawnSync` is a GLOBAL, so there is no module specifier to intercept. The
+ * question here is about bytes on disk, so it is asked of the disk, from a
+ * process nothing has mocked.
+ */
+function installedVersions(pkg: string): { version: string; path: string }[] {
+  const script = `
+import json, os, sys
+root, want = sys.argv[1], sys.argv[2]
+for dirpath, dirnames, filenames in os.walk(root):
+    if "package.json" not in filenames:
+        continue
+    f = os.path.join(dirpath, "package.json")
+    try:
+        d = json.load(open(f))
+    except Exception:
+        continue
+    # Identity comes from \`name\` IN THE FILE, never from the path: path
+    # matching fails in both directions — an absolute prefix containing
+    # /node_modules/ makes a top-level copy read as nested, and a package's own
+    # benchmark/package.json declares a different version of a similar name.
+    if d.get("name") == want and isinstance(d.get("version"), str):
+        print(d["version"], f)
+`;
+  const proc = Bun.spawnSync(["python3", "-c", script, `${REPO}/node_modules`, pkg]);
+  if (proc.exitCode !== 0) {
+    throw new Error(`probe failed: ${proc.stderr.toString()}`);
+  }
+  return proc.stdout
+    .toString()
+    .split("\n")
+    .filter(Boolean)
+    .map((l) => {
+      const [version, ...rest] = l.split(" ");
+      return { version, path: rest.join(" ") };
+    });
+}
+
+function atLeast(version: string, floor: string): boolean {
+  const a = version.split(".").map(Number);
+  const b = floor.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((a[i] ?? 0) > (b[i] ?? 0)) return true;
+    if ((a[i] ?? 0) < (b[i] ?? 0)) return false;
+  }
+  return true;
+}
+
+function readPackageJson(): any {
+  const proc = Bun.spawnSync([
+    "python3", "-c", "import sys;print(open(sys.argv[1]).read())", `${REPO}/package.json`,
+  ]);
+  return JSON.parse(proc.stdout.toString());
+}
+
+function plant(relPath: string, body: string) {
+  Bun.spawnSync([
+    "python3", "-c",
+    "import os,sys;os.makedirs(os.path.dirname(sys.argv[1]),exist_ok=True);open(sys.argv[1],'w').write(sys.argv[2])",
+    `${REPO}/${relPath}`, body,
+  ]);
+}
+
+function unplant(relDir: string) {
+  Bun.spawnSync([
+    "python3", "-c", "import shutil,sys;shutil.rmtree(sys.argv[1],ignore_errors=True)",
+    `${REPO}/${relDir}`,
+  ]);
+}
+
+describe("dependency floors (#504)", () => {
+  test("the probe can see a NESTED copy", () => {
+    // Validate the instrument before trusting its zeroes. Planted at the depth a
+    // real nested copy lives at; if this is not found, every assertion below is
+    // vacuous rather than reassuring.
+    try {
+      plant(
+        "node_modules/ajv/node_modules/fast-uri/package.json",
+        JSON.stringify({ name: "fast-uri", version: "0.0.1-planted" }),
+      );
+      const hits = installedVersions("fast-uri");
+      expect(hits.some((h) => h.version === "0.0.1-planted")).toBe(true);
+      expect(hits.length).toBeGreaterThan(1);
+    } finally {
+      unplant("node_modules/ajv/node_modules");
+    }
+  });
+
+  for (const [pkg, floor, cves] of [
+    ["fast-uri", "3.1.5", "CVE-2026-16221 (3.1.4), CVE-2026-18446 (3.1.5)"],
+    ["ip-address", "10.3.1", "CVE-2026-69192"],
+  ] as const) {
+    test(`${pkg} is at or above ${floor} in EVERY installed copy — ${cves}`, () => {
+      const hits = installedVersions(pkg);
+      // A zero here would mean the dependency chain vanished rather than that
+      // the pin held — chain-absence wearing a pass's clothes.
+      expect(hits.length).toBeGreaterThan(0);
+      const bad = hits.filter((h) => !atLeast(h.version, floor));
+      expect(bad).toEqual([]);
+    });
+  }
+
+  test("express-rate-limit is new enough to ACCEPT a fixed ip-address", () => {
+    // <8.6.0 pinned ip-address at exactly 10.1.0. Overriding ip-address without
+    // this bump forces a version the parent does not declare, which is how a
+    // private nested copy appears and the fix becomes cosmetic.
+    const hits = installedVersions("express-rate-limit");
+    expect(hits.length).toBeGreaterThan(0);
+    for (const h of hits) expect(atLeast(h.version, "8.6.0")).toBe(true);
+  });
+
+  test("the floors are DECLARED, not just currently resolved", () => {
+    // A lockfile that happens to resolve high is not a constraint; the next
+    // `bun install` can walk it back without anyone noticing.
+    const o = readPackageJson().overrides ?? {};
+    expect(o["fast-uri"]).toBeDefined();
+    expect(o["ip-address"]).toBeDefined();
+    expect(o["express-rate-limit"]).toBeDefined();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "typescript": "^5.7.0"
   },
   "overrides": {
-    "fast-uri": "^3.1.2",
-    "hono": "^4.12.25"
+    "fast-uri": "^3.1.5",
+    "hono": "^4.12.25",
+    "ip-address": "^10.3.1",
+    "express-rate-limit": "^8.6.2"
   }
 }


### PR DESCRIPTION
## Summary

trivy reports **three** HIGH advisories here, not the one this issue names:

| package | CVE | fixed in |
|---|---|---|
| fast-uri | CVE-2026-16221 | 3.1.4 |
| fast-uri | **CVE-2026-18446** | **3.1.5** |
| ip-address | **CVE-2026-69192** | **10.3.1** |

**#504 asked for `^3.1.4`, which still leaves CVE-2026-18446 live** — the two fast-uri advisories have different fixed versions and only the later covers both.

## ip-address could not simply be raised

`express-rate-limit` **<8.6.0 pins it at exactly `10.1.0`**, so an override alone forces a version its parent does not declare — and bun's answer to that is a **private nested copy**: the top-level lockfile entry reads fixed while the vulnerable copy is what loads. 8.6.0 relaxed the pin to `^10.2.0`, and the MCP SDK already accepts `^8.2.1`, so the bump resolves rather than being forced.

## Verified against the installed tree

trivy parses `bun.lock` and is structurally blind to exactly the nested-copy case ip-address was one range away from — **a green scan would not have proven this fixed.** The new test walks `node_modules` reading `name` from each manifest (never inferring identity from the path, which fails in both directions) and asserts every installed copy clears the floor:

```
fast-uri            3.1.5
ip-address         10.4.0
express-rate-limit  8.6.2
```

It **validates its own probe first**, planting a nested copy and requiring it to be found — a probe that has only run on a clean tree has not been tested.

## The probe runs out-of-process, and that is not incidental

This repo has known cross-file `mock.module` leakage (#456), and **both** modules the test needed are mocked by other files:

- an in-process `fs` walk **passed alone and failed under the full suite** — it was reading a *mocked* filesystem
- switching to `node:child_process` then failed outright: `Export named 'spawnSync' not found in module 'node:child_process'` — a partial mock replacing the real module

`Bun.spawnSync` is a global with no specifier to intercept, so a question about bytes on disk is asked from a process nothing has mocked. This is #456 biting a new file; worth noting for anyone else writing filesystem assertions here.

## Test Plan

- `./scripts/ci/validate.sh` — **2454 pass, 4 fail**
- **Suite parity:** those same 4 `wave_finalize` failures are pre-existing on `main` (#509, the non-hermetic suite) — verified by stashing and re-running on `main`. **No delta from this change.**
- `trivy fs --severity HIGH,CRITICAL` — **0 vulnerabilities** (was 3)
- **5 new tests**, confirmed running *inside* the full suite via the junit report, not merely in isolation
- **Mutation under the full suite:** walking `fast-uri` back to 3.1.3 takes failures from 4 → 5

## Linked Issues

Closes #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZC3F9Qo7aX7QasQkdHPs7