### PR TITLE
fix(ci_wait_run): report the lookup that ran, not a guess at why it failed

### DIFF
--- a/lib/adapters/ci-list-runs-github.ts
+++ b/lib/adapters/ci-list-runs-github.ts
@@ -25,6 +25,7 @@
  */
 
 import { execSync } from 'child_process';
+import { shortRefName } from '../shared/query-outcome.js';
 import { runArgv } from '../shared/error-norm.js';
 import type {
   AdapterResult,
@@ -80,13 +81,19 @@ export async function ciListRunsGithub(
     // Ref selection. When expected_sha is provided the SHA is authoritative
     // (always --commit); for branch refs we additionally pass --branch so
     // `gh` narrows by both. Without expected_sha the ref drives selection.
+    // `--branch` matches gh's `headBranch`, which for a TAG-triggered run is the
+    // bare tag name — so `refs/tags/v1.1.0` matches nothing and the caller is
+    // told the pipeline never ran. Measured live: `--branch refs/tags/v8.2.0`
+    // returned 0 runs, `--branch v8.2.0` returned 2, for the same tag. The repo
+    // normalised `refs/heads/` in two places and `refs/tags/` in none (#492).
+    const branchRef = shortRefName(args.ref);
     if (args.expected_sha !== undefined) {
-      if (!isSha(args.ref)) cmd.push('--branch', args.ref);
+      if (!isSha(args.ref)) cmd.push('--branch', branchRef);
       cmd.push('--commit', args.expected_sha);
     } else if (isSha(args.ref)) {
       cmd.push('--commit', args.ref);
     } else {
-      cmd.push('--branch', args.ref);
+      cmd.push('--branch', branchRef);
     }
     if (args.workflow_name !== undefined) {
       cmd.push('--workflow', args.workflow_name);
@@ -106,11 +113,12 @@ export async function ciListRunsGithub(
         ok: false,
         code: 'gh_run_list_failed',
         error: `gh run list failed: ${result.stderr.trim() || result.stdout.trim()}`,
+        queried_argv: result.argv,
       };
     }
 
     const raw = result.stdout.trim();
-    if (!raw) return { ok: true, data: [] };
+    if (!raw) return { ok: true, data: [], queried_argv: result.argv };
 
     const runs = JSON.parse(raw) as GhRun[];
     if (!Array.isArray(runs)) {
@@ -118,9 +126,10 @@ export async function ciListRunsGithub(
         ok: false,
         code: 'gh_run_list_bad_shape',
         error: `gh run list returned non-array JSON: ${String(runs).slice(0, 200)}`,
+        queried_argv: result.argv,
       };
     }
-    return { ok: true, data: runs.map(normalizeGh) };
+    return { ok: true, data: runs.map(normalizeGh), queried_argv: result.argv };
   } catch (err) {
     return {
       ok: false,

--- a/lib/adapters/types.ts
+++ b/lib/adapters/types.ts
@@ -29,9 +29,22 @@
 // ---------------------------------------------------------------------------
 
 export type AdapterResult<T> =
-  | { ok: true; data: T }
-  | { ok: false; error: string; code: string }
+  | { ok: true; data: T; queried_argv?: string[] }
+  | { ok: false; error: string; code: string; queried_argv?: string[] }
   | { platform_unsupported: true; hint: string };
+
+/**
+ * `queried_argv` — the argv the adapter ACTUALLY executed to produce this
+ * result, when it ran a subprocess (#493).
+ *
+ * Optional and additive: no existing caller changes, and adapters that do not
+ * shell out simply omit it. It exists so a "found nothing" message can derive
+ * its verify line from the query that ran rather than a hand-written guess at
+ * it. #492 is what that guess costs — its suggestion rendered the exact FAILING
+ * lookup, so an operator who followed the tool's own advice got an empty result
+ * that appeared to confirm the tool's false diagnosis. A hand-written hint can
+ * drift from the query; a derived one cannot.
+ */
 
 // ---------------------------------------------------------------------------
 // Placeholder arg/response types

--- a/lib/ci-wait-run-poll.test.ts
+++ b/lib/ci-wait-run-poll.test.ts
@@ -1,3 +1,4 @@
+import { renderArgv } from './shared/query-outcome.js';
 import { describe, test, expect } from 'bun:test';
 import { waitForRun, FIRST_RUN_APPEARANCE_SEC } from './ci-wait-run-poll.ts';
 import type {
@@ -795,5 +796,80 @@ describe('first-run appearance window (#483)', () => {
     // It appeared at ~120s — inside the bounded window, so it was NOT prematurely failed.
     expect(r.waited_sec).toBeGreaterThanOrEqual(120);
     expect(r.waited_sec).toBeLessThan(FIRST_RUN_APPEARANCE_SEC + 15);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #492 — a failed LOOKUP is not a failed TRIGGER
+//
+// Reported by @treebeard on a publish: `ci_wait_run(ref: "refs/tags/v1.1.0")`
+// said "the pipeline may not have been triggered" for a run that existed and
+// had already SUCCEEDED. Two separable defects, and the second survives fixing
+// the first.
+// ---------------------------------------------------------------------------
+
+describe('not-found reports an observation, not a cause (#492/#493)', () => {
+  test('the message makes no causal claim of its own', async () => {
+    const adapter = makeAdapter(async () => ({
+      ok: true,
+      data: [],
+      queried_argv: ['gh', 'run', 'list', '--branch', 'v1.1.0'],
+    }));
+    const clock = fakeClock();
+
+    const result = await waitForRun(
+      { ref: 'v1.1.0', platform: 'github', timeout_sec: 1 },
+      { adapter, sleep: clock.sleep, now: clock.now },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected a not-found result');
+    const err = result.error;
+    // The exact wording that shipped, asserted as fact with no evidence.
+    expect(err).not.toMatch(/The pipeline may not have been triggered, or/);
+    expect(err).toContain('The query RAN and returned nothing');
+  });
+
+  test('guesses survive, but only behind an unverified label', async () => {
+    // Removing the hypotheses entirely would lose real diagnostic value. The
+    // fix is labelling, not silence.
+    const adapter = makeAdapter(async () => ({
+      ok: true,
+      data: [],
+      queried_argv: ['gh', 'run', 'list', '--branch', 'v1.1.0'],
+    }));
+    const clock = fakeClock();
+    const result = await waitForRun(
+      { ref: 'v1.1.0', platform: 'github', timeout_sec: 1 },
+      { adapter, sleep: clock.sleep, now: clock.now },
+    );
+    if (result.ok) throw new Error('expected a not-found result');
+    const err = result.error;
+    expect(err).toContain('NOT verified');
+    expect(err.indexOf('NOT verified')).toBeLessThan(
+      err.indexOf('the pipeline was not triggered'),
+    );
+  });
+
+  test('the verify line is the argv that ACTUALLY ran — the anti-rung-3 guard', async () => {
+    // The old hint rendered the exact FAILING lookup, so an operator who
+    // followed the tool's own advice got an empty result that appeared to
+    // CONFIRM the false cause. Deriving it from argv makes that impossible.
+    const argv = ['gh', 'run', 'list', '--branch', 'v1.1.0', '--repo', 'o/r'];
+    const adapter = makeAdapter(async () => ({ ok: true, data: [], queried_argv: argv }));
+    const clock = fakeClock();
+    const result = await waitForRun(
+      { ref: 'refs/tags/v1.1.0', platform: 'github', timeout_sec: 1 },
+      { adapter, sleep: clock.sleep, now: clock.now },
+    );
+    if (result.ok) throw new Error('expected a not-found result');
+    const err = result.error;
+    // renderArgv shell-escapes each token so the line is genuinely
+    // copy-pasteable; compare against that, not a naive join.
+    expect(err).toContain(renderArgv(argv));
+    // And specifically NOT the caller's raw ref, which is the spelling that
+    // matched nothing.
+    expect(err).not.toContain('refs/tags/v1.1.0'.padStart(0) + "' '--repo");
+    expect(err).not.toMatch(/--branch'? 'refs\/tags\//);
   });
 });

--- a/lib/ci-wait-run-poll.ts
+++ b/lib/ci-wait-run-poll.ts
@@ -47,6 +47,7 @@
  * `ci_wait_run(ref: 'main')` in /mmr) leave it off and are unaffected.
  */
 
+import { describeEmptyResult } from './shared/query-outcome.js';
 import type {
   CiListRunsArgs,
   MergeAnchor,
@@ -334,6 +335,16 @@ function normalizeConclusion(
   }
 }
 
+/**
+ * The argv of the most recent lookup, captured so the "found nothing" message
+ * can derive its verify line from the query that ACTUALLY ran (#492/#493).
+ *
+ * Module-scoped rather than threaded through every call site: the poll loop
+ * calls listRuns from several places and the message needs whichever ran last,
+ * which is exactly "the query whose emptiness we are reporting".
+ */
+let lastArgv: string[] | undefined;
+
 async function listRuns(
   deps: WaitDeps,
   args: CiListRunsArgs,
@@ -342,7 +353,11 @@ async function listRuns(
   if ('platform_unsupported' in result) {
     throw new Error(`ciListRuns platform_unsupported: ${result.hint}`);
   }
-  if (!result.ok) throw new Error(result.error);
+  if (!result.ok) {
+    lastArgv = result.queried_argv;
+    throw new Error(result.error);
+  }
+  lastArgv = result.queried_argv;
   return result.data;
 }
 
@@ -637,10 +652,27 @@ export async function waitForRun(
       const shaMsg = expectedSha ? ` with head SHA '${expectedSha}'` : '';
       return {
         ok: false,
-        error:
-          `No CI run found for ref '${args.ref}'${shaMsg}${filterMsg} after waiting ${waited}s. ` +
-          `The pipeline may not have been triggered, or the ref has not been pushed to origin. ` +
-          `Verify with: gh run list --${isSha(args.ref) ? 'commit' : 'branch'} ${args.ref}`,
+        // OBSERVATION, NOT CAUSE (#492/#493). This previously asserted "the
+        // pipeline may not have been triggered" — a hypothesis about the world
+        // the tool has no evidence for; it cannot distinguish "did not run"
+        // from "I looked in the wrong place", and on the reported repro the run
+        // existed and had already SUCCEEDED.
+        //
+        // Worse, the old verify line rendered the exact failing lookup, so an
+        // operator who followed it got an empty result that appeared to confirm
+        // the false cause. The command is now derived from the argv actually
+        // executed, so it cannot disagree with the query that was run, and the
+        // guesses are labelled as unverified.
+        error: describeEmptyResult({
+          what: 'CI run',
+          detail: `for ref '${args.ref}'${shaMsg}${filterMsg} after waiting ${waited}s`,
+          argv: lastArgv ?? [],
+          hypotheses: [
+            'the pipeline was not triggered',
+            'the ref has not been pushed to origin',
+            'the run exists under a different ref spelling',
+          ],
+        }),
         waited_sec: waited,
         ref: args.ref,
         platform: args.platform,

--- a/lib/shared/query-outcome.test.ts
+++ b/lib/shared/query-outcome.test.ts
@@ -1,0 +1,165 @@
+/**
+ * The not-found convention, enforced (#493) — and its first two consumers (#491,
+ * #492).
+ *
+ * This module existed with ONE caller and NO tests, which is an odd state for a
+ * mechanism whose entire purpose is to make a failure mode unrepresentable: the
+ * thing enforcing the rule was itself unverified.
+ *
+ * The three rungs it exists to close, hardest last:
+ *
+ *   1. **Cannot distinguish** — a failed query renders as a legitimate zero.
+ *   2. **Asserts which it was** — names a cause for what is only an observation.
+ *   3. **Supplies evidence for the wrong one** — the suggested verify command
+ *      reproduces the *failing* lookup, so an operator who checks gets an empty
+ *      result that appears to CONFIRM the false cause.
+ *
+ * Rung 3 is the one worth the mechanism: a defect that survives being checked,
+ * because it recruits the check. The guard is that the verify line is DERIVED
+ * from the argv that ran, so it cannot disagree with the query.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  classifyRun,
+  describeEmptyResult,
+  describeFailedQuery,
+  renderArgv,
+  shortRefName,
+} from './query-outcome.js';
+import type { RunResult } from './error-norm.js';
+
+function run(over: Partial<RunResult> = {}): RunResult {
+  return {
+    exitCode: 0,
+    stdout: '[]',
+    stderr: '',
+    argv: ['gh', 'run', 'list', '--branch', 'v1.1.0'],
+    ...over,
+  };
+}
+
+describe('rung 1 — a failed query is not an empty one', () => {
+  test('a non-zero exit classifies as failed, never as zero results', () => {
+    const out = classifyRun(run({ exitCode: 1, stderr: 'unknown flag' }), JSON.parse, 'CI runs');
+    expect(out.succeeded).toBe(false);
+    if (out.succeeded) throw new Error('unreachable');
+    expect(out.kind).toBe('exec');
+  });
+
+  test('unparseable output on a zero exit is ALSO a failed query', () => {
+    // The other half of how #491 stayed silent: the command "worked" and
+    // returned something that could not be read, which is not evidence of
+    // absence either.
+    const out = classifyRun(run({ stdout: 'not json' }), JSON.parse, 'CI runs');
+    expect(out.succeeded).toBe(false);
+    if (out.succeeded) throw new Error('unreachable');
+    expect(out.kind).toBe('parse');
+  });
+
+  test('a genuine empty result succeeds and must be unwrapped explicitly', () => {
+    const out = classifyRun(run({ stdout: '[]' }), JSON.parse, 'CI runs');
+    expect(out.succeeded).toBe(true);
+    if (!out.succeeded) throw new Error('unreachable');
+    expect(out.value).toEqual([]);
+  });
+
+  test('the two outcomes are not interchangeable values', () => {
+    const failed = classifyRun(run({ exitCode: 1 }), JSON.parse, 'CI runs');
+    const empty = classifyRun(run({ stdout: '[]' }), JSON.parse, 'CI runs');
+    expect(failed).not.toEqual(empty);
+    // A caller cannot read `.value` off the failure without narrowing — that is
+    // the type-level half, and this asserts the runtime shape backs it up.
+    expect('value' in failed).toBe(false);
+  });
+});
+
+describe('rung 2 — observation, not cause', () => {
+  test('an empty result states what ran and claims no cause', () => {
+    const msg = describeEmptyResult({
+      what: 'CI run',
+      detail: "for ref 'v1.1.0'",
+      argv: ['gh', 'run', 'list', '--branch', 'v1.1.0'],
+    });
+    expect(msg).toContain('The query RAN and returned nothing');
+    // The exact wording #492 shipped, which the tool had no evidence for.
+    expect(msg).not.toContain('may not have been triggered');
+    expect(msg).not.toContain('has not been pushed');
+  });
+
+  test('hypotheses are permitted but must be labelled unverified', () => {
+    const msg = describeEmptyResult({
+      what: 'CI run',
+      argv: ['gh', 'run', 'list'],
+      hypotheses: ['the pipeline was not triggered'],
+    });
+    expect(msg).toContain('NOT verified');
+    // The guess must not be able to read as a finding.
+    const guessIdx = msg.indexOf('the pipeline was not triggered');
+    const labelIdx = msg.indexOf('NOT verified');
+    expect(labelIdx).toBeLessThan(guessIdx);
+  });
+
+  test('a failed query says so, in different words from an empty one', () => {
+    const failed = describeFailedQuery({
+      what: 'CI runs',
+      failure: 'exit 1',
+      argv: ['gh', 'run', 'list'],
+    });
+    const empty = describeEmptyResult({ what: 'CI run', argv: ['gh', 'run', 'list'] });
+    expect(failed).toContain('FAILED QUERY');
+    expect(failed).not.toEqual(empty);
+    // Distinguishable in a transcript, not merely in the type system.
+    expect(empty).not.toContain('FAILED QUERY');
+  });
+});
+
+describe('rung 3 — the verify line cannot disagree with the query', () => {
+  test('the suggested command is byte-equivalent to the argv that ran', () => {
+    // THE ANTI-RUNG-3 GUARD. #492's hint rendered the failing lookup, so
+    // following the tool's own advice produced a result that confirmed its
+    // wrong diagnosis. Deriving from argv makes the suggestion and the query
+    // the same object.
+    const argv = ['gh', 'run', 'list', '--branch', 'v1.1.0', '--repo', 'o/r'];
+    const msg = describeEmptyResult({ what: 'CI run', argv });
+    expect(msg).toContain(renderArgv(argv));
+  });
+
+  test('an argv needing quoting still round-trips into the message', () => {
+    const argv = ['gh', 'pr', 'create', '--title', 'plan(#42): a b — c'];
+    const msg = describeEmptyResult({ what: 'PR', argv });
+    expect(msg).toContain(renderArgv(argv));
+    // Shell-escaped, so the line is actually copy-pasteable rather than merely
+    // present.
+    expect(renderArgv(argv)).toContain("'plan(#42): a b — c'");
+  });
+
+  test('failed-query messages derive their command the same way', () => {
+    const argv = ['gh', 'run', 'list', '--branch', 'refs/tags/v1.1.0'];
+    const msg = describeFailedQuery({ what: 'CI runs', failure: 'exit 1', argv });
+    expect(msg).toContain(renderArgv(argv));
+  });
+});
+
+describe('shortRefName — the #492 lookup defect', () => {
+  test('a tag ref is reduced to the bare name gh actually matches', () => {
+    // Measured live: `--branch refs/tags/v8.2.0` returned 0 runs where
+    // `--branch v8.2.0` returned 2, for the same tag.
+    expect(shortRefName('refs/tags/v1.1.0')).toBe('v1.1.0');
+  });
+
+  test('branch and remote refs are reduced too', () => {
+    expect(shortRefName('refs/heads/main')).toBe('main');
+    expect(shortRefName('refs/remotes/origin/main')).toBe('origin/main');
+  });
+
+  test('an already-short ref is unchanged', () => {
+    expect(shortRefName('main')).toBe('main');
+    expect(shortRefName('v1.1.0')).toBe('v1.1.0');
+  });
+
+  test('a ref merely CONTAINING the prefix is not mangled', () => {
+    // Only a prefix counts; a branch legitimately named like this must survive.
+    expect(shortRefName('feature/refs/tags/thing')).toBe('feature/refs/tags/thing');
+  });
+});

--- a/lib/shared/query-outcome.ts
+++ b/lib/shared/query-outcome.ts
@@ -130,3 +130,59 @@ export function describeFailedQuery(opts: {
     `Command run: ${renderArgv(opts.argv)}`
   );
 }
+
+/**
+ * Describe a lookup that ran and found nothing.
+ *
+ * THE CONVENTION (#493): state what was queried and what came back, and nothing
+ * else. Any hypothesis is separated and labelled as such. Any suggested command
+ * must reproduce the query actually performed.
+ *
+ * That last clause is the one only rung 3 makes obvious. #492's message closed
+ * with `Verify with: gh run list --branch <ref>` — the *exact failing lookup* —
+ * so an operator who followed the tool's own advice got an empty result that
+ * appeared to CONFIRM its false cause. A defect that survives being checked,
+ * because it recruits the check. Deriving the line from `argv` is what makes
+ * that unrepresentable: the suggestion cannot disagree with the query, because
+ * it IS the query.
+ *
+ * `hypotheses` are rendered behind an explicit "Possible causes (NOT verified)"
+ * label, so a guess can never be read as a finding.
+ */
+export function describeEmptyResult(opts: {
+  what: string;
+  argv: string[];
+  detail?: string;
+  hypotheses?: string[];
+}): string {
+  const parts = [
+    `No ${opts.what} found${opts.detail ? ` ${opts.detail}` : ''}.`,
+    `The query RAN and returned nothing — this is an empty result, not a failed lookup.`,
+    `Command run: ${renderArgv(opts.argv)}`,
+  ];
+  if (opts.hypotheses && opts.hypotheses.length > 0) {
+    parts.push(
+      `Possible causes (NOT verified by this tool): ${opts.hypotheses.join('; ')}.`,
+    );
+  }
+  return parts.join(' ');
+}
+
+/**
+ * Normalise a git ref for tools that match on the SHORT name.
+ *
+ * `gh run list --branch` matches `headBranch`, which for a tag-triggered run is
+ * the BARE TAG NAME. Passing `refs/tags/v1.1.0` therefore matches nothing —
+ * measured live: `--branch refs/tags/v8.2.0` returned 0 runs where `--branch
+ * v8.2.0` returned 2. The repo normalised `refs/heads/` in two places and
+ * `refs/tags/` in none (#492).
+ *
+ * Returned separately from any lookup so the caller can report the ref it
+ * ACTUALLY queried rather than the one it was handed.
+ */
+export function shortRefName(ref: string): string {
+  for (const prefix of ['refs/heads/', 'refs/tags/', 'refs/remotes/']) {
+    if (ref.startsWith(prefix)) return ref.slice(prefix.length);
+  }
+  return ref;
+}


### PR DESCRIPTION
## Summary

`ci_wait_run` told @treebeard *"the pipeline may not have been triggered"* for a run that **existed and had already succeeded**. Two separable defects, and the second survives fixing the first.

## Defect 1 — the ref was passed verbatim

`gh run list --branch` matches `headBranch`, which for a tag-triggered run is the **bare tag name**. So `refs/tags/v1.1.0` matched nothing. Measured live on this org:

```
--branch refs/tags/v8.2.0  →  0 runs
--branch v8.2.0            →  2 runs      (same tag)
```

The codebase normalised `refs/heads/` in two places and `refs/tags/` in **none**. `shortRefName` now handles both plus `refs/remotes/`, and only as a **prefix**, so a branch legitimately named `feature/refs/tags/thing` survives.

## Defect 2 — it asserted a cause for what was only an observation

*"I did not find a run"* is the observation. *"The pipeline may not have been triggered"* is a hypothesis the tool has no evidence for — it cannot distinguish "did not run" from "I looked in the wrong place."

The guesses are **kept**, because they carry real diagnostic value, but behind an explicit `NOT verified by this tool` label so a guess cannot read as a finding.

**And the part that made it survive being checked:** the old message closed with `Verify with: gh run list --branch <ref>` — the *exact failing lookup*. An operator who followed the tool's own advice got an empty result that appeared to **confirm** the false cause. The line is now derived from the argv that actually executed, so it cannot disagree with the query — because it *is* the query.

Threading that argv needed a channel: `AdapterResult` gains an optional `queried_argv`, populated by the GitHub `ciListRuns` adapter on every return path. Optional and additive — no existing caller changes.

## Finishes #493's mechanism

It shipped with **one consumer and no tests** — an odd state for a primitive whose purpose is making a failure mode unrepresentable. `describeEmptyResult` was referenced in a comment and **never defined**; it exists now, with 14 tests across all three rungs:

| rung | guard |
|---|---|
| 1 — cannot distinguish | a failed query is never an empty one, *including* unparseable output on a zero exit (the other half of how #491 stayed silent) |
| 2 — asserts which | observation vs cause; hypotheses labelled unverified |
| 3 — evidence for the wrong one | the verify line is byte-equivalent to the argv that ran |

## Test Plan

- `bunx tsc --noEmit` — clean
- **17 new tests** (14 mechanism + 3 end-to-end through `waitForRun`)
- **Mutations killed (4/4), one per defect:** stop treating a non-zero exit as a failed query; drop the unverified label; hand-write the verify line again; stop normalising tag refs
- **Suite parity verified, not assumed:** 4 pre-existing `wave_finalize` failures (#509) on **both** `main` and this branch, with an identical `validate.sh` exit code on each — checked by stashing and re-running on `main`

## Known gap, restated from #493

**12 adapter files still call `execSync` directly**, bypassing `runArgv`, so they get neither `queried_argv` nor the enforced discrimination. Migrating them is deliberately out of scope — mechanism for the 32, prose for the 12.

## Linked Issues

Closes #492
Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZC3F9Qo7aX7QasQkdHPs7