### PR TITLE
fix(gitlab-api): a glab HTTP error body is not data

### DIFF
--- a/lib/gitlab-api-error-body.test.ts
+++ b/lib/gitlab-api-error-body.test.ts
@@ -1,0 +1,141 @@
+/**
+ * `glab api` reports HTTP errors on STDOUT with exit 0 (#502).
+ *
+ * So neither of execGlab's guards fired: not a non-zero exit, not empty output.
+ * The typed wrapper JSON.parsed the error body into its expected shape, every
+ * field came back `undefined`, and the handler emitted a confident `ok: true`
+ * envelope full of falsy data.
+ *
+ * That is the most dangerous shape a validation tool has — a false negative that
+ * reads as an authoritative answer. `spec_validate_structure` reported a
+ * perfectly valid issue as missing all three required sections, with `ok: true`.
+ * The tool did not fail; it answered, wrongly, and nothing downstream could tell.
+ *
+ * The detector is deliberately NARROW. Over-matching would turn real payloads
+ * into errors, which is the same class of damage pointed the other way.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { detectGlabApiError, execGlab } from './gitlab-api.js';
+
+describe('GitLab error bodies are detected (#502)', () => {
+  test('the reported shape — 404 on stdout with exit 0', () => {
+    expect(detectGlabApiError('{"message":"404 Project Not Found"}')).toBe(
+      '404 Project Not Found',
+    );
+  });
+
+  test('403 and other message-carrying errors', () => {
+    expect(detectGlabApiError('{"message":"403 Forbidden"}')).toBe('403 Forbidden');
+  });
+
+  test('the `error` carrier is recognised too', () => {
+    expect(detectGlabApiError('{"error":"insufficient_scope"}')).toBe('insufficient_scope');
+  });
+
+  test('a non-string message is rendered, not dropped', () => {
+    // GitLab returns per-field validation errors as an object or array; losing
+    // them would replace one silent failure with a quieter one.
+    const out = detectGlabApiError('{"message":{"title":["can\'t be blank"]}}');
+    expect(out).toContain('title');
+    expect(out).toContain("can't be blank");
+  });
+});
+
+describe('real payloads are NOT mistaken for errors', () => {
+  test('an issue carrying a `message`-like payload passes through', () => {
+    // A real resource always carries identifying fields; an error body does not.
+    expect(
+      detectGlabApiError('{"iid":42,"title":"x","message":"a commit message"}'),
+    ).toBeUndefined();
+  });
+
+  test('a commit — `message` is its legitimate content', () => {
+    expect(
+      detectGlabApiError('{"id":"abc123","sha":"abc123","message":"fix: thing"}'),
+    ).toBeUndefined();
+  });
+
+  test('an empty collection is a legitimate answer, not an error', () => {
+    expect(detectGlabApiError('[]')).toBeUndefined();
+    expect(detectGlabApiError('{}')).toBeUndefined();
+  });
+
+  test('an array of resources passes through', () => {
+    expect(detectGlabApiError('[{"iid":1},{"iid":2}]')).toBeUndefined();
+  });
+
+  test('non-JSON output is not our business', () => {
+    expect(detectGlabApiError('some plain text')).toBeUndefined();
+    expect(detectGlabApiError('')).toBeUndefined();
+  });
+
+  test('null and scalars do not throw', () => {
+    expect(detectGlabApiError('null')).toBeUndefined();
+    expect(detectGlabApiError('42')).toBeUndefined();
+    expect(detectGlabApiError('"a string"')).toBeUndefined();
+  });
+});
+
+describe('execGlab CONSULTS the detector (#502)', () => {
+  // The detector being correct is not the same claim as execGlab using it — a
+  // mutation disabling the call survived a suite that only tested the pure
+  // function.
+  //
+  // Driven in a SUBPROCESS. execGlab calls execSync, and this repo has known
+  // cross-file `mock.module` leakage (#456): run in-process, these pass alone
+  // and fail under the full suite because execSync is mocked by another file.
+  // A fresh `bun -e` gets a clean module registry, so the real path runs.
+  function inFreshProcess(body: string): { ok: boolean; out: string } {
+    const src = `
+      import { execGlab } from '${import.meta.dir}/gitlab-api.ts';
+      try { ${body} } catch (e) { console.log('THREW:' + String(e)); process.exit(0); }
+    `;
+    const proc = Bun.spawnSync(['bun', '-e', src]);
+    return {
+      ok: proc.exitCode === 0,
+      out: proc.stdout.toString() + proc.stderr.toString(),
+    };
+  }
+
+  test('an error body on stdout with exit 0 THROWS instead of returning', () => {
+    const r = inFreshProcess(
+      `execGlab("printf '%s' '{\\"message\\":\\"404 Project Not Found\\"}'"); console.log('NO_THROW');`,
+    );
+    expect(r.out).toContain('THREW:');
+    expect(r.out).toContain('glab API error');
+    expect(r.out).not.toContain('NO_THROW');
+  });
+
+  test('the thrown message carries the API error text', () => {
+    const r = inFreshProcess(
+      `execGlab("printf '%s' '{\\"message\\":\\"403 Forbidden\\"}'");`,
+    );
+    expect(r.out).toContain('403 Forbidden');
+  });
+
+  test('a real payload is returned unchanged', () => {
+    const r = inFreshProcess(
+      `const o = execGlab("printf '%s' '{\\"iid\\":42}'"); console.log('IID:' + JSON.parse(o).iid);`,
+    );
+    expect(r.out).toContain('IID:42');
+    expect(r.out).not.toContain('THREW:');
+  });
+
+  test('an empty collection still succeeds — it is a legitimate answer', () => {
+    const r = inFreshProcess(
+      `console.log('LEN:' + JSON.parse(execGlab("printf '%s' '[]'")).length);`,
+    );
+    expect(r.out).toContain('LEN:0');
+  });
+
+  test('genuinely empty output still throws (the #382 guard is intact)', () => {
+    const r = inFreshProcess(`execGlab("printf '%s' ''");`);
+    expect(r.out).toContain('empty output');
+  });
+
+  test('a non-zero exit still throws (the original guard is intact)', () => {
+    const r = inFreshProcess(`execGlab("sh -c 'exit 3'");`);
+    expect(r.out).toContain('glab failed');
+  });
+});

--- a/lib/gitlab-api.ts
+++ b/lib/gitlab-api.ts
@@ -140,7 +140,10 @@ export interface GitlabRepo {
 // Low-level exec wrapper
 // ---------------------------------------------------------------------------
 
-function execGlab(cmd: string, cwd?: string): string {
+// Exported for test: the guards here are the whole point of #502/#382, and a
+// test that only exercises the pure detector cannot tell whether this function
+// still consults it — that mutation survived until this was reachable.
+export function execGlab(cmd: string, cwd?: string): string {
   let raw: string;
   try {
     // `cwd` defaults to undefined, leaving execSync on `process.cwd()` —
@@ -172,7 +175,59 @@ function execGlab(cmd: string, cwd?: string): string {
   if (raw.trim() === '') {
     throw new Error(`glab returned empty output for: ${cmd}`);
   }
+  // HTTP ERRORS ARRIVE ON STDOUT WITH EXIT 0 (#502). `glab api` prints the API's
+  // error body — `{"message":"404 Project Not Found"}` — and exits ZERO, so
+  // neither guard above fires. The typed wrapper then JSON.parses it into its
+  // expected shape, every field comes back `undefined`, and the handler emits a
+  // confident `ok: true` envelope full of falsy data.
+  //
+  // That is a false negative that reads as an authoritative answer:
+  // `spec_validate_structure` reported a perfectly valid issue as missing all
+  // three required sections, with `ok: true`. The tool did not fail — it
+  // answered, wrongly, and nothing downstream could tell.
+  //
+  // Detected HERE rather than in each wrapper because this is the chokepoint
+  // every one of them routes through; fixing it per-wrapper is how #491's
+  // knowledge stayed scoped to the wrong caller for months.
+  const apiError = detectGlabApiError(raw);
+  if (apiError !== undefined) {
+    throw new Error(`glab API error for: ${cmd}\n${apiError}`);
+  }
   return raw;
+}
+
+/**
+ * GitLab's REST error body, if `raw` is one.
+ *
+ * The shape is `{"message": ...}` or `{"error": ...}` — and `message` may be a
+ * string, an array, or an object keyed by field, so it is rendered rather than
+ * assumed to be a string.
+ *
+ * Deliberately narrow: it must not mistake a legitimate payload that merely
+ * HAS a `message` field for an error. A GitLab error body is a bare object with
+ * no other content, so an object carrying `id`/`iid`/`web_url` alongside is a
+ * real resource and passes through untouched.
+ */
+export function detectGlabApiError(raw: string): string | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined; // not JSON — not our business
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return undefined;
+  }
+  const obj = parsed as Record<string, unknown>;
+  const carrier = 'message' in obj ? 'message' : 'error' in obj ? 'error' : undefined;
+  if (carrier === undefined) return undefined;
+  // A real resource that happens to carry `message` (a commit, a note) also
+  // carries identifying fields. An error body does not.
+  for (const marker of ['id', 'iid', 'web_url', 'sha', 'name', 'path']) {
+    if (marker in obj) return undefined;
+  }
+  const value = obj[carrier];
+  return typeof value === 'string' ? value : JSON.stringify(value);
 }
 
 /**


### PR DESCRIPTION
## Summary

`glab api` prints the API's error body to **stdout** and exits **zero** on 404/403/etc. `execGlab` only failed on a non-zero exit or empty output, so neither guard fired: `{"message":"404 Project Not Found"}` was returned as if it were a successful response. Every typed wrapper `JSON.parse`d it into its expected shape, every field came back `undefined`, and the handler emitted a confident **`ok: true` envelope full of falsy data**.

That is the most dangerous shape a validation tool has — **a false negative that reads as an authoritative answer**. `spec_validate_structure` reported a perfectly valid issue as missing all three required sections, with `ok: true`. The tool did not fail; it *answered, wrongly*, and nothing downstream could tell.

Detected at the **chokepoint** every wrapper routes through, not per-wrapper — scoping the knowledge to one caller is exactly how #491's identical defect sat in `pr_status` for months after #220 fixed it next door.

## The detector is deliberately narrow

Over-matching is the same damage pointed the other way — a real payload turned into an error. A GitLab error body is a bare object carrying `message`/`error` and nothing else, so anything with `id`/`iid`/`web_url`/`sha`/`name`/`path` alongside is a real resource and passes through. **Commits carry a `message` and must survive.** Empty collections (`[]`, `{}`) are legitimate answers and are untouched. Non-string `message` payloads (GitLab's per-field validation errors) are rendered rather than dropped.

Both directions are tested.

## Why `execGlab` is now exported

A suite that tested only the pure detector could not tell whether `execGlab` still **consulted** it — and a mutation disabling that call **survived** until the wiring was reachable from a test.

Those wiring tests run in a **subprocess**. `execGlab` calls `execSync`, and this repo has known cross-file `mock.module` leakage (#456): run in-process they passed alone and failed under the full suite, reading a *mocked* `execSync` rather than the real one. A fresh `bun -e` gets a clean module registry.

## Test Plan

- `bunx tsc --noEmit` — clean
- **16 new tests** — 10 detector (both directions), 6 driving the real `execGlab` path
- **Mutations killed under the FULL suite**, not in isolation: disabling detection takes failures 4 → 6; removing the real-payload guard fails the over-matching tests
- **Suite parity:** 4 pre-existing `wave_finalize` failures (#509) on both `main` and this branch, identical `validate.sh` exit code

## Linked Issues

Closes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZC3F9Qo7aX7QasQkdHPs7